### PR TITLE
feat: post detail analytics chart with metric switching

### DIFF
--- a/@fanslib/apps/web/src/features/posts/components/post-detail/AnalyticsViewsChart.tsx
+++ b/@fanslib/apps/web/src/features/posts/components/post-detail/AnalyticsViewsChart.tsx
@@ -1,12 +1,15 @@
 import { ParentSize } from "@visx/responsive";
 import { AreaSeries, Axis, Grid, Tooltip, XYChart, buildChartTheme } from "@visx/xychart";
 import { useMemo } from "react";
-import { aggregateDatapoints } from "~/lib/analytics/aggregate";
+import { type AggregatedDataPoint, aggregateDatapoints } from "~/lib/analytics/aggregate";
+
+export type ChartMetric = "views" | "engagementPercent" | "engagementSeconds";
 
 type AnalyticsViewsChartProps = {
   datapoints: Array<{ timestamp: number; views: number; interactionTime: number }>;
   postDate: string;
   postMediaId: string;
+  metric?: ChartMetric;
 };
 
 const chartTheme = buildChartTheme({
@@ -27,7 +30,28 @@ const formatNumber = (value: number): string => {
   return value.toString();
 };
 
-export const AnalyticsViewsChart = ({ datapoints, postDate }: AnalyticsViewsChartProps) => {
+export const metricLabels: Record<ChartMetric, string> = {
+  views: "Views",
+  engagementPercent: "Engagement %",
+  engagementSeconds: "Engagement Time (s)",
+};
+
+const getMetricValue = (dp: AggregatedDataPoint, metric: ChartMetric): number => {
+  switch (metric) {
+    case "views":
+      return dp.views;
+    case "engagementSeconds":
+      return dp.interactionTime / 1000;
+    case "engagementPercent":
+      return dp.views > 0 ? (dp.interactionTime / 1000 / dp.views) * 100 : 0;
+  }
+};
+
+export const AnalyticsViewsChart = ({
+  datapoints,
+  postDate,
+  metric = "views",
+}: AnalyticsViewsChartProps) => {
   const aggregatedData = useMemo(
     () => aggregateDatapoints(datapoints, postDate),
     [datapoints, postDate],
@@ -39,31 +63,33 @@ export const AnalyticsViewsChart = ({ datapoints, postDate }: AnalyticsViewsChar
 
   const chartData = aggregatedData.map((point) => ({
     date: point.date,
+    value: getMetricValue(point, metric),
     views: point.views,
+    interactionTime: point.interactionTime,
     timestamp: point.timestamp,
     daysSincePost: point.daysSincePost,
   }));
 
   const accessors = {
     xAccessor: (d: (typeof chartData)[number]) => new Date(d.timestamp),
-    yAccessor: (d: (typeof chartData)[number]) => d.views,
+    yAccessor: (d: (typeof chartData)[number]) => d.value,
   };
 
   const sevenDayIndex = chartData.findIndex((d) => d.daysSincePost >= 7);
   const thirtyDayIndex = chartData.findIndex((d) => d.daysSincePost >= 30);
 
-  const maxViews = Math.max(...chartData.map((d) => d.views), 0);
+  const maxValue = Math.max(...chartData.map((d) => d.value), 0);
 
   return (
     <div className="mt-6">
-      <h3 className="text-lg font-semibold mb-4">Views Over Time</h3>
+      <h3 className="text-lg font-semibold mb-4">{metricLabels[metric]} Over Time</h3>
       <div className="relative" style={{ minHeight: "300px" }}>
         <ParentSize>
           {({ width }) => (
             <XYChart
               theme={chartTheme}
               xScale={{ type: "time" }}
-              yScale={{ type: "linear", domain: [0, maxViews * 1.1] }}
+              yScale={{ type: "linear", domain: [0, maxValue * 1.1 || 1] }}
               width={width}
               height={300}
               margin={{ top: 20, right: 20, bottom: 40, left: 60 }}
@@ -78,7 +104,12 @@ export const AnalyticsViewsChart = ({ datapoints, postDate }: AnalyticsViewsChar
                 }}
               />
               <Axis orientation="left" numTicks={5} tickFormat={formatNumber} />
-              <AreaSeries dataKey="views" data={chartData} {...accessors} fillOpacity={0.2} />
+              <AreaSeries
+                dataKey={metricLabels[metric]}
+                data={chartData}
+                {...accessors}
+                fillOpacity={0.2}
+              />
               <Tooltip
                 snapTooltipToDatumX
                 snapTooltipToDatumY
@@ -91,7 +122,7 @@ export const AnalyticsViewsChart = ({ datapoints, postDate }: AnalyticsViewsChar
                     <div className="bg-base-100 border border-base-300 rounded-lg p-2 shadow-lg">
                       <div className="text-sm font-medium">{datum.date}</div>
                       <div className="text-sm text-base-content/70">
-                        Views: {formatNumber(datum.views)}
+                        {metricLabels[metric]}: {formatNumber(datum.value)}
                       </div>
                       <div className="text-xs text-base-content/50">Day {datum.daysSincePost}</div>
                     </div>

--- a/@fanslib/apps/web/src/features/posts/components/post-detail/PostDetailAnalytics.test.tsx
+++ b/@fanslib/apps/web/src/features/posts/components/post-detail/PostDetailAnalytics.test.tsx
@@ -1,0 +1,153 @@
+/// <reference types="@testing-library/jest-dom" />
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { describe, expect, test, vi } from "vitest";
+
+// Mock the analytics query hook
+vi.mock("~/lib/queries/analytics", () => ({
+  usePostMediaAnalyticsQuery: vi.fn(),
+  useFetchFanslyDataMutation: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+}));
+
+// Mock MediaPreview to avoid settings query dependency
+vi.mock("~/components/MediaPreview", () => ({
+  MediaPreview: () => <div data-testid="media-preview" />,
+}));
+
+// Mock visx chart components to avoid rendering complexities in tests
+vi.mock("@visx/responsive", () => ({
+  ParentSize: ({ children }: { children: (args: { width: number }) => React.ReactNode }) =>
+    children({ width: 600 }),
+}));
+
+vi.mock("@visx/xychart", () => ({
+  XYChart: ({ children }: { children: React.ReactNode }) => <svg>{children}</svg>,
+  AreaSeries: () => null,
+  Axis: () => null,
+  Grid: () => null,
+  Tooltip: () => null,
+  buildChartTheme: () => ({}),
+}));
+
+import { usePostMediaAnalyticsQuery } from "~/lib/queries/analytics";
+
+// Import after mocks
+import { PostDetailAnalytics } from "./PostDetailAnalytics";
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const mockUsePostMediaAnalyticsQuery = vi.mocked(usePostMediaAnalyticsQuery);
+
+const makePost = (overrides?: Partial<Parameters<typeof PostDetailAnalytics>[0]["post"]>) => ({
+  id: "post-1",
+  channel: { typeId: "fansly" as const, id: "ch-1", name: "test", createdAt: new Date() },
+  postMedia: [
+    {
+      id: "pm-1",
+      fanslyStatisticsId: "stats-1",
+      media: { id: "m-1", type: "image" as const, hash: "abc", width: 100, height: 100 },
+    },
+  ],
+  ...overrides,
+});
+
+const sampleDatapoints = [
+  { timestamp: 1700000000000, views: 10, interactionTime: 5000 },
+  { timestamp: 1700086400000, views: 25, interactionTime: 15000 },
+  { timestamp: 1700172800000, views: 50, interactionTime: 30000 },
+];
+
+describe("PostDetailAnalytics metric toggle", () => {
+  test("renders metric toggle with three options", () => {
+    mockUsePostMediaAnalyticsQuery.mockReturnValue({
+      data: { datapoints: sampleDatapoints, postDate: "2023-11-14" },
+      isLoading: false,
+    } as ReturnType<typeof usePostMediaAnalyticsQuery>);
+
+    render(<PostDetailAnalytics post={makePost() as Parameters<typeof PostDetailAnalytics>[0]["post"]} />, { wrapper: createWrapper() });
+
+    expect(screen.getByRole("button", { name: "Views" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Engagement %" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Engagement Time" })).toBeInTheDocument();
+  });
+
+  test("Views is the default selected metric", () => {
+    mockUsePostMediaAnalyticsQuery.mockReturnValue({
+      data: { datapoints: sampleDatapoints, postDate: "2023-11-14" },
+      isLoading: false,
+    } as ReturnType<typeof usePostMediaAnalyticsQuery>);
+
+    render(<PostDetailAnalytics post={makePost() as Parameters<typeof PostDetailAnalytics>[0]["post"]} />, { wrapper: createWrapper() });
+
+    const viewsButton = screen.getByRole("button", { name: "Views" });
+    expect(viewsButton.className).toContain("btn-primary");
+  });
+
+  test("clicking a different metric button switches the selection", async () => {
+    mockUsePostMediaAnalyticsQuery.mockReturnValue({
+      data: { datapoints: sampleDatapoints, postDate: "2023-11-14" },
+      isLoading: false,
+    } as ReturnType<typeof usePostMediaAnalyticsQuery>);
+
+    render(<PostDetailAnalytics post={makePost() as Parameters<typeof PostDetailAnalytics>[0]["post"]} />, { wrapper: createWrapper() });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "Engagement %" }));
+
+    expect(screen.getByRole("button", { name: "Engagement %" }).className).toContain("btn-primary");
+    expect(screen.getByRole("button", { name: "Views" }).className).not.toContain("btn-primary");
+  });
+
+  test("chart heading updates when metric changes", async () => {
+    mockUsePostMediaAnalyticsQuery.mockReturnValue({
+      data: { datapoints: sampleDatapoints, postDate: "2023-11-14" },
+      isLoading: false,
+    } as ReturnType<typeof usePostMediaAnalyticsQuery>);
+
+    render(<PostDetailAnalytics post={makePost() as Parameters<typeof PostDetailAnalytics>[0]["post"]} />, { wrapper: createWrapper() });
+    const user = userEvent.setup();
+
+    expect(screen.getByText("Views Over Time")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Engagement %" }));
+    expect(screen.getByText("Engagement % Over Time")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Engagement Time" }));
+    expect(screen.getByText("Engagement Time (s) Over Time")).toBeInTheDocument();
+  });
+
+  test("shows loading state while data is being fetched", () => {
+    mockUsePostMediaAnalyticsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof usePostMediaAnalyticsQuery>);
+
+    render(<PostDetailAnalytics post={makePost() as Parameters<typeof PostDetailAnalytics>[0]["post"]} />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("Loading analytics...")).toBeInTheDocument();
+  });
+
+  test("shows empty state with fetch button when no data available", () => {
+    mockUsePostMediaAnalyticsQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as ReturnType<typeof usePostMediaAnalyticsQuery>);
+
+    render(<PostDetailAnalytics post={makePost() as Parameters<typeof PostDetailAnalytics>[0]["post"]} />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("No analytics data available")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Fetch Analytics" })).toBeInTheDocument();
+  });
+});

--- a/@fanslib/apps/web/src/features/posts/components/post-detail/PostDetailAnalytics.tsx
+++ b/@fanslib/apps/web/src/features/posts/components/post-detail/PostDetailAnalytics.tsx
@@ -2,7 +2,10 @@ import type { PostWithRelations } from "@fanslib/server/schemas";
 import { useState } from "react";
 import { MediaPreview } from "~/components/MediaPreview";
 import { Button } from "~/components/ui/Button";
-import { AnalyticsViewsChart } from "~/features/posts/components/post-detail/AnalyticsViewsChart";
+import {
+  AnalyticsViewsChart,
+  type ChartMetric,
+} from "~/features/posts/components/post-detail/AnalyticsViewsChart";
 import { cn } from "~/lib/cn";
 import { useFetchFanslyDataMutation, usePostMediaAnalyticsQuery } from "~/lib/queries/analytics";
 
@@ -69,7 +72,14 @@ type PostMediaAnalyticsChartProps = {
   postMediaId: string;
 };
 
+const METRIC_OPTIONS = [
+  { value: "views", label: "Views" },
+  { value: "engagementPercent", label: "Engagement %" },
+  { value: "engagementSeconds", label: "Engagement Time" },
+] as const;
+
 const PostMediaAnalyticsChart = ({ postMediaId }: PostMediaAnalyticsChartProps) => {
+  const [metric, setMetric] = useState<ChartMetric>("views");
   const { data: analyticsData, isLoading } = usePostMediaAnalyticsQuery(postMediaId);
   const fetchAnalyticsMutation = useFetchFanslyDataMutation();
 
@@ -96,10 +106,26 @@ const PostMediaAnalyticsChart = ({ postMediaId }: PostMediaAnalyticsChartProps) 
   }
 
   return (
-    <AnalyticsViewsChart
-      datapoints={analyticsData.datapoints}
-      postDate={analyticsData.postDate}
-      postMediaId={postMediaId}
-    />
+    <div>
+      <div className="flex items-center gap-2 mb-2">
+        <div className="join">
+          {METRIC_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              className={`join-item btn btn-sm ${metric === option.value ? "btn-primary" : "btn-ghost"}`}
+              onClick={() => setMetric(option.value)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <AnalyticsViewsChart
+        datapoints={analyticsData.datapoints}
+        postDate={analyticsData.postDate}
+        postMediaId={postMediaId}
+        metric={metric}
+      />
+    </div>
   );
 };

--- a/@fanslib/apps/web/src/lib/analytics/aggregate.test.ts
+++ b/@fanslib/apps/web/src/lib/analytics/aggregate.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { aggregateDatapoints } from "./aggregate";
+
+describe("aggregateDatapoints", () => {
+  test("returns empty array for empty input", () => {
+    expect(aggregateDatapoints([], "2023-11-14")).toEqual([]);
+  });
+
+  test("preserves cumulative interactionTime in aggregated data", () => {
+    const datapoints = [
+      { timestamp: 1699920000000, views: 10, interactionTime: 5000 },
+      { timestamp: 1700006400000, views: 25, interactionTime: 15000 },
+    ];
+
+    const result = aggregateDatapoints(datapoints, "2023-11-14");
+
+    const lastPoint = result[result.length - 1];
+    expect(lastPoint?.interactionTime).toBe(20000);
+  });
+
+  test("all aggregated points include interactionTime field", () => {
+    const datapoints = [
+      { timestamp: 1699920000000, views: 10, interactionTime: 5000 },
+      { timestamp: 1700006400000, views: 25, interactionTime: 15000 },
+    ];
+
+    const result = aggregateDatapoints(datapoints, "2023-11-14");
+
+    result.forEach((point) => {
+      expect(point).toHaveProperty("interactionTime");
+      expect(typeof point.interactionTime).toBe("number");
+    });
+  });
+});

--- a/@fanslib/apps/web/src/lib/analytics/aggregate.ts
+++ b/@fanslib/apps/web/src/lib/analytics/aggregate.ts
@@ -9,6 +9,7 @@ export type AggregatedDataPoint = {
   daysSincePost: number;
   views: number;
   timestamp: number;
+  interactionTime: number;
 };
 
 export const aggregateDatapoints = (
@@ -33,20 +34,23 @@ export const aggregateDatapoints = (
   const datapointsByDay = sortedDatapoints.reduce(
     (acc, datapoint) => {
       const cumulativeViews = acc.cumulativeViews + datapoint.views;
+      const cumulativeInteractionTime = acc.cumulativeInteractionTime + datapoint.interactionTime;
       const datapointDate = new Date(datapoint.timestamp);
       datapointDate.setHours(0, 0, 0, 0);
       const dateKey = datapointDate.toISOString().split("T")[0] ?? "";
       const nextMap = new Map(acc.byDay);
       nextMap.set(dateKey, {
         views: cumulativeViews,
+        interactionTime: cumulativeInteractionTime,
         timestamp: datapoint.timestamp,
       });
 
-      return { cumulativeViews, byDay: nextMap };
+      return { cumulativeViews, cumulativeInteractionTime, byDay: nextMap };
     },
     {
       cumulativeViews: 0,
-      byDay: new Map<string, { views: number; timestamp: number }>(),
+      cumulativeInteractionTime: 0,
+      byDay: new Map<string, { views: number; interactionTime: number; timestamp: number }>(),
     },
   ).byDay;
   const dayMs = 24 * 60 * 60 * 1000;
@@ -69,19 +73,22 @@ export const aggregateDatapoints = (
       const daysSincePost = Math.floor((currentDate.getTime() - postDateObj.getTime()) / dayMs);
       const data = datapointsByDay.get(dateKey);
       const views = data?.views ?? acc.prevViews;
+      const interactionTime = data?.interactionTime ?? acc.prevInteractionTime;
       const nextPoint: AggregatedDataPoint = {
         date: formatter.format(currentDate),
         daysSincePost,
         views,
+        interactionTime,
         timestamp: data?.timestamp ?? currentDate.getTime(),
       };
 
       return {
         prevViews: views,
+        prevInteractionTime: interactionTime,
         result: [...acc.result, nextPoint],
       };
     },
-    { prevViews: 0, result: [] as AggregatedDataPoint[] },
+    { prevViews: 0, prevInteractionTime: 0, result: [] as AggregatedDataPoint[] },
   );
 
   return aggregated.result;


### PR DESCRIPTION
## Summary
- Extends post detail analytics chart to support switching between Views, Engagement %, and Engagement Time
- Adds metric toggle UI (join button group) to the chart section
- Extends `aggregateDatapoints` to track cumulative `interactionTime` for metric computation
- Chart heading, data series, and tooltip update dynamically per selected metric
- Milestone markers (7-day, 30-day) preserved

Closes #122

## Test plan
- [x] 6 UI tests for metric toggle and chart behavior
- [x] 3 unit tests for `aggregateDatapoints` interactionTime tracking
- [x] All 43 web tests pass
- [x] All 281 server tests pass
- [x] Lint clean
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)