### PR TITLE
fix: remove dead Analytics/Matching nav link

### DIFF
--- a/@fanslib/apps/web/src/components/NavigationMenu.test.tsx
+++ b/@fanslib/apps/web/src/components/NavigationMenu.test.tsx
@@ -1,0 +1,45 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    to,
+    ...props
+  }: { children: React.ReactNode; to: string } & Record<string, unknown>) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+  useLocation: () => ({ pathname: "/" }),
+}));
+
+vi.mock("jotai", () => ({
+  atom: () => ({}),
+  useAtom: () => [null, vi.fn()],
+}));
+
+import { NavigationMenu } from "./NavigationMenu";
+
+describe("NavigationMenu", () => {
+  test("does not render a Matching nav link", () => {
+    render(<NavigationMenu isCollapsed={false} />);
+
+    const matchingLink = screen.queryByRole("link", { name: /matching/i });
+    expect(matchingLink).not.toBeInTheDocument();
+  });
+
+  test("renders Active FYP and Repost Candidates analytics links", () => {
+    render(<NavigationMenu isCollapsed={false} />);
+
+    expect(screen.getByRole("link", { name: /active fyp/i })).toHaveAttribute(
+      "href",
+      "/analytics/fyp/active",
+    );
+    expect(screen.getByRole("link", { name: /repost candidates/i })).toHaveAttribute(
+      "href",
+      "/analytics/fyp/repost",
+    );
+  });
+});

--- a/@fanslib/apps/web/src/components/NavigationMenu.tsx
+++ b/@fanslib/apps/web/src/components/NavigationMenu.tsx
@@ -40,7 +40,10 @@ const menuItems: MenuItem[] = [
     to: "/analytics",
     label: "Analytics",
     icon: BarChart3,
-    children: [{ to: "/analytics/matching", label: "Matching" }],
+    children: [
+      { to: "/analytics/fyp/active", label: "Active FYP" },
+      { to: "/analytics/fyp/repost", label: "Repost Candidates" },
+    ],
   },
   { to: "/settings", label: "Settings", icon: Settings },
 ];


### PR DESCRIPTION
## Summary
- Removed the dead `/analytics/matching` nav link that returned a 404
- Replaced it with links to the two existing analytics pages: **Active FYP** (`/analytics/fyp/active`) and **Repost Candidates** (`/analytics/fyp/repost`)
- Added tests verifying the Matching link is gone and the real FYP links are present

Closes #119

## Test plan
- [x] `NavigationMenu.test.tsx` — verifies no Matching link rendered
- [x] `NavigationMenu.test.tsx` — verifies Active FYP and Repost Candidates links point to correct routes
- [x] Full test suite passes
- [x] Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)