### PR TITLE
feat: status bar + drawer UI (read-only)

### DIFF
--- a/@fanslib/apps/web/src/features/analytics/components/QueueStatusBar.test.tsx
+++ b/@fanslib/apps/web/src/features/analytics/components/QueueStatusBar.test.tsx
@@ -1,0 +1,199 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("~/lib/queries/analytics", () => ({
+  useQueueStateQuery: vi.fn(),
+}));
+
+import { useQueueStateQuery } from "~/lib/queries/analytics";
+import { QueueStatusBar } from "./QueueStatusBar";
+
+const mockUseQueueStateQuery = vi.mocked(useQueueStateQuery);
+
+// oxlint-disable-next-line typescript/no-explicit-any
+const mockQuery = (overrides: { data: any; isLoading: boolean }) =>
+  mockUseQueueStateQuery.mockReturnValue(overrides as ReturnType<typeof useQueueStateQuery>);
+
+describe("QueueStatusBar", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("renders pending count from queue data", () => {
+    mockQuery({
+      data: {
+        totalPending: 5,
+        nextFetchAt: new Date(Date.now() + 90 * 60_000).toISOString(),
+        items: [],
+      },
+      isLoading: false,
+    });
+
+    render(<QueueStatusBar />);
+    expect(screen.getByText(/5 pending/)).toBeInTheDocument();
+  });
+
+  test("renders relative time to next fetch", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-22T12:00:00Z"));
+
+    mockQuery({
+      data: {
+        totalPending: 3,
+        nextFetchAt: "2026-03-22T13:30:00Z",
+        items: [],
+      },
+      isLoading: false,
+    });
+
+    render(<QueueStatusBar />);
+    expect(screen.getByText(/next in 1h 30m/)).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  test("does not render when loading", () => {
+    mockQuery({ data: undefined, isLoading: true });
+
+    const { container } = render(<QueueStatusBar />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("clicking status bar opens the drawer", async () => {
+    mockQuery({
+      data: {
+        totalPending: 2,
+        nextFetchAt: new Date(Date.now() + 60_000).toISOString(),
+        items: [
+          {
+            postMediaId: "pm-1",
+            nextFetchAt: new Date(Date.now() + 60_000).toISOString(),
+            caption: "Test caption",
+            thumbnailUrl: "thumbnail://media-1",
+            overdue: false,
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
+    render(<QueueStatusBar />);
+    const user = userEvent.setup();
+
+    expect(screen.queryByText("Fetch Queue")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText(/2 pending/));
+
+    expect(screen.getByText("Fetch Queue")).toBeInTheDocument();
+  });
+
+  test("clicking status bar again closes the drawer", async () => {
+    mockQuery({
+      data: {
+        totalPending: 2,
+        nextFetchAt: new Date(Date.now() + 60_000).toISOString(),
+        items: [],
+      },
+      isLoading: false,
+    });
+
+    render(<QueueStatusBar />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByText(/2 pending/));
+    expect(screen.getByText("Fetch Queue")).toBeInTheDocument();
+
+    await user.click(screen.getByText(/2 pending/));
+    expect(screen.queryByText("Fetch Queue")).not.toBeInTheDocument();
+  });
+
+  test("drawer renders queue items with caption", async () => {
+    mockQuery({
+      data: {
+        totalPending: 2,
+        nextFetchAt: new Date(Date.now() + 60_000).toISOString(),
+        items: [
+          {
+            postMediaId: "pm-1",
+            nextFetchAt: new Date(Date.now() + 60_000).toISOString(),
+            caption: "First item caption",
+            thumbnailUrl: "thumbnail://media-1",
+            overdue: false,
+          },
+          {
+            postMediaId: "pm-2",
+            nextFetchAt: new Date(Date.now() + 120_000).toISOString(),
+            caption: "Second item caption",
+            thumbnailUrl: "thumbnail://media-2",
+            overdue: false,
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
+    render(<QueueStatusBar />);
+    const user = userEvent.setup();
+    await user.click(screen.getByText(/2 pending/));
+
+    expect(screen.getByText("First item caption")).toBeInTheDocument();
+    expect(screen.getByText("Second item caption")).toBeInTheDocument();
+  });
+
+  test("overdue items have distinct visual treatment", async () => {
+    mockQuery({
+      data: {
+        totalPending: 2,
+        nextFetchAt: new Date(Date.now() + 60_000).toISOString(),
+        items: [
+          {
+            postMediaId: "pm-1",
+            nextFetchAt: new Date(Date.now() - 60_000).toISOString(),
+            caption: "Overdue item",
+            thumbnailUrl: "thumbnail://media-1",
+            overdue: true,
+          },
+          {
+            postMediaId: "pm-2",
+            nextFetchAt: new Date(Date.now() + 60_000).toISOString(),
+            caption: "Normal item",
+            thumbnailUrl: "thumbnail://media-2",
+            overdue: false,
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
+    render(<QueueStatusBar />);
+    const user = userEvent.setup();
+    await user.click(screen.getByText(/2 pending/));
+
+    const overdueItem = screen.getByText("Overdue item").closest("li");
+    expect(overdueItem).toHaveClass("bg-warning/10");
+
+    expect(screen.getByText(/overdue/)).toBeInTheDocument();
+  });
+
+  test("drawer has a close button that closes it", async () => {
+    mockQuery({
+      data: {
+        totalPending: 1,
+        nextFetchAt: new Date(Date.now() + 60_000).toISOString(),
+        items: [],
+      },
+      isLoading: false,
+    });
+
+    render(<QueueStatusBar />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByText(/1 pending/));
+    expect(screen.getByText("Fetch Queue")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Close drawer"));
+    expect(screen.queryByText("Fetch Queue")).not.toBeInTheDocument();
+  });
+});

--- a/@fanslib/apps/web/src/features/analytics/components/QueueStatusBar.tsx
+++ b/@fanslib/apps/web/src/features/analytics/components/QueueStatusBar.tsx
@@ -1,0 +1,72 @@
+import { X } from "lucide-react";
+import { useState } from "react";
+import { useQueueStateQuery } from "~/lib/queries/analytics";
+import { getMediaThumbnailUrl } from "~/lib/media-urls";
+
+const formatRelativeTime = (isoDate: string): string => {
+  const diff = new Date(isoDate).getTime() - Date.now();
+  if (diff <= 0) return "overdue";
+  const totalMinutes = Math.floor(diff / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+};
+
+const extractMediaId = (thumbnailUrl: string): string =>
+  thumbnailUrl.replace("thumbnail://", "");
+
+export const QueueStatusBar = () => {
+  const { data, isLoading } = useQueueStateQuery();
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (isLoading || !data) return null;
+
+  return (
+    <div>
+      <div
+        className="flex items-center gap-2 rounded-lg bg-base-200 px-3 py-2 text-sm cursor-pointer"
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        <span>
+          {data.totalPending} pending
+          {data.nextFetchAt && ` · next in ${formatRelativeTime(data.nextFetchAt)}`}
+        </span>
+      </div>
+      {isOpen && (
+        <div className="mt-2 rounded-lg border border-base-300 bg-base-100 p-4 shadow-lg">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-sm font-semibold">Fetch Queue</h3>
+            <button
+              aria-label="Close drawer"
+              className="btn btn-ghost btn-xs btn-square"
+              onClick={() => setIsOpen(false)}
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <ul className="space-y-2">
+            {data.items.map((item) => (
+              <li
+                key={item.postMediaId}
+                className={`flex items-center gap-3 rounded-lg p-2 ${item.overdue ? "bg-warning/10" : ""}`}
+              >
+                <img
+                  src={getMediaThumbnailUrl(extractMediaId(item.thumbnailUrl))}
+                  alt=""
+                  className="h-10 w-10 rounded object-cover"
+                />
+                <div className="flex-1 min-w-0">
+                  <p className="truncate text-sm">{item.caption}</p>
+                  <p className="text-xs text-base-content/60">
+                    {formatRelativeTime(item.nextFetchAt)} · {new Date(item.nextFetchAt).toLocaleString()}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/lib/queries/analytics.ts
+++ b/@fanslib/apps/web/src/lib/queries/analytics.ts
@@ -36,6 +36,31 @@ export const useRepostCandidatesQuery = (sortBy?: "views" | "engagementPercent" 
     },
   });
 
+export type QueueItem = {
+  postMediaId: string;
+  nextFetchAt: string;
+  caption: string | null;
+  thumbnailUrl: string;
+  overdue: boolean;
+};
+
+export type QueueState = {
+  totalPending: number;
+  nextFetchAt: string | null;
+  items: QueueItem[];
+};
+
+export const useQueueStateQuery = () =>
+  useQuery({
+    queryKey: QUERY_KEYS.analytics.queue(),
+    queryFn: async () => {
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const result = await (api.api.analytics as any).queue.$get();
+      return result.json() as QueueState;
+    },
+    staleTime: 30_000,
+  });
+
 export const useFetchFanslyDataMutation = () => {
   const queryClient = useQueryClient();
 

--- a/@fanslib/apps/web/src/lib/queries/query-keys.ts
+++ b/@fanslib/apps/web/src/lib/queries/query-keys.ts
@@ -30,6 +30,7 @@ export const QUERY_KEYS = {
     datapoints: (postMediaId: string) => ["analytics", "datapoints", postMediaId] as const,
     activeFypPosts: (sortBy?: string) => ["analytics", "active-fyp-posts", sortBy] as const,
     repostCandidates: (sortBy?: string) => ["analytics", "repost-candidates", sortBy] as const,
+    queue: () => ["analytics", "queue"] as const,
   },
 
   posts: {

--- a/@fanslib/apps/web/src/routes/fansly/fyp.tsx
+++ b/@fanslib/apps/web/src/routes/fansly/fyp.tsx
@@ -2,11 +2,13 @@ import { createFileRoute } from "@tanstack/react-router";
 import { PageContainer } from "~/components/ui/PageContainer/PageContainer";
 import { PageHeader } from "~/components/ui/PageHeader/PageHeader";
 import { ActiveFypPostsPage } from "~/features/analytics/components/ActiveFypPostsPage";
+import { QueueStatusBar } from "~/features/analytics/components/QueueStatusBar";
 import { RepostCandidatesPage } from "~/features/analytics/components/RepostCandidatesPage";
 
 const FanslyFypRoute = () => (
   <PageContainer>
     <PageHeader title="FYP Analytics" description="Active FYP posts and repost candidates" />
+    <QueueStatusBar />
     <div className="space-y-8">
       <section>
         <h2 className="text-lg font-semibold mb-4">Active FYP Posts</h2>


### PR DESCRIPTION
## Summary
- Adds `QueueStatusBar` component with toggleable drawer to FYP analytics page
- TanStack Query hook (`useQueueStateQuery`) fetches queue state with 30s stale time
- Drawer shows thumbnails, captions, relative/absolute times, overdue highlighting
- 8 UI tests covering rendering, toggle, item display, and overdue treatment

Closes #150

**Stacked on #152 (issue #149)**

## Test plan
- [x] 8 Vitest tests pass for QueueStatusBar
- [x] All 42 web tests pass
- [x] Lint clean (warnings only)
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)