### PR TITLE
feat: queue state endpoint + schema

### DIFF
--- a/@fanslib/apps/server/src/features/analytics/operations/queue/fetch-queue-state.ts
+++ b/@fanslib/apps/server/src/features/analytics/operations/queue/fetch-queue-state.ts
@@ -1,0 +1,51 @@
+import { db } from "../../../../lib/db";
+import { FanslyAnalyticsAggregate } from "../../entity";
+
+type QueueItem = {
+  postMediaId: string;
+  nextFetchAt: string;
+  caption: string | null;
+  thumbnailUrl: string;
+  overdue: boolean;
+};
+
+type QueueState = {
+  totalPending: number;
+  nextFetchAt: string | null;
+  items: QueueItem[];
+};
+
+export const fetchQueueState = async (): Promise<QueueState> => {
+  const dataSource = await db();
+  const repo = dataSource.getRepository(FanslyAnalyticsAggregate);
+
+  const aggregates = await repo
+    .createQueryBuilder("agg")
+    .leftJoinAndSelect("agg.postMedia", "pm")
+    .leftJoinAndSelect("pm.post", "post")
+    .leftJoinAndSelect("pm.media", "media")
+    .where("agg.nextFetchAt IS NOT NULL")
+    .orderBy("agg.nextFetchAt", "ASC")
+    .getMany();
+
+  const now = new Date();
+
+  const items: QueueItem[] = aggregates
+    .filter((agg) => agg.nextFetchAt != null)
+    .map((agg) => {
+      const nextFetchAt = agg.nextFetchAt as Date;
+      return {
+        postMediaId: agg.postMediaId,
+        nextFetchAt: nextFetchAt.toISOString(),
+        caption: agg.postMedia?.post?.caption ?? null,
+        thumbnailUrl: `thumbnail://${agg.postMedia?.media?.id ?? ""}`,
+        overdue: nextFetchAt <= now,
+      };
+    });
+
+  return {
+    totalPending: items.length,
+    nextFetchAt: items.length > 0 ? items[0].nextFetchAt : null,
+    items,
+  };
+};

--- a/@fanslib/apps/server/src/features/analytics/routes.test.ts
+++ b/@fanslib/apps/server/src/features/analytics/routes.test.ts
@@ -463,6 +463,230 @@ describe("Analytics Routes", () => {
     });
   });
 
