### PR TITLE
Repost Candidates — frontend page with cards and sort

### DIFF
--- a/@fanslib/apps/chrome-extension/src/components/Popup/BackfillTab.tsx
+++ b/@fanslib/apps/chrome-extension/src/components/Popup/BackfillTab.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Image, Video, Check, X, Loader2, ArrowRight } from "lucide-react";
+import { Image, Video, Check, X, Loader2, ArrowRight, ExternalLink } from "lucide-react";
 import { getSettings } from "../../lib/storage";
 import { addLogEntry } from "../../lib/activity-log";
 import { eden } from "../../lib/api";
@@ -11,14 +11,17 @@ type Suggestion = {
   filename: string;
   confidence: number;
   caption?: string;
+  scheduleName?: string;
 };
 
 type Candidate = {
   id: string;
   filename: string;
   caption: string | null;
+  fanslyPostId: string;
   mediaType: string;
-  topSuggestion: Suggestion | null;
+  suggestions: Suggestion[];
+  selectedIndex: number;
   suggestionsLoading: boolean;
 };
 
@@ -26,7 +29,16 @@ type RawCandidate = {
   id: string;
   filename: string;
   caption: string | null;
+  fanslyPostId: string;
   mediaType: string;
+};
+
+const CONFIDENCE_THRESHOLD = 0.05;
+
+const getVisibleSuggestions = (suggestions: Suggestion[]): Suggestion[] => {
+  if (suggestions.length <= 1) return suggestions;
+  const topConfidence = suggestions[0].confidence;
+  return suggestions.filter((s) => topConfidence - s.confidence <= CONFIDENCE_THRESHOLD);
 };
 
 export const BackfillTab = () => {
@@ -57,8 +69,10 @@ export const BackfillTab = () => {
         id: c.id,
         filename: c.filename,
         caption: c.caption,
+        fanslyPostId: c.fanslyPostId,
         mediaType: c.mediaType,
-        topSuggestion: null,
+        suggestions: [],
+        selectedIndex: 0,
         suggestionsLoading: true,
       }));
 
@@ -91,11 +105,12 @@ export const BackfillTab = () => {
       }
 
       const suggestions = (await response.json()) as Suggestion[];
-      const topSuggestion = suggestions.length > 0 ? suggestions[0] : null;
 
       setCandidates((prev) =>
         prev.map((c) =>
-          c.id === candidateId ? { ...c, topSuggestion, suggestionsLoading: false } : c,
+          c.id === candidateId
+            ? { ...c, suggestions, selectedIndex: 0, suggestionsLoading: false }
+            : c,
         ),
       );
     } catch {
@@ -105,8 +120,7 @@ export const BackfillTab = () => {
     }
   };
 
