### PR TITLE
feat: organize API endpoints for managed library

### DIFF
--- a/@fanslib/apps/server/src/features/library/organize-routes.test.ts
+++ b/@fanslib/apps/server/src/features/library/organize-routes.test.ts
@@ -1,0 +1,305 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import "reflect-metadata";
+import { setupTestDatabase, teardownTestDatabase } from "../../lib/test-db";
+import { resetAllFixtures } from "../../lib/test-fixtures";
+import { devalueMiddleware } from "../../lib/devalue-middleware";
+import { parseResponse, createTestMedia } from "../../test-utils/setup";
+import { organizeRoutes } from "./organize-routes";
+import { Shoot } from "../shoots/entity";
+import { Media } from "./entity";
+import { getTestDataSource } from "../../lib/test-db";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+
+type UnmanagedGroup = {
+  folder: string;
+  media: Array<{ id: string; name: string; relativePath: string }>;
+};
+
+type OrganizeResponse = {
+  results: Array<{ mediaId: string; finalPath: string }>;
+  errors: Array<{ mediaId: string; error: string }>;
+};
+
+describe("Organize Routes", () => {
+  // eslint-disable-next-line functional/no-let
+  let app: Hono;
+
+  beforeAll(async () => {
+    await setupTestDatabase();
+    app = new Hono().use("*", devalueMiddleware()).route("/", organizeRoutes);
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetAllFixtures();
+  });
+
+  describe("GET /api/library/unmanaged", () => {
+    test("returns unmanaged media grouped by containing folder", async () => {
+      await createTestMedia({
+        id: "unmanaged-1",
+        name: "video1.mp4",
+        relativePath: "inbox/video1.mp4",
+        isManaged: false,
+      });
+      await createTestMedia({
+        id: "unmanaged-2",
+        name: "video2.mp4",
+        relativePath: "inbox/video2.mp4",
+        isManaged: false,
+      });
+      await createTestMedia({
+        id: "unmanaged-3",
+        name: "photo.jpg",
+        relativePath: "downloads/photo.jpg",
+        isManaged: false,
+      });
+      await createTestMedia({
+        id: "managed-1",
+        name: "managed.mp4",
+        relativePath: "library/2026/managed.mp4",
+        isManaged: true,
+      });
+
+      const response = await app.request("/api/library/unmanaged");
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<UnmanagedGroup[]>(response);
+      expect(data).toBeDefined();
+
+      const inboxGroup = data?.find((g) => g.folder === "inbox");
+      const downloadsGroup = data?.find((g) => g.folder === "downloads");
+
+      expect(inboxGroup).toBeDefined();
+      expect(inboxGroup?.media).toHaveLength(2);
+      expect(downloadsGroup).toBeDefined();
+      expect(downloadsGroup?.media).toHaveLength(1);
+
+      const allMediaIds = data?.flatMap((g) => g.media.map((m) => m.id)) ?? [];
+      expect(allMediaIds).not.toContain("managed-1");
+    });
+  });
+
+  describe("GET /api/library/known-roles", () => {
+    test("returns distinct role values from managed media", async () => {
+      await createTestMedia({ id: "role-1", name: "a.mp4", relativePath: "lib/a.mp4", isManaged: true, role: "content" });
+      await createTestMedia({ id: "role-2", name: "b.mp4", relativePath: "lib/b.mp4", isManaged: true, role: "trailer" });
+      await createTestMedia({ id: "role-3", name: "c.mp4", relativePath: "lib/c.mp4", isManaged: true, role: "content" });
+      await createTestMedia({ id: "role-4", name: "d.mp4", relativePath: "lib/d.mp4", isManaged: false, role: "unmanaged-role" });
+
+      const response = await app.request("/api/library/known-roles");
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<string[]>(response);
+      expect(data).toBeDefined();
+      expect(data).toContain("content");
+      expect(data).toContain("trailer");
+      expect(data).toHaveLength(2);
+      expect(data).not.toContain("unmanaged-role");
+    });
+  });
+
+  describe("GET /api/library/known-packages", () => {
+    test("returns distinct package values for media linked to a shoot", async () => {
+      const ds = getTestDataSource();
+      const shootRepo = ds.getRepository(Shoot);
+
+      const shoot = shootRepo.create({ id: "shoot-1", name: "Test Shoot", shootDate: new Date("2026-01-15") });
+      await shootRepo.save(shoot);
+
+      const media1 = await createTestMedia({ id: "pkg-1", name: "a.mp4", relativePath: "lib/a.mp4", isManaged: true, package: "main" });
+      const media2 = await createTestMedia({ id: "pkg-2", name: "b.mp4", relativePath: "lib/b.mp4", isManaged: true, package: "clip1" });
+      const media3 = await createTestMedia({ id: "pkg-3", name: "c.mp4", relativePath: "lib/c.mp4", isManaged: true, package: "main" });
+
+      shoot.media = [media1, media2, media3];
+      await shootRepo.save(shoot);
+
+      const response = await app.request("/api/library/known-packages?shootId=shoot-1");
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<string[]>(response);
+      expect(data).toBeDefined();
+      expect(data).toContain("main");
+      expect(data).toContain("clip1");
+      expect(data).toHaveLength(2);
+    });
+  });
+
+  describe("POST /api/library/organize", () => {
+    // eslint-disable-next-line functional/no-let
+    let tmpDir: string;
+
+    beforeEach(async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "fanslib-test-"));
+      process.env.MEDIA_PATH = tmpDir;
+      process.env.LIBRARY_PATH = tmpDir;
+      process.env.APPDATA_PATH = process.env.APPDATA_PATH ?? tmpDir;
+    });
+
+    test("renames, moves file and updates media record", async () => {
+      const ds = getTestDataSource();
+      const shootRepo = ds.getRepository(Shoot);
+
+      const shoot = shootRepo.create({ id: "shoot-org-1", name: "Oil Anal", shootDate: new Date("2026-01-15") });
+      await shootRepo.save(shoot);
+
+      const sourceDir = path.join(tmpDir, "inbox");
+      await fs.mkdir(sourceDir, { recursive: true });
+      await fs.writeFile(path.join(sourceDir, "raw-clip.mp4"), "fake-video-data");
+
+      await createTestMedia({
+        id: "org-media-1",
+        name: "raw-clip.mp4",
+        relativePath: "inbox/raw-clip.mp4",
+        type: "video",
+        isManaged: false,
+      });
+
+      const response = await app.request("/api/library/organize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          entries: [{
+            mediaId: "org-media-1",
+            shootId: "shoot-org-1",
+            package: "main",
+            role: "content",
+            contentRating: "uc",
+          }],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const data = await parseResponse<OrganizeResponse>(response);
+
+      expect(data).toBeDefined();
+      expect(data?.results).toHaveLength(1);
+      expect(data?.errors).toHaveLength(0);
+
+      const result = data?.results[0];
+      expect(result?.finalPath).toBe("2026/20260115_Oil Anal/20260115_Oil Anal_main_content_uc.mp4");
+
+      // File should exist at new location
+      const newAbsPath = path.join(tmpDir, result?.finalPath ?? "");
+      const fileExists = await fs.access(newAbsPath).then(() => true).catch(() => false);
+      expect(fileExists).toBe(true);
+
+      // Old file should be gone
+      const oldExists = await fs.access(path.join(sourceDir, "raw-clip.mp4")).then(() => true).catch(() => false);
+      expect(oldExists).toBe(false);
+
+      // Media record should be updated
+      const mediaRepo = ds.getRepository(Media);
+      const updated = await mediaRepo.findOne({ where: { id: "org-media-1" } });
+      expect(updated?.isManaged).toBe(true);
+      expect(updated?.relativePath).toBe(result?.finalPath);
+      expect(updated?.package).toBe("main");
+      expect(updated?.role).toBe("content");
+      expect(updated?.contentRating).toBe("uc");
+    });
+
+    test("appends sequence number starting at _2 on filename collision", async () => {
+      const ds = getTestDataSource();
+      const shootRepo = ds.getRepository(Shoot);
+
+      const shoot = shootRepo.create({ id: "shoot-col-1", name: "Shower", shootDate: new Date("2026-02-20") });
+      await shootRepo.save(shoot);
+
+      const targetDir = path.join(tmpDir, "2026", "20260220_Shower");
+      await fs.mkdir(targetDir, { recursive: true });
+      await fs.writeFile(path.join(targetDir, "20260220_Shower_main_content_sf.mp4"), "existing-file");
+
+      const sourceDir = path.join(tmpDir, "inbox");
+      await fs.mkdir(sourceDir, { recursive: true });
+      await fs.writeFile(path.join(sourceDir, "new-clip.mp4"), "new-file-data");
+
+      await createTestMedia({ id: "col-media-1", name: "new-clip.mp4", relativePath: "inbox/new-clip.mp4", type: "video", isManaged: false });
+
+      const response = await app.request("/api/library/organize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          entries: [{ mediaId: "col-media-1", shootId: "shoot-col-1", package: "main", role: "content", contentRating: "sf" }],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const data = await parseResponse<OrganizeResponse>(response);
+
+      expect(data?.results).toHaveLength(1);
+      expect(data?.results[0].finalPath).toBe("2026/20260220_Shower/20260220_Shower_main_content_sf_2.mp4");
+    });
+
+    test("reports missing files in errors array", async () => {
+      const ds = getTestDataSource();
+      const shootRepo = ds.getRepository(Shoot);
+
+      const shoot = shootRepo.create({ id: "shoot-miss-1", name: "Missing", shootDate: new Date("2026-03-01") });
+      await shootRepo.save(shoot);
+
+      await createTestMedia({ id: "miss-media-1", name: "gone.mp4", relativePath: "inbox/gone.mp4", type: "video", isManaged: false });
+
+      const response = await app.request("/api/library/organize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          entries: [{ mediaId: "miss-media-1", shootId: "shoot-miss-1", package: "main", role: "content", contentRating: "uc" }],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const data = await parseResponse<OrganizeResponse>(response);
+
+      expect(data?.results).toHaveLength(0);
+      expect(data?.errors).toHaveLength(1);
+      expect(data?.errors[0].mediaId).toBe("miss-media-1");
+      expect(data?.errors[0].error).toBe("File not found on disk");
+    });
+
+    test("rejects invalid content rating", async () => {
+      const response = await app.request("/api/library/organize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          entries: [{ mediaId: "any-id", shootId: "any-shoot", package: "main", role: "content", contentRating: "invalid" }],
+        }),
+      });
+
+      expect(response.status).toBe(422);
+    });
+
+    test("auto-links media to shoot", async () => {
+      const ds = getTestDataSource();
+      const shootRepo = ds.getRepository(Shoot);
+
+      const shoot = shootRepo.create({ id: "shoot-link-1", name: "Link Test", shootDate: new Date("2026-04-10") });
+      await shootRepo.save(shoot);
+
+      const sourceDir = path.join(tmpDir, "inbox");
+      await fs.mkdir(sourceDir, { recursive: true });
+      await fs.writeFile(path.join(sourceDir, "link-test.mp4"), "video-data");
+
+      await createTestMedia({ id: "link-media-1", name: "link-test.mp4", relativePath: "inbox/link-test.mp4", type: "video", isManaged: false });
+
+      const response = await app.request("/api/library/organize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          entries: [{ mediaId: "link-media-1", shootId: "shoot-link-1", package: "main", role: "content", contentRating: "cn" }],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const updatedShoot = await shootRepo.findOne({ where: { id: "shoot-link-1" }, relations: { media: true } });
+      const linkedIds = updatedShoot?.media.map((m) => m.id) ?? [];
+      expect(linkedIds).toContain("link-media-1");
+    });
+  });
+});

