### PR TITLE
feat: Media entity fields, Content Rating enum & MEDIA_PATH rename

### DIFF
--- a/@fanslib/apps/server/src/features/library/content-rating.test.ts
+++ b/@fanslib/apps/server/src/features/library/content-rating.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ContentRatingSchema,
+  type ContentRating,
+  compareContentRating,
+  CONTENT_RATINGS,
+} from "./content-rating";
+
+describe("Content Rating", () => {
+  describe("ContentRatingSchema", () => {
+    test("accepts valid content rating codes", () => {
+      (["xt", "uc", "cn", "sg", "sf"] as const).forEach((code) => {
+        expect(ContentRatingSchema.parse(code)).toBe(code);
+      });
+    });
+
+    test("rejects invalid content rating codes", () => {
+      expect(() => ContentRatingSchema.parse("invalid")).toThrow();
+      expect(() => ContentRatingSchema.parse("")).toThrow();
+      expect(() => ContentRatingSchema.parse("XX")).toThrow();
+    });
+  });
+
+  describe("CONTENT_RATINGS", () => {
+    test("contains all five ratings in descending order", () => {
+      expect(CONTENT_RATINGS).toEqual(["xt", "uc", "cn", "sg", "sf"]);
+    });
+  });
+
+  describe("compareContentRating", () => {
+    test("xt is greater than all others", () => {
+      expect(compareContentRating("xt", "uc")).toBeGreaterThan(0);
+      expect(compareContentRating("xt", "cn")).toBeGreaterThan(0);
+      expect(compareContentRating("xt", "sg")).toBeGreaterThan(0);
+      expect(compareContentRating("xt", "sf")).toBeGreaterThan(0);
+    });
+
+    test("sf is less than all others", () => {
+      expect(compareContentRating("sf", "xt")).toBeLessThan(0);
+      expect(compareContentRating("sf", "uc")).toBeLessThan(0);
+      expect(compareContentRating("sf", "cn")).toBeLessThan(0);
+      expect(compareContentRating("sf", "sg")).toBeLessThan(0);
+    });
+
+    test("equal ratings return zero", () => {
+      (["xt", "uc", "cn", "sg", "sf"] as ContentRating[]).forEach((code) => {
+        expect(compareContentRating(code, code)).toBe(0);
+      });
+    });
+
+    test("maintains full ordering xt > uc > cn > sg > sf", () => {
+      expect(compareContentRating("xt", "uc")).toBeGreaterThan(0);
+      expect(compareContentRating("uc", "cn")).toBeGreaterThan(0);
+      expect(compareContentRating("cn", "sg")).toBeGreaterThan(0);
+      expect(compareContentRating("sg", "sf")).toBeGreaterThan(0);
+    });
+
+    test("can be used to sort an array of ratings", () => {
+      const shuffled: ContentRating[] = ["sf", "xt", "cn", "sg", "uc"];
+      const sorted = [...shuffled].sort((a, b) => compareContentRating(b, a));
+      expect(sorted).toEqual(["xt", "uc", "cn", "sg", "sf"]);
+    });
+  });
+});

--- a/@fanslib/apps/server/src/features/library/content-rating.ts
+++ b/@fanslib/apps/server/src/features/library/content-rating.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+/**
+ * Ordered content rating codes, from most explicit to safest.
+ * xt = Extreme, uc = Uncensored, cn = Censored, sg = Suggestive, sf = Safe
+ */
+export const CONTENT_RATINGS = ["xt", "uc", "cn", "sg", "sf"] as const;
+
+export const ContentRatingSchema = z.enum(CONTENT_RATINGS);
+
+export type ContentRating = z.infer<typeof ContentRatingSchema>;
+
+/**
+ * Compare two content ratings by explicitness.
+ * Returns positive if `a` is more explicit than `b`, negative if less, 0 if equal.
+ */
+export const compareContentRating = (a: ContentRating, b: ContentRating): number => {
+  const indexA = CONTENT_RATINGS.indexOf(a);
+  const indexB = CONTENT_RATINGS.indexOf(b);
+  // Lower index = more explicit, so invert
+  return indexB - indexA;
+};