-  const handleConfirm = async (candidate: Candidate) => {
-    if (!candidate.topSuggestion) return;
+  const handleConfirm = async (candidate: Candidate, suggestion: Suggestion) => {
     setActionInProgress(candidate.id);
 
     try {
@@ -114,7 +128,7 @@ export const BackfillTab = () => {
       const api = eden(settings.apiUrl);
       const response = await api.api.analytics.candidates["by-id"][":id"].match.$post({
         param: { id: candidate.id },
-        json: { postMediaId: candidate.topSuggestion.postMediaId },
+        json: { postMediaId: suggestion.postMediaId },
       });
 
       if (!response.ok) {
@@ -123,7 +137,7 @@ export const BackfillTab = () => {
 
       await addLogEntry({
         type: "success",
-        message: `Matched "${candidate.filename}" to "${candidate.topSuggestion.filename}"`,
+        message: `Matched "${candidate.filename}" to "${suggestion.filename}"`,
       });
 
       setCandidates((prev) => prev.filter((c) => c.id !== candidate.id));
@@ -179,10 +193,7 @@ export const BackfillTab = () => {
             const captionPreview = candidate.caption
               ? candidate.caption.slice(0, 60) + (candidate.caption.length > 60 ? "..." : "")
               : null;
-            const suggestion = candidate.topSuggestion;
-            const suggestionCaptionPreview = suggestion?.caption
-              ? suggestion.caption.slice(0, 60) + (suggestion.caption.length > 60 ? "..." : "")
-              : null;
+            const visible = getVisibleSuggestions(candidate.suggestions);
 
             return (
               <div key={candidate.id} className="card card-compact bg-base-200 p-3">
@@ -206,63 +217,94 @@ export const BackfillTab = () => {
                       </div>
                     )}
                   </div>
+                  <a
+                    href={`https://fansly.com/post/${candidate.fanslyPostId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="btn btn-ghost btn-xs btn-square shrink-0"
+                    title="View on Fansly"
+                  >
+                    <ExternalLink className="w-3 h-3" />
+                  </a>
                 </div>
 
-                {/* Match arrow + suggestion */}
+                {/* Match suggestions */}
                 {candidate.suggestionsLoading ? (
                   <div className="text-[10px] text-base-content/40 flex items-center gap-1 pl-5">
                     <Loader2 className="w-3 h-3 animate-spin" />
                     Finding matches...
                   </div>
-                ) : suggestion ? (
-                  <div className="flex items-center gap-2">
-                    <ArrowRight className="w-3.5 h-3.5 text-green-600 shrink-0" />
-                    {/* Thumbnail */}
-                    <div className="w-10 h-10 rounded overflow-hidden bg-base-300 shrink-0">
-                      <img
-                        src={getMediaThumbnailUrl(apiUrl, suggestion.mediaId)}
-                        alt=""
-                        className="w-full h-full object-cover"
-                        onError={(e) => {
-                          (e.target as HTMLImageElement).style.display = "none";
-                        }}
-                      />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="text-[10px] uppercase tracking-wider text-base-content/40 font-semibold">
-                        Library match
-                      </div>
-                      <div className="text-xs truncate">{suggestion.filename}</div>
-                      {suggestionCaptionPreview && (
-                        <div className="text-[10px] text-base-content/50 truncate">
-                          {suggestionCaptionPreview}
+                ) : visible.length > 0 ? (
+                  <div className="space-y-1.5">
+                    {visible.map((suggestion) => {
+                      const suggestionCaptionPreview = suggestion.caption
+                        ? suggestion.caption.slice(0, 60) +
+                          (suggestion.caption.length > 60 ? "..." : "")
+                        : null;
+
+                      return (
+                        <div key={suggestion.postMediaId} className="flex items-center gap-2">
+                          <ArrowRight className="w-3.5 h-3.5 text-green-600 shrink-0" />
+                          {/* Thumbnail */}
+                          <div className="w-10 h-10 rounded overflow-hidden bg-base-300 shrink-0">
+                            <img
+                              src={getMediaThumbnailUrl(apiUrl, suggestion.mediaId)}
+                              alt=""
+                              className="w-full h-full object-cover"
+                              onError={(e) => {
+                                (e.target as HTMLImageElement).style.display = "none";
+                              }}
+                            />
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-1">
+                              <div className="text-[10px] uppercase tracking-wider text-base-content/40 font-semibold">
+                                Library match
+                              </div>
+                              {suggestion.scheduleName && (
+                                <span className="badge badge-xs badge-primary">
+                                  {suggestion.scheduleName}
+                                </span>
+                              )}
+                            </div>
+                            <div className="text-xs truncate">{suggestion.filename}</div>
+                            {suggestionCaptionPreview && (
+                              <div className="text-[10px] text-base-content/50 truncate">
+                                {suggestionCaptionPreview}
+                              </div>
+                            )}
+                            <div className="text-[10px] text-green-600">
+                              {Math.round(suggestion.confidence * 100)}% confidence
+                            </div>
+                          </div>
+                          {/* Actions */}
+                          <div className="flex gap-1 shrink-0">
+                            <button
+                              onClick={() => handleConfirm(candidate, suggestion)}
+                              disabled={isActioning}
+                              className="btn btn-success btn-xs btn-square"
+                              title="Confirm match"
+                            >
+                              {isActioning ? (
+                                <Loader2 className="w-3 h-3 animate-spin" />
+                              ) : (
+                                <Check className="w-3 h-3" />
+                              )}
+                            </button>
+                          </div>
                         </div>
-                      )}
-                      <div className="text-[10px] text-green-600">
-                        {Math.round(suggestion.confidence * 100)}% confidence
-                      </div>
-                    </div>
-                    {/* Actions */}
-                    <div className="flex gap-1 shrink-0">
-                      <button
-                        onClick={() => handleConfirm(candidate)}
-                        disabled={isActioning}
-                        className="btn btn-success btn-xs btn-square"
-                        title="Confirm match"
-                      >
-                        {isActioning ? (
-                          <Loader2 className="w-3 h-3 animate-spin" />
-                        ) : (
-                          <Check className="w-3 h-3" />
-                        )}
-                      </button>
+                      );
+                    })}
+                    {/* Ignore button below all suggestions */}
+                    <div className="flex justify-end pt-0.5">
                       <button
                         onClick={() => handleIgnore(candidate)}
                         disabled={isActioning}
-                        className="btn btn-ghost btn-xs btn-square"
+                        className="btn btn-ghost btn-xs gap-1"
                         title="Ignore"
                       >
                         <X className="w-3 h-3" />
+                        <span className="text-[10px]">Ignore</span>
                       </button>
                     </div>
                   </div>

--- a/@fanslib/apps/server/src/features/analytics/candidates/matching.ts
+++ b/@fanslib/apps/server/src/features/analytics/candidates/matching.ts
@@ -9,6 +9,7 @@ type MatchSuggestion = {
   method: "exact_filename" | "fuzzy_filename" | "manual";
   filename: string;
   caption?: string;
+  scheduleName?: string;
 };
 
 const levenshteinDistance = (str1: string, str2: string): number => {
@@ -70,6 +71,7 @@ export const computeMatchSuggestions = async (
     .createQueryBuilder("postMedia")
     .innerJoinAndSelect("postMedia.post", "post")
     .innerJoinAndSelect("postMedia.media", "media")
+    .leftJoinAndSelect("post.schedule", "schedule")
     .where("postMedia.fanslyStatisticsId IS NULL")
     .getMany();
 
@@ -80,6 +82,7 @@ export const computeMatchSuggestions = async (
 
     const normalizedMediaFilename = normalizeFilename(postMedia.media.name);
     const caption = postMedia.post.caption ?? undefined;
+    const scheduleName = postMedia.post.schedule?.name ?? undefined;
 
     // media is fully loaded via innerJoinAndSelect
     const mediaId = (postMedia.media as { id: string }).id;
@@ -92,6 +95,7 @@ export const computeMatchSuggestions = async (
         method: "exact_filename",
         filename: postMedia.media.name,
         caption,
+        scheduleName,
       });
       return;
     }
@@ -106,6 +110,7 @@ export const computeMatchSuggestions = async (
         method: "fuzzy_filename",
         filename: postMedia.media.name,
         caption,
+        scheduleName,
       });
     }
   });

--- a/@fanslib/apps/server/src/features/analytics/candidates/routes.test.ts
+++ b/@fanslib/apps/server/src/features/analytics/candidates/routes.test.ts
@@ -6,6 +6,7 @@ import { resetAllFixtures } from "../../../lib/test-fixtures";
 import { devalueMiddleware } from "../../../lib/devalue-middleware";
 import { parseResponse, createTestPost, createTestMedia } from "../../../test-utils/setup";
 import { PostMedia } from "../../posts/entity";
+import { ContentSchedule } from "../../content-schedules/entity";
 import type { FanslyMediaCandidate } from "../candidate-entity";
 import { FanslyMediaCandidate as FanslyMediaCandidateEntity } from "../candidate-entity";
 import { FanslyAnalyticsAggregate } from "../entity";
@@ -260,6 +261,93 @@ describe("Analytics Candidates Routes", () => {
         expect(data[0]).toHaveProperty("method");
         expect(data[0]).toHaveProperty("filename");
       }
+    });
+
+    test("includes scheduleName when post has a content schedule", async () => {
+      const dataSource = getTestDataSource();
+      const scheduleRepo = dataSource.getRepository(ContentSchedule);
+      const postMediaRepository = dataSource.getRepository(PostMedia);
+      const candidateRepository = dataSource.getRepository(FanslyMediaCandidateEntity);
+
+      const schedule = scheduleRepo.create({
+        id: `schedule-${Date.now()}`,
+        name: "Daily Tease",
+        type: "daily",
+      });
+      await scheduleRepo.save(schedule);
+
+      const media = await createTestMedia({ name: "scheduled-photo.jpg" });
+      const post = await createTestPost(undefined, { scheduleId: schedule.id });
+
+      const postMedia = postMediaRepository.create({
+        post,
+        media,
+        order: 0,
+        isFreePreview: false,
+      });
+      await postMediaRepository.save(postMedia);
+
+      const candidate = candidateRepository.create({
+        fanslyStatisticsId: "stats-schedule-test",
+        fanslyPostId: "post-schedule-test",
+        filename: "scheduled-photo.jpg",
+        caption: null,
+        fanslyCreatedAt: Date.now(),
+        position: 0,
+        mediaType: "image",
+        status: "pending",
+      });
+      const savedCandidate = await candidateRepository.save(candidate);
+
+      const response = await app.request(
+        `/api/analytics/candidates/by-id/${savedCandidate.id}/suggestions`,
+      );
+      expect(response.status).toBe(200);
+
+      const data =
+        await parseResponse<
+          Array<{ postMediaId: string; confidence: number; scheduleName?: string }>
+        >(response);
+      expect(data?.length).toBeGreaterThan(0);
+      expect(data?.[0]?.scheduleName).toBe("Daily Tease");
+    });
+
+    test("omits scheduleName when post has no content schedule", async () => {
+      const media = await createTestMedia({ name: "unscheduled-photo.jpg" });
+      const post = await createTestPost();
+      const dataSource = getTestDataSource();
+      const postMediaRepository = dataSource.getRepository(PostMedia);
+      const candidateRepository = dataSource.getRepository(FanslyMediaCandidateEntity);
+
+      const postMedia = postMediaRepository.create({
+        post,
+        media,
+        order: 0,
+        isFreePreview: false,
+      });
+      await postMediaRepository.save(postMedia);
+
+      const candidate = candidateRepository.create({
+        fanslyStatisticsId: "stats-no-schedule",
+        fanslyPostId: "post-no-schedule",
+        filename: "unscheduled-photo.jpg",
+        caption: null,
+        fanslyCreatedAt: Date.now(),
+        position: 0,
+        mediaType: "image",
+        status: "pending",
+      });
+      const savedCandidate = await candidateRepository.save(candidate);
+
+      const response = await app.request(
+        `/api/analytics/candidates/by-id/${savedCandidate.id}/suggestions`,
+      );
+      expect(response.status).toBe(200);
+
+      const data =
+        await parseResponse<Array<{ postMediaId: string; scheduleName?: string }>>(response);
+      expect(data?.length).toBeGreaterThan(0);
+      expect(data?.[0]?.scheduleName).toBeUndefined();
     });
 
     test("returns 404 for non-existent candidate", async () => {

--- a/@fanslib/apps/server/src/features/analytics/candidates/schema.ts
+++ b/@fanslib/apps/server/src/features/analytics/candidates/schema.ts
@@ -46,6 +46,7 @@ export const MatchSuggestionSchema = z.object({
   method: MatchMethodSchema,
   filename: z.string(),
   caption: z.string().optional(),
+  scheduleName: z.string().optional(),
 });
 
 // Operation schemas

--- a/@fanslib/apps/web/package.json
+++ b/@fanslib/apps/web/package.json
@@ -14,7 +14,8 @@
     "format:check": "oxfmt -c ../../../.oxfmtrc.json --check src/",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "clean": "rm -rf dist .output"
+    "clean": "rm -rf dist .output",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fanslib/server": "workspace:*",

--- a/@fanslib/apps/web/src/features/analytics/components/ActiveFypPostsPage.test.tsx
+++ b/@fanslib/apps/web/src/features/analytics/components/ActiveFypPostsPage.test.tsx
@@ -42,7 +42,7 @@ const makePosts = () => [
   },
 ];
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 const mockQuery = (overrides: { data: any; isLoading: boolean }) =>
   mockUseActiveFypPostsQuery.mockReturnValue(overrides as ReturnType<typeof useActiveFypPostsQuery>);
 

--- a/@fanslib/apps/web/src/lib/queries/query-keys.ts
+++ b/@fanslib/apps/web/src/lib/queries/query-keys.ts
@@ -26,10 +26,10 @@ import type { TagAnalyticsParams } from "../../hooks/useTagAnalytics";
 
 export const QUERY_KEYS = {
   analytics: {
-    all: ['analytics'] as const,
-    datapoints: (postMediaId: string) => ['analytics', 'datapoints', postMediaId] as const,
-    activeFypPosts: (sortBy?: string) => ['analytics', 'active-fyp-posts', sortBy] as const,
-    repostCandidates: (sortBy?: string) => ['analytics', 'repost-candidates', sortBy] as const,
+    all: ["analytics"] as const,
+    datapoints: (postMediaId: string) => ["analytics", "datapoints", postMediaId] as const,
+    activeFypPosts: (sortBy?: string) => ["analytics", "active-fyp-posts", sortBy] as const,
+    repostCandidates: (sortBy?: string) => ["analytics", "repost-candidates", sortBy] as const,
   },
 
   posts: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,9 @@ import preferArrowFunctions from "eslint-plugin-prefer-arrow-functions";
 
 export default [
   {
+    ignores: ["**/*.gen.ts"],
+  },
+  {
     files: ["**/*.{ts,tsx}"],
     languageOptions: {
       parser: tsParser,


### PR DESCRIPTION
## Summary

- Add `/analytics/fyp/repost` route displaying repost candidates as sortable card list
- Extend shared `AnalyticsPostCard` component with optional `timesPosted` prop showing repost count
- Implement sort toggle (views, engagement %, engagement time) fetching from repost-candidates API
- Add query hook `useRepostCandidatesQuery` and query key
- 8 new frontend tests (6 page tests + 2 card tests for times-posted feature)

**Stacked on** #105 (issue #94) and merges #107 (issue #95)

## Test plan

- [ ] Navigate to `/analytics/fyp/repost` and verify candidates load
- [ ] Verify each card shows times-posted count, caption, and all three stat values
- [ ] Click each sort toggle option and verify list re-sorts
- [ ] Verify loading spinner shows during fetch
- [ ] Verify empty state when no repost candidates exist

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)