--- a/@fanslib/apps/server/src/features/library/organize-routes.ts
+++ b/@fanslib/apps/server/src/features/library/organize-routes.ts
@@ -1,0 +1,197 @@
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import pathModule from "path";
+import { promises as fs } from "fs";
+import type { Repository } from "typeorm";
+import { db } from "../../lib/db";
+import { validationError } from "../../lib/hono-utils";
+import { Media } from "./entity";
+import { Shoot } from "../shoots/entity";
+import { ContentRatingSchema } from "./content-rating";
+import { resolveMediaPath } from "./path-utils";
+
+const OrganizeEntrySchema = z.object({
+  mediaId: z.string(),
+  shootId: z.string(),
+  package: z.string(),
+  role: z.string(),
+  contentRating: ContentRatingSchema,
+});
+
+const OrganizeRequestSchema = z.object({
+  entries: z.array(OrganizeEntrySchema).min(1),
+});
+
+const formatDate = (date: Date): string => {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}${m}${d}`;
+};
+
+const buildTargetPath = (
+  shoot: Shoot,
+  pkg: string,
+  role: string,
+  contentRating: string,
+  ext: string,
+  seq?: number,
+): string => {
+  const dateStr = formatDate(shoot.shootDate);
+  const year = shoot.shootDate.getFullYear().toString();
+  const shootFolder = `${dateStr}_${shoot.name}`;
+  const baseName = `${dateStr}_${shoot.name}_${pkg}_${role}_${contentRating}`;
+  const seqSuffix = seq ? `_${seq}` : "";
+  return `${year}/${shootFolder}/${baseName}${seqSuffix}${ext}`;
+};
+
+const pathExists = (filePath: string): Promise<boolean> =>
+  fs.access(filePath).then(() => true).catch(() => false);
+
+const findAvailablePath = async (
+  shoot: Shoot,
+  pkg: string,
+  role: string,
+  contentRating: string,
+  ext: string,
+): Promise<string> => {
+  const basePath = buildTargetPath(shoot, pkg, role, contentRating, ext);
+  if (!(await pathExists(resolveMediaPath(basePath)))) return basePath;
+
+  // eslint-disable-next-line functional/no-let, functional/no-loop-statements
+  for (let seq = 2; ; seq++) {
+    const seqPath = buildTargetPath(shoot, pkg, role, contentRating, ext, seq);
+    if (!(await pathExists(resolveMediaPath(seqPath)))) return seqPath;
+  }
+};
+
+type OrganizeEntry = z.infer<typeof OrganizeEntrySchema>;
+type OrganizeResult = { mediaId: string; finalPath: string };
+type OrganizeError = { mediaId: string; error: string };
+
+const processEntry = async (
+  entry: OrganizeEntry,
+  mediaRepo: Repository<Media>,
+  shootRepo: Repository<Shoot>,
+): Promise<OrganizeResult | OrganizeError> => {
+  const media = await mediaRepo.findOne({ where: { id: entry.mediaId } });
+  if (!media) return { mediaId: entry.mediaId, error: "Media not found" };
+
+  const shoot = await shootRepo.findOne({
+    where: { id: entry.shootId },
+    relations: { media: true },
+  });
+  if (!shoot) return { mediaId: entry.mediaId, error: "Shoot not found" };
+
+  const sourcePath = resolveMediaPath(media.relativePath);
+  if (!(await pathExists(sourcePath))) {
+    return { mediaId: entry.mediaId, error: "File not found on disk" };
+  }
+
+  const ext = pathModule.extname(media.name);
+  const targetRelPath = await findAvailablePath(shoot, entry.package, entry.role, entry.contentRating, ext);
+  const targetAbsPath = resolveMediaPath(targetRelPath);
+
+  await fs.mkdir(pathModule.dirname(targetAbsPath), { recursive: true });
+  await fs.rename(sourcePath, targetAbsPath);
+
+  media.relativePath = targetRelPath;
+  media.name = pathModule.basename(targetRelPath);
+  media.package = entry.package;
+  media.role = entry.role;
+  media.contentRating = entry.contentRating;
+  media.isManaged = true;
+  await mediaRepo.save(media);
+
+  const alreadyLinked = shoot.media.some((m) => m.id === media.id);
+  if (!alreadyLinked) {
+    shoot.media.push(media);
+    await shootRepo.save(shoot);
+  }
+
+  return { mediaId: media.id, finalPath: targetRelPath };
+};
+
+const isError = (r: OrganizeResult | OrganizeError): r is OrganizeError => "error" in r;
+
+export const organizeRoutes = new Hono()
+  .basePath("/api/library")
+  .get("/unmanaged", async (c) => {
+    const database = await db();
+    const mediaRepo = database.getRepository(Media);
+
+    const unmanagedMedia = await mediaRepo.find({
+      where: { isManaged: false },
+      order: { relativePath: "ASC" },
+    });
+
+    const groups = unmanagedMedia.reduce<Map<string, Media[]>>((acc, media) => {
+      const folder = pathModule.dirname(media.relativePath);
+      const existing = acc.get(folder) ?? [];
+      acc.set(folder, [...existing, media]);
+      return acc;
+    }, new Map());
+
+    const result = Array.from(groups.entries()).map(([folder, media]) => ({
+      folder,
+      media,
+    }));
+
+    return c.json(result);
+  })
+  .get("/known-roles", async (c) => {
+    const database = await db();
+    const results = await database
+      .getRepository(Media)
+      .createQueryBuilder("media")
+      .select("DISTINCT media.role", "role")
+      .where("media.isManaged = :managed", { managed: true })
+      .andWhere("media.role IS NOT NULL")
+      .getRawMany<{ role: string }>();
+
+    return c.json(results.map((r) => r.role));
+  })
+  .get("/known-packages", async (c) => {
+    const shootId = c.req.query("shootId");
+    if (!shootId) {
+      return c.json({ error: "shootId query parameter is required" }, 400);
+    }
+
+    const database = await db();
+    const results = await database
+      .getRepository(Media)
+      .createQueryBuilder("media")
+      .innerJoin("shoot_media", "sm", "sm.media_id = media.id")
+      .select("DISTINCT media.package", "package")
+      .where("sm.shoot_id = :shootId", { shootId })
+      .andWhere("media.package IS NOT NULL")
+      .getRawMany<{ package: string }>();
+
+    return c.json(results.map((r) => r.package));
+  })
+  .post(
+    "/organize",
+    zValidator("json", OrganizeRequestSchema, validationError),
+    async (c) => {
+      const { entries } = c.req.valid("json");
+      const database = await db();
+      const mediaRepo = database.getRepository(Media);
+      const shootRepo = database.getRepository(Shoot);
+
+      // Process entries sequentially (each may depend on prior filesystem state)
+      const outcomes = await entries.reduce<Promise<Array<OrganizeResult | OrganizeError>>>(
+        async (accPromise, entry) => {
+          const acc = await accPromise;
+          const result = await processEntry(entry, mediaRepo, shootRepo);
+          return [...acc, result];
+        },
+        Promise.resolve([]),
+      );
+
+      return c.json({
+        results: outcomes.filter((r): r is OrganizeResult => !isError(r)),
+        errors: outcomes.filter(isError),
+      });
+    },
+  );

--- a/@fanslib/apps/server/src/index.ts
+++ b/@fanslib/apps/server/src/index.ts
@@ -12,6 +12,7 @@ import { contentSchedulesRoutes } from "./features/content-schedules/routes";
 import { filterPresetsRoutes } from "./features/filter-presets/routes";
 import { hashtagsRoutes } from "./features/hashtags/routes";
 import { libraryRoutes } from "./features/library/routes";
+import { organizeRoutes } from "./features/library/organize-routes";
 import { pipelineRoutes } from "./features/pipeline/routes";
 import { runwayRoutes } from "./features/pipeline/runway-routes";
 import { postsRoutes } from "./features/posts/routes";
@@ -85,6 +86,7 @@ const app = new Hono()
   .route("/", channelsRoutes)
   .route("/", contentSchedulesRoutes)
   .route("/", libraryRoutes)
+  .route("/", organizeRoutes)
   .route("/", pipelineRoutes)
   .route("/", runwayRoutes)
   .route("/", postsRoutes)


### PR DESCRIPTION
## Summary
- Added `GET /api/library/unmanaged` — returns unmanaged media grouped by containing folder
- Added `GET /api/library/known-roles` — returns distinct role values from managed media for autocomplete
- Added `GET /api/library/known-packages?shootId=X` — returns distinct package values for a shoot for autocomplete
- Added `POST /api/library/organize` — batch rename/move files into managed library structure with filename convention `{date}_{shoot}_{package}_{role}_{rating}.{ext}`, collision handling (sequence numbers `_2`, `_3`...), auto-linking to shoots, and error reporting for missing files

Closes #116

## Test plan
- [x] Unmanaged endpoint returns media grouped by folder, excludes managed
- [x] Known-roles returns distinct roles from managed media only
- [x] Known-packages returns distinct packages filtered by shoot
- [x] Organize renames/moves files and updates media records
- [x] Collision handling appends sequence numbers starting at `_2`
- [x] Missing files reported in errors array (not hard failure)
- [x] Invalid content rating rejected with 422
- [x] Media auto-linked to shoot after organize
- [x] Full test suite passes (281 tests)
- [x] Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)