### PR TITLE
Bug: ffmpeg auf tsumetai funktioniert nicht — keine Thumbnails

### DIFF
--- a/@fanslib/apps/server/src/features/library/operations/scan/thumbnail.ts
+++ b/@fanslib/apps/server/src/features/library/operations/scan/thumbnail.ts
@@ -1,7 +1,7 @@
 import { spawn } from "child_process";
 import { promises as fs } from "fs";
 import path from "path";
-import { appdataPath } from "../../../../lib/env";
+import { appdataPath, env } from "../../../../lib/env";
 
 const THUMBNAIL_DIR = path.join(appdataPath(), "thumbnails");
 
@@ -51,10 +51,11 @@ export const generateThumbnail = async (
       ffmpegArgs.push("-i", mediaPath, "-vf", "scale=320:-1", "-y", thumbnailPath);
     }
 
-    const ffmpeg = spawn("ffmpeg", ffmpegArgs);
+    const ffmpegBin = env().ffmpegPath ?? "ffmpeg";
+    const ffmpeg = spawn(ffmpegBin, ffmpegArgs);
 
     ffmpeg.on("error", (err) => {
-      reject(new Error(`Failed to spawn ffmpeg: ${err.message}`));
+      reject(new Error(`Failed to spawn ffmpeg (binary: "${ffmpegBin}"): ${err.message}. Install ffmpeg or set FFMPEG_PATH env var.`));
     });
 
     ffmpeg.on("exit", (code) => {

--- a/@fanslib/apps/server/src/lib/env.ts
+++ b/@fanslib/apps/server/src/lib/env.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 type EnvConfig = {
   appdataPath: string;
   libraryPath: string;
+  ffmpegPath: string | undefined;
   ffprobePath: string | undefined;
 };
 
@@ -21,6 +22,7 @@ export const env = (): EnvConfig => {
   return {
     appdataPath,
     libraryPath,
+    ffmpegPath: process.env.FFMPEG_PATH,
     ffprobePath: process.env.FFPROBE_PATH
   };
 };


### PR DESCRIPTION
Splitter: 927c1175-ab1e-4bc1-9ed8-11ce9bfb989d

ffmpeg scheint auf dem Server tsumetai nicht korrekt zu funktionieren, was dazu führt dass keine Thumbnails generiert werden.

**Zu untersuchen:**
- ffmpeg Installation/Version auf tsumetai
- Pfade, Permissions
- Logs der Thumbnail-Generierung in Fanslib