### PR TITLE
feat: scheduling capture — extension intercepts and links posts

### DIFF
--- a/@fanslib/apps/chrome-extension/src/background/index.ts
+++ b/@fanslib/apps/chrome-extension/src/background/index.ts
@@ -13,6 +13,11 @@ type Message =
         fanslyClientCheck?: string;
         fanslyClientId?: string;
       };
+    }
+  | {
+      type: 'FANSLIB_SCHEDULE_CAPTURE';
+      contentId: string;
+      caption: string;
     };
 
 const BATCH_DELAY_MS = 2000;
@@ -364,6 +369,58 @@ const addToBuffer = (candidates: CandidateItem[]): void => {
   }
 };
 
+const sendScheduleCapture = async (
+  contentId: string,
+  caption: string
+): Promise<{ matched: boolean; postId: string | null }> => {
+  debug('info', 'Sending schedule capture to server', { contentId, captionLength: caption.length });
+
+  const apiUrl = await getApiUrl();
+  const endpoint = `${apiUrl}/api/posts/schedule-capture`;
+
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ contentId, caption }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const result = (await response.json()) as { matched: boolean; postId: string | null };
+
+    debug('info', 'Schedule capture result', { matched: result.matched, postId: result.postId });
+
+    await chrome.storage.local.set({
+      lastScheduleCaptureResult: {
+        matched: result.matched,
+        postId: result.postId,
+        timestamp: Date.now(),
+      },
+    });
+
+    return result;
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    debug('error', 'Failed to send schedule capture', { error: errorMessage });
+
+    await chrome.storage.local.set({
+      lastScheduleCaptureResult: {
+        matched: false,
+        postId: null,
+        timestamp: Date.now(),
+        error: errorMessage,
+      },
+    });
+
+    throw error;
+  }
+};
+
 chrome.runtime.onMessage.addListener(
   (message: Message, _sender, sendResponse) => {
     if (message.type === 'FANSLY_TIMELINE_DATA') {
@@ -377,6 +434,20 @@ chrome.runtime.onMessage.addListener(
         // Silently fail - credentials will be retried on next capture
       });
       sendResponse({ success: true });
+      return true;
+    }
+
+    if (message.type === 'FANSLIB_SCHEDULE_CAPTURE') {
+      sendScheduleCapture(message.contentId, message.caption)
+        .then((result) => {
+          sendResponse({ success: true, ...result });
+        })
+        .catch((error) => {
+          sendResponse({
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
       return true;
     }
 

--- a/@fanslib/apps/chrome-extension/src/components/Popup/Popup.tsx
+++ b/@fanslib/apps/chrome-extension/src/components/Popup/Popup.tsx
@@ -23,10 +23,46 @@ export const Popup = () => {
   );
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [linkedPostId, setLinkedPostId] = useState<string | null>(null);
 
   useEffect(() => {
     loadPosts();
   }, []);
+
+  useEffect(() => {
+    const listener = (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      areaName: string
+    ) => {
+      if (
+        areaName === 'local' &&
+        changes.lastScheduleCaptureResult?.newValue
+      ) {
+        const result = changes.lastScheduleCaptureResult.newValue as {
+          matched: boolean;
+          postId: string | null;
+          timestamp: number;
+        };
+
+        if (result.matched && result.postId) {
+          setLinkedPostId(result.postId);
+
+          setTimeout(() => {
+            setLinkedPostId(null);
+            loadPosts().then(() => {
+              // Auto-advance to next post after reload
+              setCurrentIndex((prev) => Math.min(prev + 1, posts.length - 1));
+            });
+          }, 2000);
+        }
+      }
+    };
+
+    chrome.storage.onChanged.addListener(listener);
+    return () => {
+      chrome.storage.onChanged.removeListener(listener);
+    };
+  }, [posts.length]);
 
   const loadPosts = async (isRefresh = false) => {
     if (isRefresh) {
@@ -187,6 +223,7 @@ export const Popup = () => {
               bridgeUrl={settings?.bridgeUrl ?? ''}
               onMarkPosted={() => markAsPosted(currentPost.id)}
               onMarkScheduled={() => markAsScheduled(currentPost.id)}
+              linked={linkedPostId === currentPost.id}
             />
 
             <PostNavigation

--- a/@fanslib/apps/chrome-extension/src/components/Popup/PostCard.tsx
+++ b/@fanslib/apps/chrome-extension/src/components/Popup/PostCard.tsx
@@ -28,6 +28,7 @@ type PostCardProps = {
   bridgeUrl: string;
   onMarkPosted: () => void;
   onMarkScheduled: () => void;
+  linked?: boolean;
 };
 
 export const PostCard = ({
@@ -38,6 +39,7 @@ export const PostCard = ({
   bridgeUrl,
   onMarkPosted,
   onMarkScheduled,
+  linked = false,
 }: PostCardProps) => {
   const media = Array.isArray(post.postMedia) ? post.postMedia : [];
   const hasLibraryPath = !!libraryPath;
@@ -123,7 +125,14 @@ export const PostCard = ({
   };
 
   return (
-    <div className='rounded-xl p-3 bg-base-100'>
+    <div className='rounded-xl p-3 bg-base-100 relative'>
+      {linked && (
+        <div className='absolute inset-0 z-10 flex items-center justify-center bg-success/10 rounded-xl border-2 border-success'>
+          <span className='px-4 py-2 bg-success text-success-content rounded-lg font-semibold text-sm shadow-lg'>
+            Linked ✓
+          </span>
+        </div>
+      )}
       <div className='flex items-start justify-between mb-3'>
         <div className='flex flex-col'>
           <span className='text-base font-semibold text-base-content'>

--- a/@fanslib/apps/chrome-extension/src/content/fansly-bridge.ts
+++ b/@fanslib/apps/chrome-extension/src/content/fansly-bridge.ts
@@ -73,6 +73,47 @@ window.addEventListener('message', (event) => {
     }
   }
   
+  if (event.data.type === 'FANSLIB_SCHEDULE_CAPTURE') {
+    debug('info', 'Received schedule capture from MAIN world', {
+      contentId: event.data.contentId,
+      captionLength: event.data.caption?.length,
+    });
+
+    try {
+      if (!chrome?.runtime) {
+        debug('error', 'chrome.runtime not available for schedule capture');
+        return;
+      }
+
+      const message = {
+        type: "FANSLIB_SCHEDULE_CAPTURE",
+        contentId: event.data.contentId,
+        caption: event.data.caption,
+      };
+
+      debug('info', 'Attempting to send schedule capture to background', {
+        messageType: message.type,
+        contentId: message.contentId,
+      });
+
+      chrome.runtime.sendMessage(message)
+        .then(() => {
+          debug('info', 'Schedule capture sent successfully to background script');
+        })
+        .catch((error) => {
+          debug('error', 'Failed to send schedule capture to background script', {
+            error,
+            errorMessage: error instanceof Error ? error.message : String(error),
+          });
+        });
+    } catch (error) {
+      debug('error', 'Failed to forward schedule capture', {
+        error,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   if (event.data.type === 'FANSLIB_CREDENTIALS') {
     debug('info', 'Received credentials from MAIN world', {
       hasAuth: !!event.data.credentials?.fanslyAuth,

--- a/@fanslib/apps/chrome-extension/src/content/fansly-interceptor.ts
+++ b/@fanslib/apps/chrome-extension/src/content/fansly-interceptor.ts
@@ -162,6 +162,8 @@ let fetchInterceptCount = 0;
 let xhrInterceptCount = 0;
 // eslint-disable-next-line functional/no-let
 let timelineInterceptCount = 0;
+// eslint-disable-next-line functional/no-let
+let scheduleCaptureCount = 0;
 
 const processCandidates = (candidates: CandidateItem[]) => {
   if (candidates.length > 0) {
@@ -243,6 +245,57 @@ const sendCredentialsIfPresent = (
   }
 };
 
+const processScheduleResponse = (url: string, responseText: string) => {
+  try {
+    const data = JSON.parse(responseText) as {
+      success: boolean;
+      response?: {
+        postTemplate?: {
+          content?: string;
+          attachments?: Array<{ contentId: string }>;
+        };
+        post?: {
+          content?: string;
+          attachments?: Array<{ contentId: string }>;
+        };
+      };
+    };
+
+    if (!data.success || !data.response) return;
+
+    const postData = data.response.postTemplate ?? data.response.post;
+    if (!postData) return;
+
+    const contentId = postData.attachments?.[0]?.contentId;
+    if (!contentId) return;
+
+    const caption = postData.content ?? '';
+
+    scheduleCaptureCount++;
+    debug('info', `Schedule capture detected (#${scheduleCaptureCount})`, {
+      url,
+      contentId,
+      captionLength: caption.length,
+    });
+
+    window.postMessage(
+      {
+        type: 'FANSLIB_SCHEDULE_CAPTURE',
+        contentId,
+        caption,
+      },
+      '*'
+    );
+
+    debug('info', 'Schedule capture posted to window');
+  } catch (error) {
+    debug('error', 'Failed to process schedule response', {
+      error,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
 const processTimelineResponse = (url: string, responseText: string) => {
   timelineInterceptCount++;
   debug('info', `Timeline request detected (#${timelineInterceptCount})`, {
@@ -312,6 +365,31 @@ const interceptedFetch = (async (...args): Promise<Response> => {
       processTimelineResponse(url, responseText);
     } catch (error) {
       debug('error', 'Failed to process fetch timeline response', {
+        error,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const method = (init?.method ?? 'GET').toUpperCase();
+  if (
+    url.includes('apiv3.fansly.com') &&
+    (method === 'POST' || method === 'PUT') &&
+    !url.includes('timelinenew')
+  ) {
+    try {
+      const clone = response.clone();
+      const responseText = await clone.text();
+      if (responseText.includes('postTemplate') || responseText.includes('"post"')) {
+        debug('info', 'Potential schedule response via fetch detected', {
+          url,
+          method,
+          status: response.status,
+        });
+        processScheduleResponse(url, responseText);
+      }
+    } catch (error) {
+      debug('error', 'Failed to process fetch schedule response', {
         error,
         errorMessage: error instanceof Error ? error.message : String(error),
       });
@@ -396,8 +474,19 @@ XMLHttpRequest.prototype.send = function (...args: unknown[]) {
     sendCredentialsIfPresent(credentials);
   }
 
-  if (url.includes('apiv3.fansly.com/api/v1/timelinenew')) {
-    debug('info', 'Timeline request via XHR detected', { url, method });
+  const isTimelineRequest = url.includes('apiv3.fansly.com/api/v1/timelinenew');
+  const isScheduleCandidate =
+    url.includes('apiv3.fansly.com') &&
+    (method === 'POST' || method === 'PUT') &&
+    !url.includes('timelinenew');
+
+  if (isTimelineRequest || isScheduleCandidate) {
+    if (isTimelineRequest) {
+      debug('info', 'Timeline request via XHR detected', { url, method });
+    }
+    if (isScheduleCandidate) {
+      debug('info', 'Potential schedule request via XHR detected', { url, method });
+    }
 
     const originalOnLoad = xhr.onload;
     const originalOnReadyStateChange = xhr.onreadystatechange;
@@ -407,20 +496,43 @@ XMLHttpRequest.prototype.send = function (...args: unknown[]) {
       ...eventArgs: unknown[]
     ) {
       if (this.readyState === 4 && this.status === 200) {
-        debug('info', 'XHR timeline request completed', {
-          status: this.status,
-          statusText: this.statusText,
-          responseLength: this.responseText?.length,
-        });
-
-        try {
-          processTimelineResponse(url, this.responseText);
-        } catch (error) {
-          debug('error', 'Failed to process XHR timeline response', {
-            error,
-            errorMessage:
-              error instanceof Error ? error.message : String(error),
+        if (isTimelineRequest) {
+          debug('info', 'XHR timeline request completed', {
+            status: this.status,
+            statusText: this.statusText,
+            responseLength: this.responseText?.length,
           });
+
+          try {
+            processTimelineResponse(url, this.responseText);
+          } catch (error) {
+            debug('error', 'Failed to process XHR timeline response', {
+              error,
+              errorMessage:
+                error instanceof Error ? error.message : String(error),
+            });
+          }
+        }
+
+        if (isScheduleCandidate) {
+          try {
+            const responseText = this.responseText;
+            if (responseText.includes('postTemplate') || responseText.includes('"post"')) {
+              debug('info', 'XHR schedule response detected', {
+                url,
+                method,
+                status: this.status,
+                responseLength: responseText?.length,
+              });
+              processScheduleResponse(url, responseText);
+            }
+          } catch (error) {
+            debug('error', 'Failed to process XHR schedule response', {
+              error,
+              errorMessage:
+                error instanceof Error ? error.message : String(error),
+            });
+          }
         }
       }
 
@@ -430,10 +542,12 @@ XMLHttpRequest.prototype.send = function (...args: unknown[]) {
     };
 
     xhr.onload = function (this: XMLHttpRequest, ...eventArgs: unknown[]) {
-      debug('info', 'XHR onload fired for timeline request', {
-        status: this.status,
-        responseLength: this.responseText?.length,
-      });
+      if (isTimelineRequest) {
+        debug('info', 'XHR onload fired for timeline request', {
+          status: this.status,
+          responseLength: this.responseText?.length,
+        });
+      }
 
       if (originalOnLoad) {
         return originalOnLoad.apply(this, eventArgs as [ProgressEvent]);

--- a/@fanslib/apps/server/src/features/analytics/candidates/matching.ts
+++ b/@fanslib/apps/server/src/features/analytics/candidates/matching.ts
@@ -44,7 +44,7 @@ const levenshteinDistance = (str1: string, str2: string): number => {
   return matrix[len1][len2];
 };
 
-const calculateSimilarity = (str1: string, str2: string): number => {
+export const calculateSimilarity = (str1: string, str2: string): number => {
   const maxLen = Math.max(str1.length, str2.length);
   if (maxLen === 0) return 1.0;
   const distance = levenshteinDistance(str1.toLowerCase(), str2.toLowerCase());

--- a/@fanslib/apps/server/src/features/posts/operations/schedule-capture.test.ts
+++ b/@fanslib/apps/server/src/features/posts/operations/schedule-capture.test.ts
@@ -1,0 +1,228 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import "reflect-metadata";
+import { getTestDataSource, setupTestDatabase, teardownTestDatabase } from "../../../lib/test-db";
+import { resetAllFixtures } from "../../../lib/test-fixtures";
+import { createTestChannel, createTestMedia, createTestPost } from "../../../test-utils/setup";
+import { PostMedia, Post } from "../entity";
+import { FanslyAnalyticsAggregate } from "../../analytics/entity";
+import { processScheduleCapture } from "./schedule-capture";
+
+describe("processScheduleCapture", () => {
+  beforeAll(async () => {
+    await setupTestDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetAllFixtures();
+  });
+
+  const createReadyFanslyPost = async (caption: string) => {
+    const dataSource = getTestDataSource();
+    const postMediaRepo = dataSource.getRepository(PostMedia);
+
+    const channel = await createTestChannel({ typeId: "fansly" });
+    const post = await createTestPost(channel.id, {
+      caption,
+      status: "ready",
+      date: new Date(),
+    });
+    const media = await createTestMedia();
+    const postMedia = postMediaRepo.create({
+      post,
+      media,
+      order: 0,
+    });
+    await postMediaRepo.save(postMedia);
+    return { post, postMedia, channel };
+  };
+
+  test("matches post by exact caption and links it", async () => {
+    const dataSource = getTestDataSource();
+    const postRepo = dataSource.getRepository(Post);
+    const postMediaRepo = dataSource.getRepository(PostMedia);
+    const aggregateRepo = dataSource.getRepository(FanslyAnalyticsAggregate);
+
+    const { post, postMedia } = await createReadyFanslyPost("Hello world! This is my first post 🎉");
+
+    const result = await processScheduleCapture({
+      contentId: "fansly-content-123",
+      caption: "Hello world! This is my first post 🎉",
+    });
+
+    expect(result.matched).toBe(true);
+    expect(result.postId).toBe(post.id);
+
+    // Post status should be "scheduled"
+    const updatedPost = await postRepo.findOne({ where: { id: post.id } });
+    expect(updatedPost?.status).toBe("scheduled");
+
+    // PostMedia should have fanslyStatisticsId set
+    const updatedPostMedia = await postMediaRepo.findOne({ where: { id: postMedia.id } });
+    expect(updatedPostMedia?.fanslyStatisticsId).toBe("fansly-content-123");
+
+    // Aggregate should be created with initial nextFetchAt
+    const aggregate = await aggregateRepo.findOne({ where: { postMediaId: postMedia.id } });
+    expect(aggregate).toBeTruthy();
+    expect(aggregate?.nextFetchAt).toBeInstanceOf(Date);
+  });
+
+  test("returns unmatched when no caption matches above threshold", async () => {
+    await createReadyFanslyPost("Completely different caption");
+
+    const result = await processScheduleCapture({
+      contentId: "fansly-content-456",
+      caption: "This is nothing alike at all",
+    });
+
+    expect(result.matched).toBe(false);
+    expect(result.postId).toBeUndefined();
+  });
+
+  test("matches with similarity >= 0.9 (minor differences)", async () => {
+    const dataSource = getTestDataSource();
+    const postRepo = dataSource.getRepository(Post);
+
+    const { post } = await createReadyFanslyPost("Check out my new photo shoot! Link in bio");
+
+    const result = await processScheduleCapture({
+      contentId: "fansly-content-789",
+      caption: "Check out my new photo shoot! link in bio",  // lowercase "link" vs "Link"
+    });
+
+    expect(result.matched).toBe(true);
+    expect(result.postId).toBe(post.id);
+
+    const updatedPost = await postRepo.findOne({ where: { id: post.id } });
+    expect(updatedPost?.status).toBe("scheduled");
+  });
+
+  test("does not match at similarity 0.89 (below threshold)", async () => {
+    await createReadyFanslyPost("ABCDEFGHIJ");
+
+    // "ABCDEFGHIJ" vs "ABCDEFGHxx" = 2 edits out of 10 = 0.8 similarity (below 0.9)
+    const result = await processScheduleCapture({
+      contentId: "fansly-content-000",
+      caption: "ABCDEFGHxx",
+    });
+
+    expect(result.matched).toBe(false);
+  });
+
+  test("only matches posts with status 'ready'", async () => {
+    const dataSource = getTestDataSource();
+    const channel = await createTestChannel({ typeId: "fansly" });
+    const post = await createTestPost(channel.id, {
+      caption: "Exact match caption",
+      status: "scheduled",
+      date: new Date(),
+    });
+    const postMediaRepo = dataSource.getRepository(PostMedia);
+    const media = await createTestMedia();
+    await postMediaRepo.save(postMediaRepo.create({ post, media, order: 0 }));
+
+    const result = await processScheduleCapture({
+      contentId: "fansly-content-111",
+      caption: "Exact match caption",
+    });
+
+    expect(result.matched).toBe(false);
+  });
+
+  test("only matches fansly channel posts", async () => {
+    const dataSource = getTestDataSource();
+    const channelTypeRepo = dataSource.getRepository("ChannelType");
+
+    // eslint-disable-next-line functional/no-let
+    let blueskyType = await channelTypeRepo.findOne({ where: { id: "bluesky" } });
+    if (!blueskyType) {
+      blueskyType = channelTypeRepo.create({ id: "bluesky", name: "Bluesky" });
+      await channelTypeRepo.save(blueskyType);
+    }
+
+    const channel = await createTestChannel({ typeId: "bluesky" });
+    const post = await createTestPost(channel.id, {
+      caption: "Exact match but wrong channel",
+      status: "ready",
+      date: new Date(),
+    });
+    const postMediaRepo = dataSource.getRepository(PostMedia);
+    const media = await createTestMedia();
+    await postMediaRepo.save(postMediaRepo.create({ post, media, order: 0 }));
+
+    const result = await processScheduleCapture({
+      contentId: "fansly-content-222",
+      caption: "Exact match but wrong channel",
+    });
+
+    expect(result.matched).toBe(false);
+  });
+
+  test("does not mutate data when no match", async () => {
+    const dataSource = getTestDataSource();
+    const postRepo = dataSource.getRepository(Post);
+
+    const { post } = await createReadyFanslyPost("My post caption");
+
+    await processScheduleCapture({
+      contentId: "fansly-content-333",
+      caption: "Totally unrelated scheduling text",
+    });
+
+    const unchangedPost = await postRepo.findOne({ where: { id: post.id } });
+    expect(unchangedPost?.status).toBe("ready");
+  });
+
+  test("links only attachments[0] (first PostMedia by order)", async () => {
+    const dataSource = getTestDataSource();
+    const postMediaRepo = dataSource.getRepository(PostMedia);
+
+    const channel = await createTestChannel({ typeId: "fansly" });
+    const post = await createTestPost(channel.id, {
+      caption: "Multi-media post",
+      status: "ready",
+      date: new Date(),
+    });
+    const media1 = await createTestMedia();
+    const media2 = await createTestMedia();
+    const pm1 = postMediaRepo.create({ post, media: media1, order: 0 });
+    const pm2 = postMediaRepo.create({ post, media: media2, order: 1 });
+    await postMediaRepo.save(pm1);
+    await postMediaRepo.save(pm2);
+
+    const result = await processScheduleCapture({
+      contentId: "fansly-multi-001",
+      caption: "Multi-media post",
+    });
+
+    expect(result.matched).toBe(true);
+
+    const updatedPm1 = await postMediaRepo.findOne({ where: { id: pm1.id } });
+    const updatedPm2 = await postMediaRepo.findOne({ where: { id: pm2.id } });
+    expect(updatedPm1?.fanslyStatisticsId).toBe("fansly-multi-001");
+    expect(updatedPm2?.fanslyStatisticsId).toBeNull();
+  });
+
+  test("handles null caption in queue post gracefully", async () => {
+    const channel = await createTestChannel({ typeId: "fansly" });
+    const post = await createTestPost(channel.id, {
+      caption: null,
+      status: "ready",
+      date: new Date(),
+    });
+    const dataSource = getTestDataSource();
+    const postMediaRepo = dataSource.getRepository(PostMedia);
+    const media = await createTestMedia();
+    await postMediaRepo.save(postMediaRepo.create({ post, media, order: 0 }));
+
+    const result = await processScheduleCapture({
+      contentId: "fansly-content-444",
+      caption: "Some caption",
+    });
+
+    expect(result.matched).toBe(false);
+  });
+});

--- a/@fanslib/apps/server/src/features/posts/operations/schedule-capture.ts
+++ b/@fanslib/apps/server/src/features/posts/operations/schedule-capture.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import { db } from "../../../lib/db";
+import { calculateSimilarity } from "../../analytics/candidates/matching";
+import { FanslyAnalyticsAggregate } from "../../analytics/entity";
+import { Post, PostMedia } from "../entity";
+
+export const ScheduleCaptureRequestBodySchema = z.object({
+  contentId: z.string(),
+  caption: z.string(),
+});
+
+export type ScheduleCaptureResult = {
+  matched: boolean;
+  postId?: string;
+  similarity?: number;
+};
+
+const SIMILARITY_THRESHOLD = 0.9;
+const INITIAL_FETCH_INTERVAL_DAYS = 1;
+
+export const processScheduleCapture = async (
+  input: z.infer<typeof ScheduleCaptureRequestBodySchema>,
+): Promise<ScheduleCaptureResult> => {
+  const dataSource = await db();
+  const postRepo = dataSource.getRepository(Post);
+  const postMediaRepo = dataSource.getRepository(PostMedia);
+  const aggregateRepo = dataSource.getRepository(FanslyAnalyticsAggregate);
+
+  // Find ready Fansly posts
+  const readyPosts = await postRepo
+    .createQueryBuilder("post")
+    .leftJoinAndSelect("post.channel", "channel")
+    .leftJoinAndSelect("post.postMedia", "postMedia")
+    .where("post.status = :status", { status: "ready" })
+    .andWhere("channel.typeId = :typeId", { typeId: "fansly" })
+    .andWhere("post.caption IS NOT NULL")
+    .orderBy("post.date", "ASC")
+    .getMany();
+
+  // Find best caption match
+  const matches = readyPosts
+    .map((post) => ({
+      post,
+      similarity: calculateSimilarity(post.caption ?? "", input.caption),
+    }))
+    .filter((m) => m.similarity >= SIMILARITY_THRESHOLD)
+    .sort((a, b) => b.similarity - a.similarity);
+
+  if (matches.length === 0) {
+    return { matched: false };
+  }
+
+  const bestMatch = matches[0];
+  const post = bestMatch.post;
+
+  // Update post status to "scheduled"
+  await postRepo.update(post.id, { status: "scheduled" });
+
+  // Link first PostMedia (attachments[0]) with fanslyStatisticsId
+  const firstPostMedia = [...post.postMedia].sort((a, b) => a.order - b.order)[0];
+  if (firstPostMedia) {
+    await postMediaRepo.update(firstPostMedia.id, {
+      fanslyStatisticsId: input.contentId,
+    });
+
+    // Create or update aggregate with initial nextFetchAt
+    const existingAggregate = await aggregateRepo.findOne({
+      where: { postMediaId: firstPostMedia.id },
+    });
+
+    if (existingAggregate) {
+      existingAggregate.nextFetchAt = new Date(Date.now() + INITIAL_FETCH_INTERVAL_DAYS * 24 * 60 * 60 * 1000);
+      await aggregateRepo.save(existingAggregate);
+    } else {
+      const aggregate = aggregateRepo.create({
+        postMediaId: firstPostMedia.id,
+        postMedia: firstPostMedia,
+        totalViews: 0,
+        averageEngagementSeconds: 0,
+        averageEngagementPercent: 0,
+        nextFetchAt: new Date(Date.now() + INITIAL_FETCH_INTERVAL_DAYS * 24 * 60 * 60 * 1000),
+      });
+      await aggregateRepo.save(aggregate);
+    }
+  }
+
+  return {
+    matched: true,
+    postId: post.id,
+    similarity: bestMatch.similarity,
+  };
+};

--- a/@fanslib/apps/server/src/features/posts/routes.ts
+++ b/@fanslib/apps/server/src/features/posts/routes.ts
@@ -13,6 +13,7 @@ import { fetchPostById } from "./operations/post/fetch-by-id";
 import { fetchPostsByMediaId } from "./operations/post/fetch-by-media-id";
 import { FetchRecentPostsRequestSchema, fetchRecentPosts } from "./operations/post/fetch-recent";
 import { UpdatePostRequestBodySchema, updatePost } from "./operations/post/update";
+import { ScheduleCaptureRequestBodySchema, processScheduleCapture } from "./operations/schedule-capture";
 import { PostFiltersSchema } from "./schemas/post-filters";
 
 const FetchAllPostsQuerySchema = z.object({
@@ -90,6 +91,11 @@ export const postsRoutes = new Hono()
       return notFound(c, "Post not found");
     }
     return c.json(post);
+  })
+  .post("/schedule-capture", zValidator("json", ScheduleCaptureRequestBodySchema, validationError), async (c) => {
+    const body = c.req.valid("json");
+    const result = await processScheduleCapture(body);
+    return c.json(result);
   })
   .patch("/by-id/:id/media/:postMediaId", zValidator("json", UpdatePostMediaRequestBodySchema, validationError), async (c) => {
     const id = c.req.param("id");


### PR DESCRIPTION
## Summary
- Extension intercepts Fansly scheduling API responses (POST/PUT to `apiv3.fansly.com`), extracts `contentId` and `caption` from `postTemplate`/`post` structures
- New `FANSLIB_SCHEDULE_CAPTURE` message type flows through bridge → background → server API
- Server `POST /api/posts/schedule-capture` matches caption via Levenshtein similarity (>= 0.9) to "ready" Fansly posts, then: sets post status to "scheduled", links first PostMedia with `fanslyStatisticsId`, creates aggregate with initial `nextFetchAt`
- Side panel shows green "Linked" badge on matched post and auto-advances to next queue post after 2 seconds

Closes #78

## Test plan
- [x] 9 server-side tests: exact match, fuzzy match at threshold, below threshold rejection, status/channel filtering, no-match safety, multi-media linking (attachments[0] only), null caption handling
- [x] Full server test suite passes (201 tests)
- [x] TypeScript type check clean (server + extension)
- [x] Server lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)