### PR TITLE
Fix grey flash on media tile hover preview

### DIFF
--- a/@fanslib/apps/web/src/features/library/components/MediaTile/MediaTileLite.tsx
+++ b/@fanslib/apps/web/src/features/library/components/MediaTile/MediaTileLite.tsx
@@ -58,6 +58,7 @@ export const MediaTileLite = memo(
     const imageError = controlledImageError ?? localImageError;
     const videoRef = useRef<HTMLVideoElement>(null);
     const previewIntervalRef = useRef<number | null>(null);
+    const [isVideoReady, setIsVideoReady] = useState(false);
 
     const { data: mediaTags = [] } = useMediaTagsQuery({ mediaId: media.id });
     const stickerTags = (mediaTags ?? []).filter((mt) => mt.stickerDisplay === "color");
@@ -70,17 +71,23 @@ export const MediaTileLite = memo(
     }, [onImageError]);
 
     useEffect(() => {
-      if (!videoRef.current || media.type !== "video" || !isActivePreview) return () => {};
+      if (!videoRef.current || media.type !== "video" || !isActivePreview) {
+        setIsVideoReady(false);
+        return () => {};
+      }
 
       const video = videoRef.current;
       video.muted = true;
       video.currentTime = 0;
 
+      const onCanPlay = () => setIsVideoReady(true);
+      video.addEventListener("canplay", onCanPlay, { once: true });
+
       const playVideo = async () => {
         try {
           video.play();
-        } catch (error) {
-          console.error("Failed to play video:", error);
+        } catch {
+          // Play may be interrupted if user moves mouse away quickly
         }
       };
 
@@ -96,8 +103,10 @@ export const MediaTileLite = memo(
       }, 1000);
 
       return () => {
+        video.removeEventListener("canplay", onCanPlay);
         video.pause();
         video.currentTime = 0;
+        setIsVideoReady(false);
         if (previewIntervalRef.current) {
           clearInterval(previewIntervalRef.current);
         }
@@ -112,16 +121,17 @@ export const MediaTileLite = memo(
         )}
         {media.type === "video" ? (
           <>
-            {!isActivePreview && (
-              <img
-                src={getMediaThumbnailUrl(media.id)}
-                alt={media.name}
-                className={getBlurClassName("absolute inset-0 w-full h-full object-contain")}
-                onError={handleImageError}
-                loading="lazy"
-                draggable={false}
-              />
-            )}
+            <img
+              src={getMediaThumbnailUrl(media.id)}
+              alt={media.name}
+              className={getBlurClassName(cn(
+                "absolute inset-0 w-full h-full object-contain",
+                isActivePreview && isVideoReady && "invisible"
+              ))}
+              onError={handleImageError}
+              loading="lazy"
+              draggable={false}
+            />
             <video
               ref={videoRef}
               src={getMediaFileUrl(media.id)}

--- a/@fanslib/apps/web/src/features/library/components/MediaTile/MediaTileVideo.tsx
+++ b/@fanslib/apps/web/src/features/library/components/MediaTile/MediaTileVideo.tsx
@@ -21,7 +21,7 @@ export const MediaTileVideo = ({
   cover,
 }: MediaTileVideoProps) => {
   const isPreviewActive = useMediaHoverStore((s) => withPreview && s.hoveredMediaId === media.id);
-  const { videoRef } = useVideoPreview({
+  const { videoRef, isVideoReady } = useVideoPreview({
     isActive: isPreviewActive,
     mediaType: "video",
   });
@@ -29,20 +29,19 @@ export const MediaTileVideo = ({
 
   return (
     <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-      {!isPreviewActive && (
-        <img
-          src={getMediaThumbnailUrl(media.id)}
-          alt={media.name}
-          className={getBlurClassName(
-            cn(
-              "absolute inset-0 w-full h-full bg-base-300",
-              cover ? "object-cover" : "object-contain"
-            )
-          )}
-          loading="lazy"
-          draggable={false}
-        />
-      )}
+      <img
+        src={getMediaThumbnailUrl(media.id)}
+        alt={media.name}
+        className={getBlurClassName(
+          cn(
+            "absolute inset-0 w-full h-full bg-base-300",
+            cover ? "object-cover" : "object-contain",
+            isPreviewActive && isVideoReady && "invisible"
+          )
+        )}
+        loading="lazy"
+        draggable={false}
+      />
       <video
         ref={videoRef}
         src={getMediaFileUrl(media.id)}

--- a/@fanslib/apps/web/src/hooks/useVideoPreview.ts
+++ b/@fanslib/apps/web/src/hooks/useVideoPreview.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type UseVideoPreviewOptions = {
   isActive: boolean;
@@ -8,16 +8,30 @@ type UseVideoPreviewOptions = {
 export const useVideoPreview = ({ isActive, mediaType }: UseVideoPreviewOptions) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const previewIntervalRef = useRef<number | undefined>(undefined);
+  const [isVideoReady, setIsVideoReady] = useState(false);
 
   useEffect(() => {
-    if (!videoRef.current || mediaType !== "video" || !isActive) return () => {};
+    if (!videoRef.current || mediaType !== "video" || !isActive) {
+      setIsVideoReady(false);
+      return () => {};
+    }
 
     const video = videoRef.current;
     video.muted = true;
     video.currentTime = 0;
 
+    const onCanPlay = () => {
+      setIsVideoReady(true);
+    };
+
+    video.addEventListener("canplay", onCanPlay, { once: true });
+
     const playVideo = async () => {
-      await video.play();
+      try {
+        await video.play();
+      } catch {
+        // Play may be interrupted if user moves mouse away quickly
+      }
     };
 
     playVideo();
@@ -32,13 +46,15 @@ export const useVideoPreview = ({ isActive, mediaType }: UseVideoPreviewOptions)
     }, 1000);
 
     return () => {
+      video.removeEventListener("canplay", onCanPlay);
       video.pause();
       video.currentTime = 0;
+      setIsVideoReady(false);
       if (previewIntervalRef.current !== undefined) {
         clearInterval(previewIntervalRef.current);
       }
     };
   }, [isActive, mediaType]);
 
-  return { videoRef };
+  return { videoRef, isVideoReady };
 };


### PR DESCRIPTION
## Summary
- Keep thumbnail visible until the video fires `canplay` event, then hide it with `invisible` (preserves layout, no grey flash)
- Previously the thumbnail was unmounted immediately on hover, exposing the empty video container's `bg-base-300` background
- Added `isVideoReady` state to `useVideoPreview` hook via the `canplay` event listener
- Applied the same fix to both `MediaTileVideo` (gallery) and `MediaTileLite` (media selection)

Closes #91

## Test plan
- [ ] Hover over a video tile in the library gallery — no grey flash before video starts
- [ ] Hover over a video in the media selection panel — same smooth transition
- [ ] Move mouse away quickly before video loads — thumbnail remains, no flash
- [ ] Hover again after moving away — preview works correctly on re-hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)