--- a/@fanslib/apps/server/src/features/library/entity.ts
+++ b/@fanslib/apps/server/src/features/library/entity.ts
@@ -13,6 +13,7 @@ import {
 import { PostMedia } from "../posts/entity";
 import { Shoot } from "../shoots/entity";
 import { MediaTag } from "../tags/entity";
+import type { ContentRating } from "./content-rating";
 
 export type MediaType = "image" | "video";
 
@@ -46,6 +47,18 @@ export class Media {
   @Column({ type: "boolean", default: false, name: "excluded" })
   excluded: boolean = false;
 
+  @Column({ type: "varchar", nullable: true, name: "contentRating" })
+  contentRating: ContentRating | null = null;
+
+  @Column({ type: "varchar", nullable: true, name: "package" })
+  package: string | null = null;
+
+  @Column({ type: "varchar", nullable: true, name: "role" })
+  role: string | null = null;
+
+  @Column({ type: "boolean", default: false, name: "isManaged" })
+  isManaged: boolean = false;
+
   @CreateDateColumn({ type: "datetime", name: "createdAt" })
   createdAt!: Date;
 
@@ -76,3 +89,4 @@ export class Media {
 export type MediaWithoutRelations = Omit<Media, "id">;
 
 export { MediaSchema, MediaTypeSchema } from "./schema";
+export { ContentRatingSchema, type ContentRating } from "./content-rating";

--- a/@fanslib/apps/server/src/features/library/fixtures-data.ts
+++ b/@fanslib/apps/server/src/features/library/fixtures-data.ts
@@ -11,6 +11,10 @@ export type MediaFixture = Omit<
   | "postMedia"
   | "shoots"
   | "mediaTags"
+  | "contentRating"
+  | "package"
+  | "role"
+  | "isManaged"
 >;
 
 export const MEDIA_FIXTURES: MediaFixture[] = [

--- a/@fanslib/apps/server/src/features/library/media-fields.test.ts
+++ b/@fanslib/apps/server/src/features/library/media-fields.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import "reflect-metadata";
+import { getTestDataSource, setupTestDatabase, teardownTestDatabase } from "../../lib/test-db";
+import { clearAllTables } from "../../lib/test-db";
+import { Media } from "./entity";
+
+describe("Media entity new fields", () => {
+  beforeAll(async () => {
+    await setupTestDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearAllTables();
+  });
+
+  test("contentRating defaults to null", async () => {
+    const ds = getTestDataSource();
+    const repo = ds.getRepository(Media);
+
+    const media = repo.create({
+      relativePath: "/test/photo.jpg",
+      type: "image",
+      name: "photo.jpg",
+      size: 1024,
+      fileCreationDate: new Date(),
+      fileModificationDate: new Date(),
+    });
+    await repo.save(media);
+
+    const saved = await repo.findOneBy({ id: media.id });
+    expect(saved?.contentRating).toBeNull();
+  });
+
+  test("contentRating can be set to a valid code", async () => {
+    const ds = getTestDataSource();
+    const repo = ds.getRepository(Media);
+
+    const media = repo.create({
+      relativePath: "/test/photo.jpg",
+      type: "image",
+      name: "photo.jpg",
+      size: 1024,
+      contentRating: "xt",
+      fileCreationDate: new Date(),
+      fileModificationDate: new Date(),
+    });
+    await repo.save(media);
+
+    const saved = await repo.findOneBy({ id: media.id });
+    expect(saved?.contentRating).toBe("xt");
+  });
+
+  test("package defaults to null", async () => {
+    const ds = getTestDataSource();
+    const repo = ds.getRepository(Media);
+
+    const media = repo.create({
+      relativePath: "/test/photo.jpg",
+      type: "image",
+      name: "photo.jpg",
+      size: 1024,
+      fileCreationDate: new Date(),
+      fileModificationDate: new Date(),
+    });
+    await repo.save(media);
+
+    const saved = await repo.findOneBy({ id: media.id });
+    expect(saved?.package).toBeNull();
+  });
+
+  test("role defaults to null", async () => {
+    const ds = getTestDataSource();
+    const repo = ds.getRepository(Media);
+
+    const media = repo.create({
+      relativePath: "/test/photo.jpg",
+      type: "image",
+      name: "photo.jpg",
+      size: 1024,
+      fileCreationDate: new Date(),
+      fileModificationDate: new Date(),
+    });
+    await repo.save(media);
+
+    const saved = await repo.findOneBy({ id: media.id });
+    expect(saved?.role).toBeNull();
+  });
+
+  test("isManaged defaults to false", async () => {
+    const ds = getTestDataSource();
+    const repo = ds.getRepository(Media);
+
+    const media = repo.create({
+      relativePath: "/test/photo.jpg",
+      type: "image",
+      name: "photo.jpg",
+      size: 1024,
+      fileCreationDate: new Date(),
+      fileModificationDate: new Date(),
+    });
+    await repo.save(media);
+
+    const saved = await repo.findOneBy({ id: media.id });
+    expect(saved?.isManaged).toBe(false);
+  });
+
+  test("all new fields can be set together", async () => {
+    const ds = getTestDataSource();
+    const repo = ds.getRepository(Media);
+
+    const media = repo.create({
+      relativePath: "/test/photo.jpg",
+      type: "image",
+      name: "photo.jpg",
+      size: 1024,
+      contentRating: "cn",
+      package: "main",
+      role: "content",
+      isManaged: true,
+      fileCreationDate: new Date(),
+      fileModificationDate: new Date(),
+    });
+    await repo.save(media);
+
+    const saved = await repo.findOneBy({ id: media.id });
+    expect(saved?.contentRating).toBe("cn");
+    expect(saved?.package).toBe("main");
+    expect(saved?.role).toBe("content");
+    expect(saved?.isManaged).toBe(true);
+  });
+});

--- a/@fanslib/apps/server/src/features/library/operations/media/delete.ts
+++ b/@fanslib/apps/server/src/features/library/operations/media/delete.ts
@@ -28,8 +28,8 @@ export const deleteMedia = async (id: string, deleteFile = false): Promise<boole
 
   if (deleteFile) {
     try {
-      const libraryPath = env().libraryPath;
-      const filePath = `${libraryPath}/${media.relativePath}`;
+      const mediaPath = env().mediaPath;
+      const filePath = `${mediaPath}/${media.relativePath}`;
       await fs.unlink(filePath);
     } catch (error) {
       console.error("Failed to delete file:", error);

--- a/@fanslib/apps/server/src/features/library/operations/media/update.ts
+++ b/@fanslib/apps/server/src/features/library/operations/media/update.ts
@@ -3,6 +3,7 @@ import { db } from "../../../../lib/db";
 import { ChannelSchema } from "../../../channels/entity";
 import { PostMediaSchema, PostSchema } from "../../../posts/schema";
 import { SubredditSchema } from "../../../subreddits/entity";
+import { ContentRatingSchema } from "../../content-rating";
 import { Media } from "../../entity";
 import { MediaSchema, MediaTypeSchema } from "../../schema";
 
@@ -19,6 +20,10 @@ export const UpdateMediaRequestBodySchema = z.object({
   redgifsUrl: z.string().nullable().optional(),
   description: z.string().nullable().optional(),
   excluded: z.boolean().optional(),
+  contentRating: ContentRatingSchema.nullable().optional(),
+  package: z.string().nullable().optional(),
+  role: z.string().nullable().optional(),
+  isManaged: z.boolean().optional(),
   fileCreationDate: z.coerce.date().optional(),
   fileModificationDate: z.coerce.date().optional(),
 });

--- a/@fanslib/apps/server/src/features/library/operations/scan/find-by-stats.ts
+++ b/@fanslib/apps/server/src/features/library/operations/scan/find-by-stats.ts
@@ -10,7 +10,7 @@ import { Media } from "../../entity";
  * This helps identify renamed files by matching size and creation time
  * Only considers it a match if the original file no longer exists at its old location
  */
-export const findMediaByStats = async (stats: Stats, libraryPath: string) => {
+export const findMediaByStats = async (stats: Stats, mediaPath: string) => {
   // Find all media with matching size and creation date
   const mediaRepo = (await db()).getRepository(Media);
   const potentialMatches = await mediaRepo.find({
@@ -25,7 +25,7 @@ export const findMediaByStats = async (stats: Stats, libraryPath: string) => {
     try {
       // Check if the original file still exists using path resolution
       try {
-        const resolvedPath = convertRelativeToAbsolute(media.relativePath, libraryPath);
+        const resolvedPath = convertRelativeToAbsolute(media.relativePath, mediaPath);
         await fs.access(resolvedPath);
         // If we can access the file, it still exists, so this is not our moved file
         continue;

--- a/@fanslib/apps/server/src/features/library/operations/scan/scan.ts
+++ b/@fanslib/apps/server/src/features/library/operations/scan/scan.ts
@@ -64,11 +64,11 @@ const VIDEO_EXTENSIONS = new Set([".mp4", ".webm", ".mov", ".avi", ".mkv"]);
 let currentScanProgress: z.infer<typeof LibraryScanProgressSchema> | null = null;
 let currentScanResult: z.infer<typeof LibraryScanResultSchema> | null = null;
 
-const convertToRelativePath = (absolutePath: string, libraryPath: string): string => {
+const convertToRelativePath = (absolutePath: string, mediaPath: string): string => {
   if (!path.isAbsolute(absolutePath)) {
     return absolutePath;
   }
-  return path.relative(libraryPath, absolutePath);
+  return path.relative(mediaPath, absolutePath);
 };
 
 const isMediaFile = (
@@ -91,11 +91,11 @@ export const scanFile = async (filePath: string): Promise<z.infer<typeof FileSca
     throw new Error(`Unsupported file type: ${filePath}`);
   }
 
-  const libraryPath = env().libraryPath;
-  const relativePath = convertToRelativePath(filePath, libraryPath);
+  const mediaPath = env().mediaPath;
+  const relativePath = convertToRelativePath(filePath, mediaPath);
   const stats = await fs.stat(filePath);
   const existingMedia =
-    (await fetchMediaByPath(relativePath)) ?? (await findMediaByStats(stats, libraryPath));
+    (await fetchMediaByPath(relativePath)) ?? (await findMediaByStats(stats, mediaPath));
 
   if (!existingMedia) {
     const media = {
@@ -191,13 +191,13 @@ class LibraryScanner {
     try {
       // First pass: collect all files
       const filesToProcess: string[] = [];
-      const libraryPath = env().libraryPath;
+      const mediaPath = env().mediaPath;
 
       console.log("Library scan starting", {
-        libraryPath,
+        mediaPath,
       });
 
-      for await (const filePath of walkDirectory(libraryPath)) {
+      for await (const filePath of walkDirectory(mediaPath)) {
         const { isSupported } = isMediaFile(filePath);
         if (isSupported) {
           filesToProcess.push(filePath);
@@ -205,7 +205,7 @@ class LibraryScanner {
       }
 
       console.log("Library scan files discovered", {
-        libraryPath,
+        mediaPath,
         totalFiles: filesToProcess.length,
         files: filesToProcess,
       });
@@ -273,7 +273,7 @@ class LibraryScanner {
 
         // Check if the file still exists using path resolution
         try {
-          const resolvedPath = convertRelativeToAbsolute(media.relativePath, libraryPath);
+          const resolvedPath = convertRelativeToAbsolute(media.relativePath, mediaPath);
           await fs.access(resolvedPath);
           // File exists, keep it
           continue;

--- a/@fanslib/apps/server/src/features/library/operations/upload/index.ts
+++ b/@fanslib/apps/server/src/features/library/operations/upload/index.ts
@@ -58,7 +58,7 @@ export type UploadMediaInput = {
 };
 
 export const uploadMediaToShoot = async ({ shootId, file }: UploadMediaInput) => {
-  const libraryPath = env().libraryPath;
+  const mediaPath = env().mediaPath;
 
   const database = await db();
   const shoot = await database.getRepository(Shoot).findOne({ where: { id: shootId } });
@@ -73,7 +73,7 @@ export const uploadMediaToShoot = async ({ shootId, file }: UploadMediaInput) =>
   if (!type) throw new Error(`Cannot determine media type for: ${ext}`);
 
   const folderName = shootFolderName(shoot);
-  const targetDir = path.join(libraryPath, "shoots", folderName);
+  const targetDir = path.join(mediaPath, "shoots", folderName);
   await fs.mkdir(targetDir, { recursive: true });
 
   const uniqueFilename = await resolveUniqueFilename(targetDir, file.name);

--- a/@fanslib/apps/server/src/features/library/path-utils.ts
+++ b/@fanslib/apps/server/src/features/library/path-utils.ts
@@ -1,8 +1,8 @@
 import { env } from "../../lib/env";
 
 export const resolveMediaPath = (relativePath: string) => {
-  const libraryPath = env().libraryPath;
-  return `${libraryPath}/${relativePath}`;
+  const mediaPath = env().mediaPath;
+  return `${mediaPath}/${relativePath}`;
 };
 
 export const convertRelativeToAbsolute = (relativePath: string) => resolveMediaPath(relativePath);

--- a/@fanslib/apps/server/src/features/library/routes.test.ts
+++ b/@fanslib/apps/server/src/features/library/routes.test.ts
@@ -246,6 +246,97 @@ describe("Library Routes", () => {
     });
   });
 
+  describe("new fields in API responses", () => {
+    test("GET by-id returns new fields with defaults for existing media", async () => {
+      const fixtureMedia = MEDIA_FIXTURES[0];
+      if (!fixtureMedia) throw new Error("No media fixtures available");
+
+      const response = await app.request(`/api/media/by-id/${fixtureMedia.id}`);
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<Media>(response);
+      expect(data?.contentRating).toBeNull();
+      expect(data?.package).toBeNull();
+      expect(data?.role).toBeNull();
+      expect(data?.isManaged).toBe(false);
+    });
+
+    test("POST all returns new fields with defaults for existing media", async () => {
+      const response = await app.request("/api/media/all", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ items: Media[] }>(response);
+      const media = data?.items[0];
+      expect(media).toBeDefined();
+      expect(media?.contentRating).toBeNull();
+      expect(media?.package).toBeNull();
+      expect(media?.role).toBeNull();
+      expect(media?.isManaged).toBe(false);
+    });
+
+    test("PATCH can set contentRating on media", async () => {
+      const fixtureMedia = MEDIA_FIXTURES[0];
+      if (!fixtureMedia) throw new Error("No media fixtures available");
+
+      const response = await app.request(`/api/media/by-id/${fixtureMedia.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ contentRating: "uc" }),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<Media>(response);
+      expect(data?.contentRating).toBe("uc");
+    });
+
+    test("PATCH can set package and role on media", async () => {
+      const fixtureMedia = MEDIA_FIXTURES[0];
+      if (!fixtureMedia) throw new Error("No media fixtures available");
+
+      const response = await app.request(`/api/media/by-id/${fixtureMedia.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ package: "main", role: "content" }),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<Media>(response);
+      expect(data?.package).toBe("main");
+      expect(data?.role).toBe("content");
+    });
+
+    test("PATCH can set isManaged on media", async () => {
+      const fixtureMedia = MEDIA_FIXTURES[0];
+      if (!fixtureMedia) throw new Error("No media fixtures available");
+
+      const response = await app.request(`/api/media/by-id/${fixtureMedia.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ isManaged: true }),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<Media>(response);
+      expect(data?.isManaged).toBe(true);
+    });
+
+    test("PATCH rejects invalid contentRating code", async () => {
+      const fixtureMedia = MEDIA_FIXTURES[0];
+      if (!fixtureMedia) throw new Error("No media fixtures available");
+
+      const response = await app.request(`/api/media/by-id/${fixtureMedia.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ contentRating: "invalid" }),
+      });
+      expect(response.status).toBe(422);
+    });
+  });
+
   describe("POST /api/media/by-id/:id/adjacent", () => {
     test("returns adjacent media", async () => {
       const fixtureMedia = MEDIA_FIXTURES[1];

--- a/@fanslib/apps/server/src/features/library/routes.ts
+++ b/@fanslib/apps/server/src/features/library/routes.ts
@@ -17,6 +17,7 @@ import { uploadMediaToShoot } from "./operations/upload";
 import { resolveMediaPath } from "./path-utils";
 import { MediaFilterSchema } from "./schemas/media-filter";
 import { MediaSortSchema } from "./schemas/media-sort";
+import { ContentRatingSchema } from "./content-rating";
 import { MediaTypeSchema } from "./schema";
 
 // Zod Schemas for request/response validation
@@ -43,9 +44,14 @@ const UpdateMediaRequestBodySchema = z.object({
   size: z.number().optional(),
   duration: z.number().optional(),
   redgifsUrl: z.string().nullable().optional(),
+  description: z.string().nullable().optional(),
   fileCreationDate: z.coerce.date().optional(),
   fileModificationDate: z.coerce.date().optional(),
   excluded: z.boolean().optional(),
+  contentRating: ContentRatingSchema.nullable().optional(),
+  package: z.string().nullable().optional(),
+  role: z.string().nullable().optional(),
+  isManaged: z.boolean().optional(),
 });
 
 const FindAdjacentMediaBodySchema = z.object({

--- a/@fanslib/apps/server/src/features/library/schema.ts
+++ b/@fanslib/apps/server/src/features/library/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ContentRatingSchema } from "./content-rating";
 import { RepostStatusValueSchema } from "./schemas/media-filter";
 
 export const MediaTypeSchema = z.enum(["image", "video"]);
@@ -13,6 +14,10 @@ export const MediaSchema = z.object({
   redgifsUrl: z.string().nullable(),
   description: z.string().nullable(),
   excluded: z.boolean().default(false),
+  contentRating: ContentRatingSchema.nullable().default(null),
+  package: z.string().nullable().default(null),
+  role: z.string().nullable().default(null),
+  isManaged: z.boolean().default(false),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
   fileCreationDate: z.coerce.date(),

--- a/@fanslib/apps/server/src/features/settings/operations/setting/load.ts
+++ b/@fanslib/apps/server/src/features/settings/operations/setting/load.ts
@@ -15,13 +15,15 @@ export const loadSettings = async (): Promise<LoadSettingsResponse> => {
     const settings = JSON.parse(data) as LoadSettingsResponse;
     return {
       ...settings,
-      libraryPath: env().libraryPath,
+      mediaPath: env().mediaPath,
+      libraryPath: env().mediaPath,
     };
   } catch (error) {
     console.error("Error loading settings:", error);
     return {
       ...DEFAULT_SETTINGS,
-      libraryPath: env().libraryPath,
+      mediaPath: env().mediaPath,
+      libraryPath: env().mediaPath,
     };
   }
 };

--- a/@fanslib/apps/server/src/features/settings/schemas/settings.ts
+++ b/@fanslib/apps/server/src/features/settings/schemas/settings.ts
@@ -11,6 +11,7 @@ export const SettingsSchema = z.object({
   sfwDefaultMode: z.union([z.literal("off"), z.literal("on"), z.literal("remember")]),
   sfwHoverDelay: z.number(),
   backgroundJobsServerUrl: z.string().optional(),
+  mediaPath: z.string().optional(),
   libraryPath: z.string().optional(),
   repostSettings: z
     .object({

--- a/@fanslib/apps/server/src/index.ts
+++ b/@fanslib/apps/server/src/index.ts
@@ -32,24 +32,24 @@ import { seedDatabase } from "./lib/seed";
 import { walkDirectory } from "./lib/walkDirectory";
 
 const logStartupEnvironment = async (): Promise<void> => {
-  const { appdataPath, libraryPath, ffprobePath } = env();
+  const { appdataPath, mediaPath, ffprobePath } = env();
 
   console.log("Environment configuration", {
     APPDATA_PATH: appdataPath,
-    LIBRARY_PATH: libraryPath,
+    MEDIA_PATH: mediaPath,
     FFPROBE_PATH: ffprobePath ?? null,
   });
 
   try {
     const files: string[] = [];
     // eslint-disable-next-line functional/no-loop-statements
-    for await (const filePath of walkDirectory(libraryPath)) {
+    for await (const filePath of walkDirectory(mediaPath)) {
       if (!filePath) continue;
       files.push(filePath);
     }
 
     console.log("Library contents at startup", {
-      libraryPath,
+      mediaPath,
       totalFiles: files.length,
     });
   } catch (error) {

--- a/@fanslib/apps/server/src/lib/env.test.ts
+++ b/@fanslib/apps/server/src/lib/env.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import "reflect-metadata";
+
+describe("env()", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Clear relevant env vars before each test
+    delete process.env.MEDIA_PATH;
+    delete process.env.LIBRARY_PATH;
+    // Reset module cache so env() re-reads process.env
+    delete require.cache[require.resolve("./env")];
+  });
+
+  afterEach(() => {
+    // Restore original env
+    process.env.MEDIA_PATH = originalEnv.MEDIA_PATH;
+    process.env.LIBRARY_PATH = originalEnv.LIBRARY_PATH;
+  });
+
+  test("uses MEDIA_PATH when set", async () => {
+    process.env.MEDIA_PATH = "/media/path";
+    process.env.APPDATA_PATH = process.env.APPDATA_PATH ?? "/tmp/appdata";
+    // Dynamic import to get fresh module
+    const { env } = await import("./env");
+    expect(env().mediaPath).toBe("/media/path");
+  });
+
+  test("falls back to LIBRARY_PATH when MEDIA_PATH is not set", async () => {
+    process.env.LIBRARY_PATH = "/library/path";
+    process.env.APPDATA_PATH = process.env.APPDATA_PATH ?? "/tmp/appdata";
+    const { env } = await import("./env");
+    expect(env().mediaPath).toBe("/library/path");
+  });
+
+  test("MEDIA_PATH takes precedence over LIBRARY_PATH", async () => {
+    process.env.MEDIA_PATH = "/media/path";
+    process.env.LIBRARY_PATH = "/library/path";
+    process.env.APPDATA_PATH = process.env.APPDATA_PATH ?? "/tmp/appdata";
+    const { env } = await import("./env");
+    expect(env().mediaPath).toBe("/media/path");
+  });
+
+  test("throws when neither MEDIA_PATH nor LIBRARY_PATH is set", async () => {
+    process.env.APPDATA_PATH = process.env.APPDATA_PATH ?? "/tmp/appdata";
+    const { env } = await import("./env");
+    expect(() => env()).toThrow();
+  });
+});

--- a/@fanslib/apps/server/src/lib/env.ts
+++ b/@fanslib/apps/server/src/lib/env.ts
@@ -2,7 +2,7 @@ import { join } from "path";
 
 type EnvConfig = {
   appdataPath: string;
-  libraryPath: string;
+  mediaPath: string;
   ffmpegPath: string | undefined;
   ffprobePath: string | undefined;
 };
@@ -17,11 +17,16 @@ const requireEnv = (name: string): string => {
 
 export const env = (): EnvConfig => {
   const appdataPath = requireEnv("APPDATA_PATH");
-  const libraryPath = requireEnv("LIBRARY_PATH");
+  const mediaPath = process.env.MEDIA_PATH ?? process.env.LIBRARY_PATH;
+  if (!mediaPath) {
+    throw new Error(
+      "Required environment variable MEDIA_PATH is not set (LIBRARY_PATH also accepted as fallback)",
+    );
+  }
 
   return {
     appdataPath,
-    libraryPath,
+    mediaPath,
     ffmpegPath: process.env.FFMPEG_PATH,
     ffprobePath: process.env.FFPROBE_PATH,
   };

--- a/@fanslib/apps/server/src/lib/path-utils.ts
+++ b/@fanslib/apps/server/src/lib/path-utils.ts
@@ -1,8 +1,8 @@
 import * as path from "path";
 
-// Convert relative path to absolute path using library path
-export const convertRelativeToAbsolute = (relativePath: string, libraryPath: string): string => {
+// Convert relative path to absolute path using media path
+export const convertRelativeToAbsolute = (relativePath: string, mediaPath: string): string => {
   if (!relativePath) throw new Error("Relative path cannot be empty");
   if (path.isAbsolute(relativePath)) return relativePath;
-  return path.join(libraryPath, relativePath);
+  return path.join(mediaPath, relativePath);
 };

--- a/@fanslib/apps/server/src/test-utils/env.setup.ts
+++ b/@fanslib/apps/server/src/test-utils/env.setup.ts
@@ -13,9 +13,10 @@ const ensureDir = async (dirPath: string) => {
 
 const cwd = process.cwd();
 process.env.APPDATA_PATH = process.env.APPDATA_PATH ?? `${cwd}/.test-data/appdata`;
-process.env.LIBRARY_PATH = process.env.LIBRARY_PATH ?? `${cwd}/.test-data/library`;
+process.env.MEDIA_PATH = process.env.MEDIA_PATH ?? `${cwd}/.test-data/library`;
+process.env.LIBRARY_PATH = process.env.LIBRARY_PATH ?? process.env.MEDIA_PATH;
 
 await ensureDir(process.env.APPDATA_PATH);
-await ensureDir(process.env.LIBRARY_PATH);
+await ensureDir(process.env.MEDIA_PATH);
 // Also ensure sqlite dir exists if db path nests
 await ensureDir(dirname(`${process.env.APPDATA_PATH}/fanslib.sqlite`));


### PR DESCRIPTION
## Summary
- Add `contentRating` (nullable varchar), `package` (nullable varchar), `role` (nullable varchar), `isManaged` (boolean, default false) fields to the Media entity
- Implement ordered Content Rating enum with codes `xt > uc > cn > sg > sf` and comparison logic
- Rename `LIBRARY_PATH` env var to `MEDIA_PATH` with backwards-compatible fallback
- Update API responses (GET/POST/PATCH media) and settings schema to include new fields
- All existing records return null/false for new fields

Closes #113

## Test plan
- [x] Content Rating enum: schema validation, ordering, comparison, sorting
- [x] Media entity: all four new fields persist with correct defaults
- [x] Env var: MEDIA_PATH accepted, LIBRARY_PATH fallback, precedence, error on missing
- [x] API: GET/POST return new fields with defaults, PATCH can set them, invalid contentRating rejected (422)
- [x] All 247 server tests pass, lint clean, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)