### PR TITLE
fix: use FanslyIcon instead of BarChart3 for Fansly navigation

### DIFF
--- a/@fanslib/apps/web/src/components/NavigationMenu.tsx
+++ b/@fanslib/apps/web/src/components/NavigationMenu.tsx
@@ -2,7 +2,6 @@ import { Link, useLocation } from "@tanstack/react-router";
 import { useAtom } from "jotai";
 import type { LucideIcon } from "lucide-react";
 import {
-  BarChart3,
   Calendar,
   Camera,
   ChevronDown,
@@ -18,6 +17,7 @@ import {
 } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
+import { FanslyIcon } from "~/components/icons";
 import { cn } from "~/lib/cn";
 import { closeSidebarAtom, toggleSidebarCollapsedAtom } from "~/state/sidebar";
 
@@ -36,7 +36,7 @@ const menuItems: MenuItem[] = [
   { to: "/captioning", label: "Captioning", icon: MessageSquareText },
   { to: "/channels", label: "Channels", icon: Radio },
   { to: "/hashtags", label: "Hashtags", icon: Hash },
-  { to: "/fansly/fyp", label: "Fansly", icon: BarChart3 },
+  { to: "/fansly/fyp", label: "Fansly", icon: FanslyIcon },
   { to: "/settings", label: "Settings", icon: Settings },
 ];
 


### PR DESCRIPTION
## Summary
Replace the analytics icon with the proper Fansly icon component for the navigation menu item.

## Test plan
- [x] Navigation displays Fansly icon instead of analytics icon
- [x] Fansly navigation link still routes correctly to /fansly/fyp

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)