### PR TITLE
Add page headers to settings subpages

### DIFF
--- a/packages/apps/electron/src/renderer/src/pages/Settings/BackgroundJobsSettings.tsx
+++ b/packages/apps/electron/src/renderer/src/pages/Settings/BackgroundJobsSettings.tsx
@@ -2,7 +2,7 @@ import { Button } from "@renderer/components/ui/Button";
 import { Input } from "@renderer/components/ui/Input";
 import { Status } from "@renderer/components/ui/Status";
 import { useSettings } from "@renderer/contexts/SettingsContext";
-import { RefreshCw } from "lucide-react";
+import { RefreshCw, Server } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { SettingRow } from "./SettingRow";
 
@@ -95,7 +95,15 @@ export const BackgroundJobsSettings = () => {
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
+      <div>
+        <h1 className="flex items-center gap-2 text-2xl font-semibold">
+          <Server /> Background Jobs
+        </h1>
+        <p className="text-muted-foreground">Configure background job server for automated tasks</p>
+      </div>
+
+      <div className="space-y-4">
       <SettingRow
         title="Server URL"
         description="URL of the background jobs server for automated Reddit posting and other tasks"
@@ -133,6 +141,7 @@ export const BackgroundJobsSettings = () => {
           </div>
         </div>
       </SettingRow>
+      </div>
     </div>
   );
 };

--- a/packages/apps/electron/src/renderer/src/pages/Settings/FilterPresetSettings.tsx
+++ b/packages/apps/electron/src/renderer/src/pages/Settings/FilterPresetSettings.tsx
@@ -2,7 +2,7 @@ import { FilterPresetProvider } from "../../contexts/FilterPresetContext";
 import { FilterPresetManager } from "../../components/MediaFilters/FilterPresetManager";
 import { useState } from "react";
 import { Button } from "../../components/ui/Button";
-import { Settings as SettingsIcon } from "lucide-react";
+import { Filter, Settings as SettingsIcon } from "lucide-react";
 
 export const FilterPresetSettings = () => {
   const [showManager, setShowManager] = useState(false);
@@ -12,13 +12,17 @@ export const FilterPresetSettings = () => {
 
   return (
     <FilterPresetProvider onFiltersChange={handleFiltersChange}>
-      <div className="space-y-4">
+      <div className="space-y-6">
         <div>
-          <h3 className="text-sm font-medium">Filter Presets</h3>
-          <p className="text-sm text-muted-foreground">
-            Manage your saved filter presets. Create, edit, and delete presets for quick filtering.
+          <h1 className="flex items-center gap-2 text-2xl font-semibold">
+            <Filter /> Filter Presets
+          </h1>
+          <p className="text-muted-foreground">
+            Manage your saved filter presets for quick media filtering
           </p>
         </div>
+
+        <div className="space-y-4">
         <div>
           <Button
             variant="outline"
@@ -30,6 +34,7 @@ export const FilterPresetSettings = () => {
           </Button>
         </div>
         <FilterPresetManager open={showManager} onOpenChange={setShowManager} />
+        </div>
       </div>
     </FilterPresetProvider>
   );


### PR DESCRIPTION
## Summary
- Added consistent page headers with icons to Background Jobs and Filter Presets settings pages
- Used Server icon for Background Jobs and Filter icon for Filter Presets  
- Updated layout spacing to match other settings pages that already had headers
- All settings subpages now have consistent header styling following the same pattern as General and Appearance tabs

## Test plan
- [ ] Navigate to Settings > Background Jobs and verify page header displays correctly
- [ ] Navigate to Settings > Filter Presets and verify page header displays correctly  
- [ ] Verify header styling is consistent with other settings pages
- [ ] Check that all icons and descriptions are appropriate

🤖 Generated with [Claude Code](https://claude.ai/code)