### PR TITLE
Fix library scan progress bar — stuck at 0% or 100%

### DIFF
--- a/@fanslib/apps/server/src/features/library/operations/scan/scan.ts
+++ b/@fanslib/apps/server/src/features/library/operations/scan/scan.ts
@@ -173,12 +173,9 @@ class LibraryScanner {
   }
 
   public onComplete(result: z.infer<typeof LibraryScanResultSchema>): void {
-    // Store result in module-level state instead of sending IPC events
+    // Store result and clear progress atomically
     currentScanResult = result;
-    // Delay clearing progress slightly to ensure it's visible for status checks
-    setTimeout(() => {
-      currentScanProgress = null;
-    }, 100);
+    currentScanProgress = null;
   }
 
   public async startScan(): Promise<void> {
@@ -187,7 +184,7 @@ class LibraryScanner {
     }
 
     this.isScanning = true;
-    currentScanProgress = null;
+    currentScanProgress = { current: 0, total: 0 };
     currentScanResult = null;
 
     try {
@@ -212,6 +209,9 @@ class LibraryScanner {
         totalFiles: filesToProcess.length,
         files: filesToProcess,
       });
+
+      // Update progress with discovered total
+      this.onProgress({ current: 0, total: filesToProcess.length });
 
       // Get existing media for cleanup
       const database = await db();

--- a/@fanslib/apps/web/src/features/library/components/ScanProgress.tsx
+++ b/@fanslib/apps/web/src/features/library/components/ScanProgress.tsx
@@ -15,9 +15,15 @@ export const ScanProgress = ({ scanProgress, scanResult }: ScanProgressProps) =>
         <div className="mb-4">
           <div className="flex justify-between text-sm text-muted-foreground mb-2">
             <span>Scanning library...</span>
-            <span>{Math.round((scanProgress.current / scanProgress.total) * 100)}%</span>
+            <span>
+              {scanProgress.total > 0
+                ? `${Math.round((scanProgress.current / scanProgress.total) * 100)}%`
+                : 'Discovering files...'}
+            </span>
           </div>
-          <Progress value={(scanProgress.current / scanProgress.total) * 100} />
+          <Progress
+            value={scanProgress.total > 0 ? (scanProgress.current / scanProgress.total) * 100 : undefined}
+          />
         </div>
       )}
 

--- a/@fanslib/apps/web/src/hooks/useScan.ts
+++ b/@fanslib/apps/web/src/hooks/useScan.ts
@@ -24,13 +24,13 @@ export const useScan = (onScanComplete?: () => void): UseScanResult => {
 
       if (!status) return;
 
-      if ('isScanning' in status && status.isScanning && status.progress) {
-        setScanProgress(status.progress);
-      }
-
-      if ('isScanning' in status && !status.isScanning && status.result) {
+      if ('isScanning' in status && status.isScanning) {
+        setScanProgress(status.progress ?? null);
+      } else if ('isScanning' in status && !status.isScanning) {
         setScanProgress(null);
-        setScanResult(status.result);
+        if (status.result) {
+          setScanResult(status.result);
+        }
         setIsScanning(false);
         onScanComplete?.();
       }
@@ -56,7 +56,7 @@ export const useScan = (onScanComplete?: () => void): UseScanResult => {
   return {
     scanProgress,
     scanResult,
-    isScanning: scanProgress !== null,
+    isScanning,
     handleScan,
     resetScan,
   };


### PR DESCRIPTION
## Summary
- **Server**: Initialize scan progress to `{current:0, total:0}` at scan start so polls during file discovery return valid progress instead of `null`
- **Server**: Remove `setTimeout` race condition in `onComplete()` — clear progress atomically with setting result
- **Frontend**: Use actual `isScanning` state variable instead of deriving from `scanProgress !== null`, which caused the UI to miss the scanning phase
- **Frontend**: Handle zero-total discovery phase gracefully ("Discovering files..." instead of NaN%)

Closes #90

## Test plan
- [ ] Trigger a library scan on a folder with many files
- [ ] Verify progress bar appears immediately (shows "Discovering files..." initially)
- [ ] Verify progress updates smoothly from 0% to 100% as files are processed
- [ ] Verify scan completes and shows result summary
- [ ] Verify scan button is disabled during scan and re-enabled after

🤖 Generated with [Claude Code](https://claude.com/claude-code)