+  describe("GET /api/analytics/queue", () => {
+    test("returns empty queue state when no aggregates exist", async () => {
+      const res = await app.request("/api/analytics/queue");
+      expect(res.status).toBe(200);
+
+      const data = await parseResponse<{ totalPending: number; nextFetchAt: null; items: unknown[] }>(res);
+      expect(data?.totalPending).toBe(0);
+      expect(data?.nextFetchAt).toBeNull();
+      expect(data?.items).toEqual([]);
+    });
+
+    test("excludes items with nextFetchAt = null (halted/plateaued)", async () => {
+      const dataSource = getTestDataSource();
+      const postMediaRepo = dataSource.getRepository(PostMedia);
+      const aggregateRepo = dataSource.getRepository(FanslyAnalyticsAggregate);
+
+      const channel = await createTestChannel();
+      const post = await createTestPost(channel.id, { caption: "Halted post" });
+      const media = await createTestMedia();
+      const postMedia = postMediaRepo.create({ post, media, order: 0 });
+      await postMediaRepo.save(postMedia);
+
+      // Aggregate with no nextFetchAt (halted)
+      const aggregate = aggregateRepo.create({
+        postMedia,
+        postMediaId: postMedia.id,
+        totalViews: 100,
+        averageEngagementSeconds: 30,
+        averageEngagementPercent: 50,
+        nextFetchAt: undefined,
+      });
+      await aggregateRepo.save(aggregate);
+
+      const res = await app.request("/api/analytics/queue");
+      expect(res.status).toBe(200);
+
+      const data = await parseResponse<{ totalPending: number; items: unknown[] }>(res);
+      expect(data?.totalPending).toBe(0);
+      expect(data?.items).toEqual([]);
+    });
+
+    test("returns correct totalPending count for items with non-null nextFetchAt", async () => {
+      const dataSource = getTestDataSource();
+      const postMediaRepo = dataSource.getRepository(PostMedia);
+      const aggregateRepo = dataSource.getRepository(FanslyAnalyticsAggregate);
+      const channel = await createTestChannel();
+
+      // Create 2 items with nextFetchAt and 1 without
+      const createQueueItem = async (nextFetchAt?: Date) => {
+        const post = await createTestPost(channel.id);
+        const media = await createTestMedia();
+        const pm = postMediaRepo.create({ post, media, order: 0 });
+        await postMediaRepo.save(pm);
+        await aggregateRepo.save(
+          aggregateRepo.create({
+            postMedia: pm,
+            postMediaId: pm.id,
+            totalViews: 100,
+            averageEngagementSeconds: 30,
+            averageEngagementPercent: 50,
+            nextFetchAt,
+          }),
+        );
+      };
+      await createQueueItem(new Date(Date.now() + 60000));
+      await createQueueItem(new Date(Date.now() + 120000));
+      await createQueueItem(undefined);
+
+      const res = await app.request("/api/analytics/queue");
+      expect(res.status).toBe(200);
+
+      const data = await parseResponse<{ totalPending: number; items: unknown[] }>(res);
+      expect(data?.totalPending).toBe(2);
+      expect(data?.items).toHaveLength(2);
+    });
+
+    test("returns the earliest nextFetchAt as the top-level nextFetchAt", async () => {
+      const dataSource = getTestDataSource();
+      const postMediaRepo = dataSource.getRepository(PostMedia);
+      const aggregateRepo = dataSource.getRepository(FanslyAnalyticsAggregate);
+      const channel = await createTestChannel();
+
+      const earliest = new Date(Date.now() + 30000);
+      const later = new Date(Date.now() + 120000);
+
+      const createWithFetchAt = async (nextFetchAt: Date) => {
+        const post = await createTestPost(channel.id);
+        const media = await createTestMedia();
+        const pm = postMediaRepo.create({ post, media, order: 0 });
+        await postMediaRepo.save(pm);
+        await aggregateRepo.save(
+          aggregateRepo.create({
+            postMedia: pm,
+            postMediaId: pm.id,
+            totalViews: 100,
+            averageEngagementSeconds: 30,
+            averageEngagementPercent: 50,
+            nextFetchAt,
+          }),
+        );
+      };
+      await createWithFetchAt(later);
+      await createWithFetchAt(earliest);
+
+      const res = await app.request("/api/analytics/queue");
+      expect(res.status).toBe(200);
+
+      const data = await parseResponse<{ nextFetchAt: Date }>(res);
+      expect(new Date(data?.nextFetchAt as Date).toISOString()).toBe(earliest.toISOString());
+    });
+
+    test("each item includes postMediaId, nextFetchAt, caption, thumbnailUrl, overdue", async () => {
+      const dataSource = getTestDataSource();
+      const postMediaRepo = dataSource.getRepository(PostMedia);
+      const aggregateRepo = dataSource.getRepository(FanslyAnalyticsAggregate);
+      const channel = await createTestChannel();
+
+      const nextFetch = new Date(Date.now() + 60000);
+      const post = await createTestPost(channel.id, { caption: "My caption" });
+      const media = await createTestMedia();
+      const pm = postMediaRepo.create({ post, media, order: 0 });
+      await postMediaRepo.save(pm);
+      await aggregateRepo.save(
+        aggregateRepo.create({
+          postMedia: pm,
+          postMediaId: pm.id,
+          totalViews: 100,
+          averageEngagementSeconds: 30,
+          averageEngagementPercent: 50,
+          nextFetchAt: nextFetch,
+        }),
+      );
+
+      const res = await app.request("/api/analytics/queue");
+      expect(res.status).toBe(200);
+
+      type QueueItem = {
+        postMediaId: string;
+        nextFetchAt: string;
+        caption: string | null;
+        thumbnailUrl: string;
+        overdue: boolean;
+      };
+      const data = await parseResponse<{ items: QueueItem[] }>(res);
+      const item = data?.items[0];
+      expect(item?.postMediaId).toBe(pm.id);
+      expect(new Date(item?.nextFetchAt as string).toISOString()).toBe(nextFetch.toISOString());
+      expect(item?.caption).toBe("My caption");
+      expect(item?.thumbnailUrl).toBe(`thumbnail://${media.id}`);
+      expect(item?.overdue).toBe(false);
+    });
+
+    test("items where nextFetchAt <= now have overdue: true", async () => {
+      const dataSource = getTestDataSource();
+      const postMediaRepo = dataSource.getRepository(PostMedia);
+      const aggregateRepo = dataSource.getRepository(FanslyAnalyticsAggregate);
+      const channel = await createTestChannel();
+
+      // Past date = overdue
+      const pastDate = new Date(Date.now() - 60000);
+      const post = await createTestPost(channel.id);
+      const media = await createTestMedia();
+      const pm = postMediaRepo.create({ post, media, order: 0 });
+      await postMediaRepo.save(pm);
+      await aggregateRepo.save(
+        aggregateRepo.create({
+          postMedia: pm,
+          postMediaId: pm.id,
+          totalViews: 100,
+          averageEngagementSeconds: 30,
+          averageEngagementPercent: 50,
+          nextFetchAt: pastDate,
+        }),
+      );
+
+      const res = await app.request("/api/analytics/queue");
+      expect(res.status).toBe(200);
+
+      const data = await parseResponse<{ items: Array<{ overdue: boolean }> }>(res);
+      expect(data?.items[0]?.overdue).toBe(true);
+    });
+
+    test("items are sorted by nextFetchAt ascending", async () => {
+      const dataSource = getTestDataSource();
+      const postMediaRepo = dataSource.getRepository(PostMedia);
+      const aggregateRepo = dataSource.getRepository(FanslyAnalyticsAggregate);
+      const channel = await createTestChannel();
+
+      const times = [
+        new Date(Date.now() + 300000),
+        new Date(Date.now() + 60000),
+        new Date(Date.now() + 180000),
+      ];
+
+      const createSorted = async (nextFetchAt: Date) => {
+        const post = await createTestPost(channel.id);
+        const media = await createTestMedia();
+        const pm = postMediaRepo.create({ post, media, order: 0 });
+        await postMediaRepo.save(pm);
+        await aggregateRepo.save(
+          aggregateRepo.create({
+            postMedia: pm,
+            postMediaId: pm.id,
+            totalViews: 100,
+            averageEngagementSeconds: 30,
+            averageEngagementPercent: 50,
+            nextFetchAt,
+          }),
+        );
+      };
+      await createSorted(times[0]);
+      await createSorted(times[1]);
+      await createSorted(times[2]);
+
+      const res = await app.request("/api/analytics/queue");
+      expect(res.status).toBe(200);
+
+      const data = await parseResponse<{ items: Array<{ nextFetchAt: string | Date }> }>(res);
+      const fetchAts = data?.items.map((i) => new Date(i.nextFetchAt).toISOString()) ?? [];
+      const sorted = [...fetchAts].sort();
+      expect(fetchAts).toEqual(sorted);
+    });
+  });
+
   describe("GET /api/analytics/repost-candidates", () => {
     // Helper: create a PostMedia linked to a Media with an analytics aggregate.
     // By default creates a naturally-plateaued PostMedia (eligible for repost).

--- a/@fanslib/apps/server/src/features/analytics/routes.ts
+++ b/@fanslib/apps/server/src/features/analytics/routes.ts
@@ -9,6 +9,7 @@ import { fetchActiveFypPosts } from "./operations/fyp/fetch-active-posts";
 import { fetchRepostCandidates } from "./operations/fyp/fetch-repost-candidates";
 import { fetchFypActionItems } from "./operations/fyp/fetch-actions";
 import { fetchAnalyticsHealth } from "./operations/health/fetch-health";
+import { fetchQueueState } from "./operations/queue/fetch-queue-state";
 import { fetchDatapoints } from "./operations/post-analytics/fetch-datapoints";
 import { getFanslyPostsWithAnalytics } from "./operations/post-analytics/fetch-posts-with-analytics";
 import { initializeAnalyticsAggregates } from "./operations/post-analytics/initialize-aggregates";
@@ -88,6 +89,10 @@ export const analyticsRoutes = new Hono()
   .get("/fyp-actions", zValidator("query", FypActionsQuerySchema, validationError), async (c) => {
     const query = c.req.valid("query");
     const result = await fetchFypActionItems(query);
+    return c.json(result);
+  })
+  .get("/queue", async (c) => {
+    const result = await fetchQueueState();
     return c.json(result);
   })
   .get("/active-fyp-posts", zValidator("query", ActiveFypPostsQuerySchema, validationError), async (c) => {

--- a/@fanslib/apps/server/src/features/analytics/schemas/queue-state.ts
+++ b/@fanslib/apps/server/src/features/analytics/schemas/queue-state.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const QueueItemSchema = z.object({
+  postMediaId: z.string(),
+  nextFetchAt: z.string(),
+  caption: z.string().nullable(),
+  thumbnailUrl: z.string(),
+  overdue: z.boolean(),
+});
+
+export const QueueStateSchema = z.object({
+  totalPending: z.number(),
+  nextFetchAt: z.string().nullable(),
+  items: z.array(QueueItemSchema),
+});


### PR DESCRIPTION
## Summary
- Adds `GET /api/analytics/queue` endpoint returning pending fetch queue state
- Includes Zod response schema, TypeORM query with post/media joins, overdue flag computation
- 7 server tests covering count, sorting, overdue flags, and halted item exclusion

Closes #149

## Test plan
- [x] Server tests pass (36 total, 7 new)
- [x] Lint clean
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)