### PR TITLE
feat: capture and store Fansly post ID during schedule interception

### DIFF
--- a/@fanslib/apps/chrome-extension/src/background/index.ts
+++ b/@fanslib/apps/chrome-extension/src/background/index.ts
@@ -20,6 +20,7 @@ type Message =
       type: "FANSLIB_SCHEDULE_CAPTURE";
       contentId: string;
       caption: string;
+      fanslyPostId?: string;
     };
 
 const BATCH_DELAY_MS = 2000;
@@ -366,8 +367,9 @@ const addToBuffer = (candidates: CandidateItem[]): void => {
 const sendScheduleCapture = async (
   contentId: string,
   caption: string,
+  fanslyPostId?: string,
 ): Promise<{ matched: boolean; postId: string | null }> => {
-  debug("info", "Sending schedule capture to server", { contentId, captionLength: caption.length });
+  debug("info", "Sending schedule capture to server", { contentId, fanslyPostId, captionLength: caption.length });
 
   const apiUrl = await getApiUrl();
   if (!apiUrl) return { matched: false, postId: null };
@@ -375,7 +377,7 @@ const sendScheduleCapture = async (
 
   try {
     const response = await api.api.posts["schedule-capture"].$post({
-      json: { contentId, caption },
+      json: { contentId, caption, ...(fanslyPostId ? { fanslyPostId } : {}) },
     });
 
     if (!response.ok) {
@@ -442,7 +444,7 @@ chrome.runtime.onMessage.addListener((message: Message, _sender, sendResponse) =
   }
 
   if (message.type === "FANSLIB_SCHEDULE_CAPTURE") {
-    sendScheduleCapture(message.contentId, message.caption)
+    sendScheduleCapture(message.contentId, message.caption, message.fanslyPostId)
       .then((result) => {
         sendResponse({ success: true, ...result });
       })

--- a/@fanslib/apps/chrome-extension/src/content/fansly-bridge.ts
+++ b/@fanslib/apps/chrome-extension/src/content/fansly-bridge.ts
@@ -142,6 +142,7 @@ window.addEventListener("message", (event) => {
   if (event.data.type === "FANSLIB_SCHEDULE_CAPTURE") {
     debug("info", "Received schedule capture from MAIN world", {
       contentId: event.data.contentId,
+      fanslyPostId: event.data.fanslyPostId,
       captionLength: event.data.caption?.length,
     });
 
@@ -150,6 +151,7 @@ window.addEventListener("message", (event) => {
         type: "FANSLIB_SCHEDULE_CAPTURE",
         contentId: event.data.contentId,
         caption: event.data.caption,
+        fanslyPostId: event.data.fanslyPostId,
       },
       "schedule capture",
     );

--- a/@fanslib/apps/chrome-extension/src/content/fansly-interceptor.ts
+++ b/@fanslib/apps/chrome-extension/src/content/fansly-interceptor.ts
@@ -280,6 +280,7 @@ const processScheduleResponse = (
     const data = JSON.parse(responseText) as {
       success: boolean;
       response?: {
+        postId?: string;
         postTemplate?: PostData | string;
         post?: PostData | string;
       };
@@ -313,6 +314,9 @@ const processScheduleResponse = (
     } else if (rawPostData && typeof rawPostData === "object") {
       postData = rawPostData;
     }
+
+    // Extract Fansly post ID from the top-level response
+    const fanslyPostId = data.response.postId;
 
     // Try to get contentId from response attachments
     // eslint-disable-next-line functional/no-let
@@ -367,6 +371,7 @@ const processScheduleResponse = (
     debug("info", `Schedule capture detected (#${scheduleCaptureCount})`, {
       url,
       contentId,
+      fanslyPostId,
       captionLength: caption.length,
       captionPreview: caption.substring(0, 80),
       source,
@@ -377,6 +382,7 @@ const processScheduleResponse = (
         type: "FANSLIB_SCHEDULE_CAPTURE",
         contentId,
         caption,
+        fanslyPostId,
       },
       "*",
     );

--- a/@fanslib/apps/server/src/features/posts/entity.ts
+++ b/@fanslib/apps/server/src/features/posts/entity.ts
@@ -67,6 +67,9 @@ export class Post {
   @Column({ type: "int", default: 0, name: "blueskyRetryCount" })
   blueskyRetryCount: number = 0;
 
+  @Column({ type: "varchar", nullable: true, name: "fanslyPostId" })
+  fanslyPostId: string | null = null;
+
   @Column({
     type: "varchar",
     enum: ["draft", "ready", "scheduled", "posted"],

--- a/@fanslib/apps/server/src/features/posts/operations/schedule-capture.test.ts
+++ b/@fanslib/apps/server/src/features/posts/operations/schedule-capture.test.ts
@@ -208,6 +208,40 @@ describe("processScheduleCapture", () => {
     expect(updatedPm2?.fanslyStatisticsId).toBeNull();
   });
 
+  test("does not set fanslyPostId when not provided", async () => {
+    const dataSource = getTestDataSource();
+    const postRepo = dataSource.getRepository(Post);
+
+    const { post } = await createReadyFanslyPost("No post ID provided");
+
+    await processScheduleCapture({
+      contentId: "fansly-content-888",
+      caption: "No post ID provided",
+    });
+
+    const updatedPost = await postRepo.findOne({ where: { id: post.id } });
+    expect(updatedPost?.status).toBe("scheduled");
+    expect(updatedPost?.fanslyPostId).toBeNull();
+  });
+
+  test("stores fanslyPostId on matched post", async () => {
+    const dataSource = getTestDataSource();
+    const postRepo = dataSource.getRepository(Post);
+
+    const { post } = await createReadyFanslyPost("Store the post ID please");
+
+    const result = await processScheduleCapture({
+      contentId: "fansly-content-999",
+      caption: "Store the post ID please",
+      fanslyPostId: "892032980896215040",
+    });
+
+    expect(result.matched).toBe(true);
+
+    const updatedPost = await postRepo.findOne({ where: { id: post.id } });
+    expect(updatedPost?.fanslyPostId).toBe("892032980896215040");
+  });
+
   test("handles null caption in queue post gracefully", async () => {
     const channel = await createTestChannel({ typeId: "fansly" });
     const post = await createTestPost(channel.id, {

--- a/@fanslib/apps/server/src/features/posts/operations/schedule-capture.ts
+++ b/@fanslib/apps/server/src/features/posts/operations/schedule-capture.ts
@@ -7,6 +7,7 @@ import { Post, PostMedia } from "../entity";
 export const ScheduleCaptureRequestBodySchema = z.object({
   contentId: z.string(),
   caption: z.string(),
+  fanslyPostId: z.string().optional(),
 });
 
 export type ScheduleCaptureResult = {
@@ -53,8 +54,11 @@ export const processScheduleCapture = async (
   const bestMatch = matches[0];
   const post = bestMatch.post;
 
-  // Update post status to "scheduled"
-  await postRepo.update(post.id, { status: "scheduled" });
+  // Update post status to "scheduled" and store fanslyPostId if provided
+  await postRepo.update(post.id, {
+    status: "scheduled",
+    ...(input.fanslyPostId ? { fanslyPostId: input.fanslyPostId } : {}),
+  });
 
   // Link first PostMedia (attachments[0]) with fanslyStatisticsId
   const firstPostMedia = [...post.postMedia].sort((a, b) => a.order - b.order)[0];

--- a/@fanslib/apps/server/src/features/posts/schema.ts
+++ b/@fanslib/apps/server/src/features/posts/schema.ts
@@ -31,6 +31,7 @@ export const PostSchema = z.object({
   blueskyPostUri: z.string().nullable(),
   blueskyPostError: z.string().nullable(),
   blueskyRetryCount: z.number(),
+  fanslyPostId: z.string().nullable(),
   status: PostStatusSchema,
   channelId: z.string(),
   subredditId: z.string().nullable(),


### PR DESCRIPTION
## Summary
- Extract `fanslyPostId` from `response.postId` in the Fansly schedule interceptor and thread it through bridge → background → server API
- Add `fanslyPostId` column (varchar, nullable) to the `Post` entity
- Store `fanslyPostId` on the matched post during schedule capture processing
- Backward-compatible: `fanslyPostId` is optional in the schema, existing clients continue to work

## Test plan
- [x] New test: `stores fanslyPostId on matched post` — verifies the field is persisted
- [x] New test: `does not set fanslyPostId when not provided` — verifies backward compatibility
- [x] All 11 schedule-capture tests pass
- [x] Lint and typecheck clean

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)