### PR TITLE
feat: extension activity log in side panel

### DIFF
--- a/@fanslib/apps/chrome-extension/src/background/index.ts
+++ b/@fanslib/apps/chrome-extension/src/background/index.ts
@@ -1,3 +1,4 @@
+import { addLogEntry } from '../lib/activity-log';
 import type { CandidateItem } from '../content/fansly-interceptor';
 
 type Message =
@@ -395,6 +396,12 @@ const sendScheduleCapture = async (
 
     debug('info', 'Schedule capture result', { matched: result.matched, postId: result.postId });
 
+    if (result.matched) {
+      await addLogEntry({ type: 'success', message: "Linked '" + caption.slice(0, 40) + "' to post" });
+    } else {
+      await addLogEntry({ type: 'warning', message: "Unrecognized post scheduled: '" + caption.slice(0, 40) + "'" });
+    }
+
     await chrome.storage.local.set({
       lastScheduleCaptureResult: {
         matched: result.matched,
@@ -407,6 +414,8 @@ const sendScheduleCapture = async (
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     debug('error', 'Failed to send schedule capture', { error: errorMessage });
+
+    await addLogEntry({ type: 'error', message: 'Schedule capture failed: ' + errorMessage });
 
     await chrome.storage.local.set({
       lastScheduleCaptureResult: {

--- a/@fanslib/apps/chrome-extension/src/components/Popup/ActivityLogTab.tsx
+++ b/@fanslib/apps/chrome-extension/src/components/Popup/ActivityLogTab.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+import {
+  clearActivityLog,
+  getActivityLog,
+  type ActivityLogEntry,
+} from '../../lib/activity-log';
+
+const formatRelativeTime = (timestamp: number): string => {
+  const now = Date.now();
+  const diffMs = now - timestamp;
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSeconds < 60) return 'Just now';
+  if (diffMinutes < 60)
+    return `${diffMinutes}m ago`;
+  if (diffHours < 24)
+    return `${diffHours}h ago`;
+  if (diffDays < 7)
+    return `${diffDays}d ago`;
+
+  const date = new Date(timestamp);
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+};
+
+const typeStyles: Record<ActivityLogEntry['type'], { dot: string; text: string }> = {
+  success: { dot: 'bg-green-500', text: 'text-green-600' },
+  warning: { dot: 'bg-yellow-500', text: 'text-yellow-600' },
+  error: { dot: 'bg-red-500', text: 'text-red-600' },
+};
+
+export const ActivityLogTab = () => {
+  const [entries, setEntries] = useState<ActivityLogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadEntries = async () => {
+    try {
+      const log = await getActivityLog();
+      setEntries(log);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadEntries();
+
+    const storageListener = (
+      changes: Record<string, chrome.storage.StorageChange>,
+      areaName: string
+    ) => {
+      if (areaName === 'local' && changes.fanslib_activity_log) {
+        const newEntries = changes.fanslib_activity_log.newValue;
+        if (Array.isArray(newEntries)) {
+          setEntries(newEntries as ActivityLogEntry[]);
+        }
+      }
+    };
+
+    if (typeof chrome !== 'undefined' && chrome?.storage?.onChanged) {
+      chrome.storage.onChanged.addListener(storageListener);
+      return () => {
+        chrome.storage.onChanged.removeListener(storageListener);
+      };
+    }
+  }, []);
+
+  const handleClear = async () => {
+    await clearActivityLog();
+    setEntries([]);
+  };
+
+  return (
+    <div className='px-3 pt-3 pb-4'>
+      <div className='flex items-center justify-between mb-3'>
+        <h3 className='text-sm font-semibold'>Activity Log</h3>
+        {entries.length > 0 && (
+          <button
+            onClick={handleClear}
+            className='btn btn-ghost btn-xs'
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {loading ? (
+        <div className='text-sm text-base-content/70'>Loading...</div>
+      ) : entries.length === 0 ? (
+        <div className='text-sm text-base-content/50 text-center py-8'>
+          No activity yet
+        </div>
+      ) : (
+        <div className='space-y-1 max-h-[calc(100vh-10rem)] overflow-y-auto'>
+          {entries.map((entry, index) => {
+            const styles = typeStyles[entry.type];
+            return (
+              <div
+                key={`${entry.timestamp}-${index}`}
+                className='flex items-start gap-2 p-2 rounded-lg hover:bg-base-200'
+              >
+                <div
+                  className={`w-2 h-2 rounded-full mt-1.5 shrink-0 ${styles.dot}`}
+                />
+                <div className='flex-1 min-w-0'>
+                  <div className='text-xs leading-relaxed'>
+                    {entry.message}
+                  </div>
+                  <div className='text-[10px] text-base-content/40 mt-0.5'>
+                    {formatRelativeTime(entry.timestamp)}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/@fanslib/apps/chrome-extension/src/components/Popup/Popup.tsx
+++ b/@fanslib/apps/chrome-extension/src/components/Popup/Popup.tsx
@@ -3,6 +3,7 @@ import type { PostWithRelations } from '@fanslib/server/schemas';
 import { useEffect, useState } from 'react';
 import { eden } from '../../lib/api';
 import { getSettings, type Settings } from '../../lib/storage';
+import { ActivityLogTab } from './ActivityLogTab';
 import { CredentialsTab } from './CredentialsTab';
 import { EmptyState } from './EmptyState';
 import { PopupHeader } from './PopupHeader';
@@ -11,7 +12,7 @@ import { PostNavigation } from './PostNavigation';
 import { StatisticsTab } from './StatisticsTab';
 
 type Post = PostWithRelations;
-type Tab = 'queue' | 'statistics' | 'credentials';
+type Tab = 'queue' | 'statistics' | 'activity' | 'credentials';
 
 export const Popup = () => {
   const [settings, setSettings] = useState<Settings | null>(null);
@@ -203,6 +204,12 @@ export const Popup = () => {
           Statistics
         </button>
         <button
+          className={`tab ${activeTab === 'activity' ? 'tab-active' : ''}`}
+          onClick={() => setActiveTab('activity')}
+        >
+          Activity
+        </button>
+        <button
           className={`tab ${activeTab === 'credentials' ? 'tab-active' : ''}`}
           onClick={() => setActiveTab('credentials')}
         >
@@ -236,6 +243,8 @@ export const Popup = () => {
         ) : null
       ) : activeTab === 'statistics' ? (
         <StatisticsTab />
+      ) : activeTab === 'activity' ? (
+        <ActivityLogTab />
       ) : (
         <CredentialsTab />
       )}

--- a/@fanslib/apps/chrome-extension/src/lib/activity-log.ts
+++ b/@fanslib/apps/chrome-extension/src/lib/activity-log.ts
@@ -1,0 +1,78 @@
+export type ActivityLogEntry = {
+  timestamp: number;
+  type: 'success' | 'warning' | 'error';
+  message: string;
+};
+
+const STORAGE_KEY = 'fanslib_activity_log';
+const MAX_ENTRIES = 100;
+
+const getStorage = (): typeof chrome.storage.local | null => {
+  if (typeof chrome !== 'undefined' && chrome?.storage?.local) {
+    return chrome.storage.local;
+  }
+  return null;
+};
+
+export const addLogEntry = async (
+  entry: Omit<ActivityLogEntry, 'timestamp'>
+): Promise<void> => {
+  const storage = getStorage();
+
+  if (!storage) {
+    // Test mode fallback using localStorage
+    if (typeof window !== 'undefined') {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const existing: ActivityLogEntry[] = raw ? JSON.parse(raw) : [];
+      const newEntry: ActivityLogEntry = {
+        ...entry,
+        timestamp: Date.now(),
+      };
+      const updated = [newEntry, ...existing].slice(0, MAX_ENTRIES);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+    }
+    return;
+  }
+
+  const result = await storage.get(STORAGE_KEY);
+  const existing: ActivityLogEntry[] =
+    (result[STORAGE_KEY] as ActivityLogEntry[] | undefined) ?? [];
+
+  const newEntry: ActivityLogEntry = {
+    ...entry,
+    timestamp: Date.now(),
+  };
+
+  const updated = [newEntry, ...existing].slice(0, MAX_ENTRIES);
+  await storage.set({ [STORAGE_KEY]: updated });
+};
+
+export const getActivityLog = async (): Promise<ActivityLogEntry[]> => {
+  const storage = getStorage();
+
+  if (!storage) {
+    // Test mode fallback using localStorage
+    if (typeof window !== 'undefined') {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : [];
+    }
+    return [];
+  }
+
+  const result = await storage.get(STORAGE_KEY);
+  return (result[STORAGE_KEY] as ActivityLogEntry[] | undefined) ?? [];
+};
+
+export const clearActivityLog = async (): Promise<void> => {
+  const storage = getStorage();
+
+  if (!storage) {
+    // Test mode fallback using localStorage
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+    return;
+  }
+
+  await storage.set({ [STORAGE_KEY]: [] });
+};


### PR DESCRIPTION
## Summary
- Rolling 100-entry activity log stored in `chrome.storage.local`, oldest evicted on overflow
- New "Activity" tab in extension side panel with scrollable list of log entries
- Each entry shows colored dot (green/yellow/red), message text, and relative timestamp
- Scheduling capture integration: logs success on match, warning on unrecognized post, error on failure
- Real-time updates via `chrome.storage.onChanged` listener
- Clear button to reset the log

Closes #79

## Test plan
- [x] TypeScript compilation passes (extension + server)
- [x] Server test suite passes (201 tests)
- [x] Server lint passes
- [ ] Manual: verify log entries appear on schedule capture match/no-match
- [ ] Manual: verify 100-entry cap with oldest eviction
- [ ] Manual: verify log persists across extension restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)