### PR TITLE
Add database import functionality to settings (#5)

### DIFF
--- a/src/features/os/api-type.ts
+++ b/src/features/os/api-type.ts
@@ -1,10 +1,22 @@
 import { prefixNamespace, PrefixNamespace, StripNamespace } from "../../lib/namespace";
 
-const methods = ["revealInFinder", "copyToClipboard", "startDrag"] as const;
+export type ShowOpenDialogResult = {
+  canceled: boolean;
+  filePaths: string[];
+};
+
+export type ShowOpenDialogOptions = {
+  title?: string;
+  filters?: Array<{ name: string; extensions: string[] }>;
+  properties?: Array<"openFile" | "openDirectory" | "multiSelections">;
+};
+
+const methods = ["revealInFinder", "copyToClipboard", "startDrag", "showOpenDialog"] as const;
 export type OsHandlers = {
   revealInFinder: (_: any, path: string) => void;
   copyToClipboard: (_: any, text: string) => void;
   startDrag: (_: any, filePaths: string[]) => void;
+  showOpenDialog: (_: any, options: ShowOpenDialogOptions) => Promise<ShowOpenDialogResult>;
 };
 
 export const namespace = "os" as const;

--- a/src/features/os/api.ts
+++ b/src/features/os/api.ts
@@ -1,8 +1,8 @@
-import { clipboard, nativeImage, shell } from "electron";
+import { clipboard, dialog, nativeImage, shell } from "electron";
 import fs from "fs";
 import path from "path";
 import { prefixNamespaceObject } from "../../lib/namespace";
-import { namespace, OsHandlers } from "./api-type";
+import { namespace, OsHandlers, ShowOpenDialogOptions } from "./api-type";
 
 export const handlers: OsHandlers = {
   revealInFinder: (_, filePath) => {
@@ -75,6 +75,18 @@ export const handlers: OsHandlers = {
       return { success: true, fileCount: validFiles.length };
     } catch (error) {
       console.error("Failed to start drag:", error);
+      throw error;
+    }
+  },
+  showOpenDialog: async (_, options: ShowOpenDialogOptions) => {
+    try {
+      const result = await dialog.showOpenDialog(options);
+      return {
+        canceled: result.canceled,
+        filePaths: result.filePaths || []
+      };
+    } catch (error) {
+      console.error("Failed to show open dialog:", error);
       throw error;
     }
   },

--- a/src/features/settings/api-type.ts
+++ b/src/features/settings/api-type.ts
@@ -8,6 +8,17 @@ type FanslyCredentials = {
   fanslyClientId?: string;
 };
 
+export type DatabaseImportResult = {
+  success: boolean;
+  error?: string;
+};
+
+export type ValidationResult = {
+  totalFiles: number;
+  missingFiles: string[];
+  validFiles: number;
+};
+
 const methods = [
   "load",
   "save",
@@ -15,6 +26,8 @@ const methods = [
   "saveFanslyCredentials",
   "loadFanslyCredentials",
   "clearFanslyCredentials",
+  "importDatabase",
+  "validateImportedDatabase",
 ] as const;
 export type SettingsHandlers = {
   load: (_: any) => Promise<Settings>;
@@ -23,6 +36,8 @@ export type SettingsHandlers = {
   saveFanslyCredentials: (_: any, credentials: Partial<FanslyCredentials>) => Promise<void>;
   loadFanslyCredentials: (_: any) => Promise<FanslyCredentials>;
   clearFanslyCredentials: (_: any) => Promise<void>;
+  importDatabase: (_: any, sourcePath: string) => Promise<DatabaseImportResult>;
+  validateImportedDatabase: (_: any, libraryPath: string) => Promise<ValidationResult>;
 };
 
 export const namespace = "settings" as const;

--- a/src/features/settings/api.ts
+++ b/src/features/settings/api.ts
@@ -1,5 +1,6 @@
 import { prefixNamespaceObject } from "../../lib/namespace";
 import { namespace, SettingsHandlers } from "./api-type";
+import { importDatabase, validateImportedDatabase } from "./import";
 import { loadSettings } from "./load";
 import { resetDatabase } from "./reset";
 import { saveSettings } from "./save";
@@ -16,6 +17,8 @@ export const handlers: SettingsHandlers = {
   saveFanslyCredentials: (_: any, credentials) => saveFanslyCredentials(credentials),
   loadFanslyCredentials: (_: any) => loadFanslyCredentials(),
   clearFanslyCredentials: (_: any) => clearFanslyCredentials(),
+  importDatabase: (_: any, sourcePath: string) => importDatabase(sourcePath),
+  validateImportedDatabase: (_: any, libraryPath: string) => validateImportedDatabase(libraryPath),
 };
 
 export const settingsHandlers = prefixNamespaceObject(namespace, handlers);

--- a/src/features/settings/import.ts
+++ b/src/features/settings/import.ts
@@ -1,0 +1,86 @@
+import { app } from "electron";
+import { existsSync } from "fs";
+import { copyFile, mkdir, access } from "fs/promises";
+import { join, dirname } from "path";
+import { db, uninitialize } from "../../lib/db";
+import { Media } from "../library/entity";
+import { convertRelativeToAbsolute } from "../library/path-utils";
+import { DatabaseImportResult, ValidationResult } from "./api-type";
+
+const dbPath = join(app.getPath("userData"), "fanslib.sqlite");
+const backupPath = join(app.getPath("userData"), "fanslib.sqlite.backup");
+
+export const backupCurrentDatabase = async (): Promise<void> => {
+  if (existsSync(dbPath)) {
+    await copyFile(dbPath, backupPath);
+  }
+};
+
+export const importDatabase = async (sourcePath: string): Promise<DatabaseImportResult> => {
+  try {
+    // Validate source file exists
+    if (!existsSync(sourcePath)) {
+      return { success: false, error: "Source database file does not exist" };
+    }
+
+    // Backup current database if it exists
+    await backupCurrentDatabase();
+
+    // Close current database connection
+    await uninitialize();
+
+    // Ensure userData directory exists
+    await mkdir(dirname(dbPath), { recursive: true });
+
+    // Copy the source file to the app's database location
+    await copyFile(sourcePath, dbPath);
+
+    // Initialize the new database
+    await db();
+
+    return { success: true };
+  } catch (error) {
+    console.error("Error importing database:", error);
+    return { 
+      success: false, 
+      error: error instanceof Error ? error.message : "Unknown error occurred" 
+    };
+  }
+};
+
+export const validateImportedDatabase = async (libraryPath: string): Promise<ValidationResult> => {
+  try {
+    const database = await db();
+    const mediaRepository = database.getRepository(Media);
+    
+    // Get all media files from the database
+    const allMedia = await mediaRepository.find();
+    
+    let validFiles = 0;
+    const missingFiles: string[] = [];
+    
+    // Check each media file
+    for (const media of allMedia) {
+      try {
+        const absolutePath = convertRelativeToAbsolute(media.relativePath, libraryPath);
+        await access(absolutePath);
+        validFiles++;
+      } catch {
+        missingFiles.push(media.relativePath);
+      }
+    }
+    
+    return {
+      totalFiles: allMedia.length,
+      missingFiles,
+      validFiles
+    };
+  } catch (error) {
+    console.error("Error validating imported database:", error);
+    return {
+      totalFiles: 0,
+      missingFiles: [],
+      validFiles: 0
+    };
+  }
+};

--- a/src/renderer/src/components/DatabaseImportWizard.tsx
+++ b/src/renderer/src/components/DatabaseImportWizard.tsx
@@ -1,0 +1,303 @@
+import { Button } from "@renderer/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@renderer/components/ui/dialog";
+import { Input } from "@renderer/components/ui/input";
+import { Label } from "@renderer/components/ui/label";
+import { Progress } from "@renderer/components/ui/progress";
+import { useToast } from "@renderer/components/ui/use-toast";
+import { useImportDatabase, useValidateImportedDatabase } from "@renderer/hooks/api/useImportDatabase";
+import { useUpdateSettings } from "@renderer/hooks/api/useSettings";
+import { AlertCircle, CheckCircle, Database, FolderOpen, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { ValidationResult } from "../../../features/settings/api-type";
+
+type ImportStep = "file-selection" | "library-path" | "validation" | "success";
+
+type DatabaseImportWizardProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: () => void;
+};
+
+export const DatabaseImportWizard = ({ open, onOpenChange, onSuccess }: DatabaseImportWizardProps) => {
+  const [currentStep, setCurrentStep] = useState<ImportStep>("file-selection");
+  const [selectedFile, setSelectedFile] = useState<string>("");
+  const [libraryPath, setLibraryPath] = useState<string>("");
+  const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
+
+  const { toast } = useToast();
+  const updateSettings = useUpdateSettings();
+  const importDatabase = useImportDatabase();
+  const validateDatabase = useValidateImportedDatabase();
+
+  const selectDatabaseFile = async () => {
+    try {
+      const result = await window.api["os:showOpenDialog"]({
+        title: "Select Database File",
+        filters: [
+          { name: "SQLite Database", extensions: ["sqlite", "sqlite3", "db"] },
+          { name: "All Files", extensions: ["*"] }
+        ],
+        properties: ["openFile"]
+      });
+
+      if (!result.canceled && result.filePaths.length > 0) {
+        setSelectedFile(result.filePaths[0]);
+      }
+    } catch (_error) {
+      console.error("Error selecting file:", _error);
+      toast({
+        title: "Error",
+        description: "Failed to select database file",
+        variant: "destructive"
+      });
+    }
+  };
+
+  const selectLibraryPath = async () => {
+    try {
+      const result = await window.api["os:showOpenDialog"]({
+        title: "Select Library Folder",
+        properties: ["openDirectory"]
+      });
+
+      if (!result.canceled && result.filePaths.length > 0) {
+        setLibraryPath(result.filePaths[0]);
+      }
+    } catch (_error) {
+      console.error("Error selecting library path:", _error);
+      toast({
+        title: "Error",
+        description: "Failed to select library folder",
+        variant: "destructive"
+      });
+    }
+  };
+
+  const handleImportDatabase = async () => {
+    if (!selectedFile) return;
+
+    try {
+      const result = await importDatabase.mutateAsync(selectedFile);
+      
+      if (!result.success) {
+        toast({
+          title: "Import Failed",
+          description: result.error || "Unknown error occurred",
+          variant: "destructive"
+        });
+        return;
+      }
+
+      setCurrentStep("library-path");
+    } catch (error) {
+      toast({
+        title: "Import Failed",
+        description: "Failed to import database",
+        variant: "destructive"
+      });
+    }
+  };
+
+  const handleLibraryPathSubmit = async () => {
+    if (!libraryPath) return;
+
+    try {
+      // Update library path in settings
+      await updateSettings.mutateAsync({ libraryPath });
+      
+      setCurrentStep("validation");
+      
+      // Validate the imported database
+      const result = await validateDatabase.mutateAsync(libraryPath);
+      setValidationResult(result);
+      
+      setCurrentStep("success");
+    } catch (error) {
+      toast({
+        title: "Validation Failed",
+        description: "Failed to validate library path",
+        variant: "destructive"
+      });
+    }
+  };
+
+  const handleFinish = () => {
+    onOpenChange(false);
+    onSuccess?.();
+    
+    // Reset wizard state
+    setCurrentStep("file-selection");
+    setSelectedFile("");
+    setLibraryPath("");
+    setValidationResult(null);
+  };
+
+  const getStepTitle = () => {
+    switch (currentStep) {
+      case "file-selection":
+        return "Select Database File";
+      case "library-path":
+        return "Configure Library Path";
+      case "validation":
+        return "Validating Import";
+      case "success":
+        return "Import Complete";
+    }
+  };
+
+  const getProgressValue = () => {
+    switch (currentStep) {
+      case "file-selection":
+        return 25;
+      case "library-path":
+        return 50;
+      case "validation":
+        return 75;
+      case "success":
+        return 100;
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Database className="h-5 w-5" />
+            {getStepTitle()}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <Progress value={getProgressValue()} className="w-full" />
+
+          {currentStep === "file-selection" && (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Select the fanslib.sqlite database file from your other machine.
+              </p>
+              
+              <div className="space-y-2">
+                <Label>Database File</Label>
+                <div className="flex gap-2">
+                  <Input
+                    value={selectedFile}
+                    placeholder="No file selected"
+                    readOnly
+                    className="flex-1"
+                  />
+                  <Button onClick={selectDatabaseFile} variant="outline">
+                    <FolderOpen className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" onClick={() => onOpenChange(false)}>
+                  Cancel
+                </Button>
+                <Button 
+                  onClick={handleImportDatabase}
+                  disabled={!selectedFile || importDatabase.isPending}
+                >
+                  {importDatabase.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  Import Database
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {currentStep === "library-path" && (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Select the folder where your media files are located.
+              </p>
+              
+              <div className="space-y-2">
+                <Label>Library Path</Label>
+                <div className="flex gap-2">
+                  <Input
+                    value={libraryPath}
+                    placeholder="No folder selected"
+                    readOnly
+                    className="flex-1"
+                  />
+                  <Button onClick={selectLibraryPath} variant="outline">
+                    <FolderOpen className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" onClick={() => setCurrentStep("file-selection")}>
+                  Back
+                </Button>
+                <Button 
+                  onClick={handleLibraryPathSubmit}
+                  disabled={!libraryPath || updateSettings.isPending || validateDatabase.isPending}
+                >
+                  {(updateSettings.isPending || validateDatabase.isPending) && 
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  }
+                  Validate & Complete
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {currentStep === "validation" && (
+            <div className="space-y-4">
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-8 w-8 animate-spin" />
+              </div>
+              <p className="text-center text-sm text-muted-foreground">
+                Validating media files...
+              </p>
+            </div>
+          )}
+
+          {currentStep === "success" && validationResult && (
+            <div className="space-y-4">
+              <div className="flex items-center gap-2 text-green-600">
+                <CheckCircle className="h-5 w-5" />
+                <span className="font-medium">Database imported successfully!</span>
+              </div>
+
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span>Total files:</span>
+                  <span>{validationResult.totalFiles}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>Valid files:</span>
+                  <span className="text-green-600">{validationResult.validFiles}</span>
+                </div>
+                {validationResult.missingFiles.length > 0 && (
+                  <div className="flex justify-between">
+                    <span>Missing files:</span>
+                    <span className="text-orange-600">{validationResult.missingFiles.length}</span>
+                  </div>
+                )}
+              </div>
+
+              {validationResult.missingFiles.length > 0 && (
+                <div className="p-3 bg-orange-50 border border-orange-200 rounded-md">
+                  <div className="flex items-center gap-2 text-orange-800 text-sm">
+                    <AlertCircle className="h-4 w-4" />
+                    <span>Some media files could not be found at the specified library path.</span>
+                  </div>
+                </div>
+              )}
+
+              <div className="flex justify-end">
+                <Button onClick={handleFinish}>
+                  Finish
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/renderer/src/components/WelcomeScreen.tsx
+++ b/src/renderer/src/components/WelcomeScreen.tsx
@@ -1,21 +1,49 @@
-import { Settings } from "lucide-react";
+import { DatabaseImportWizard } from "@renderer/components/DatabaseImportWizard";
+import { Database, Settings } from "lucide-react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "./ui/button";
 
 export const WelcomeScreen = () => {
   const navigate = useNavigate();
+  const [showImportWizard, setShowImportWizard] = useState(false);
 
   return (
-    <div className="flex w-full h-full flex-col p-8 justify-center">
-      <div className="flex flex-col items-center text-center gap-1 mb-8">
-        <Settings className="w-12 h-12 text-muted-foreground" />
-        <h1 className="text-2xl font-semibold">Welcome to FansLib</h1>
-        <p>Library path is not set. Please configure it in settings.</p>
-        <Button onClick={() => navigate("/settings")} className="flex items-center mt-4 gap-2">
-          <Settings className="w-4 h-4" />
-          Go to Settings
-        </Button>
+    <>
+      <DatabaseImportWizard
+        open={showImportWizard}
+        onOpenChange={setShowImportWizard}
+        onSuccess={() => {
+          // Refresh the page or navigate to main view
+          window.location.reload();
+        }}
+      />
+      <div className="flex w-full h-full flex-col p-8 justify-center">
+        <div className="flex flex-col items-center text-center gap-6">
+          <div className="flex flex-col items-center gap-2">
+            <Settings className="w-12 h-12 text-muted-foreground" />
+            <h1 className="text-2xl font-semibold">Welcome to FansLib</h1>
+            <p className="text-muted-foreground">Get started by setting up your library or importing an existing database.</p>
+          </div>
+          
+          <div className="flex flex-col gap-3 w-full max-w-sm">
+            <Button onClick={() => navigate("/settings")} className="flex items-center gap-2" size="lg">
+              <Settings className="w-4 h-4" />
+              Set up new library
+            </Button>
+            
+            <Button 
+              onClick={() => setShowImportWizard(true)} 
+              variant="outline" 
+              className="flex items-center gap-2" 
+              size="lg"
+            >
+              <Database className="w-4 h-4" />
+              Import existing database
+            </Button>
+          </div>
+        </div>
       </div>
-    </div>
+    </>
   );
 };

--- a/src/renderer/src/hooks/api/useImportDatabase.ts
+++ b/src/renderer/src/hooks/api/useImportDatabase.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { DatabaseImportResult, ValidationResult } from "../../../../features/settings/api-type";
+
+export const useImportDatabase = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<DatabaseImportResult, Error, string>({
+    mutationFn: async (sourcePath: string) => {
+      const result = await window.api["settings:importDatabase"](sourcePath);
+      return result;
+    },
+    onSuccess: () => {
+      // Invalidate all queries since the database has changed
+      queryClient.invalidateQueries();
+    },
+  });
+};
+
+export const useValidateImportedDatabase = () => {
+  return useMutation<ValidationResult, Error, string>({
+    mutationFn: async (libraryPath: string) => {
+      const result = await window.api["settings:validateImportedDatabase"](libraryPath);
+      return result;
+    },
+  });
+};

--- a/src/renderer/src/hooks/api/useSettings.ts
+++ b/src/renderer/src/hooks/api/useSettings.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useSettings as useSettingsContext } from "../../contexts/SettingsContext";
+
+export const useSettings = useSettingsContext;
+
+export const useUpdateSettings = () => {
+  const { saveSettings } = useSettingsContext();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (updates: Parameters<typeof saveSettings>[0]) => {
+      saveSettings(updates);
+      // Return the updated settings
+      return window.api["settings:load"]();
+    },
+    onSuccess: () => {
+      // Invalidate settings-related queries
+      queryClient.invalidateQueries({ queryKey: ["settings"] });
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- Added database import functionality to allow importing existing FansLib databases
- Enhanced WelcomeScreen to provide both new library setup and import options
- Implemented file selection dialog support in OS API

## Changes
- **OS API**: Added `showOpenDialog` method for native file selection
- **Settings API**: Added `importDatabase` and `validateImportedDatabase` handlers
- **Import Module**: Created comprehensive database import with validation
- **UI Components**: Added `DatabaseImportWizard` for guided import process
- **Hooks**: Added `useImportDatabase` and `useSettings` hooks for data operations
- **WelcomeScreen**: Enhanced with import option alongside existing setup flow

## Test plan
- [ ] Verify file selection dialog opens correctly
- [ ] Test database import with valid FansLib database
- [ ] Test validation of imported database files
- [ ] Confirm welcome screen shows both options
- [ ] Test import wizard flow end-to-end

🤖 Generated with [Claude Code](https://claude.ai/code)