### PR TITLE
fix: deleted post still appears in FYP fetch queue

### DIFF
--- a/@fanslib/apps/server/src/features/analytics/routes.test.ts
+++ b/@fanslib/apps/server/src/features/analytics/routes.test.ts
@@ -12,6 +12,7 @@ import { PostMedia } from "../posts/entity";
 import { FanslyAnalyticsAggregate, FanslyAnalyticsDatapoint } from "./entity";
 import { fetchFanslyAnalyticsData } from "./fetch-fansly-data";
 import { initializeAnalyticsAggregates } from "./operations/post-analytics/initialize-aggregates";
+import { deletePost } from "../posts/operations/post/delete";
 import { analyticsRoutes } from "./routes";
 
 describe("Analytics Routes", () => {
@@ -452,6 +453,31 @@ describe("Analytics Routes", () => {
       expect(data[0].averageEngagementSeconds).toBe(10);
       expect(data[1].averageEngagementSeconds).toBe(35);
       expect(data[2].averageEngagementSeconds).toBe(60);
+    });
+
+    test("deleting a post removes its PostMedia and analytics aggregate", async () => {
+      const dataSource = getTestDataSource();
+      const postMediaRepo = dataSource.getRepository(PostMedia);
+      const aggregateRepo = dataSource.getRepository(FanslyAnalyticsAggregate);
+
+      const { post, postMedia, aggregate } = await createActivePost();
+
+      // Verify records exist
+      expect(await postMediaRepo.findOne({ where: { id: postMedia.id } })).toBeTruthy();
+      expect(await aggregateRepo.findOne({ where: { id: aggregate.id } })).toBeTruthy();
+
+      // Delete via the actual deletePost operation
+      const deleted = await deletePost(post.id);
+      expect(deleted).toBe(true);
+
+      // PostMedia and aggregate should be gone
+      expect(await postMediaRepo.findOne({ where: { id: postMedia.id } })).toBeNull();
+      expect(await aggregateRepo.findOne({ where: { id: aggregate.id } })).toBeNull();
+
+      // And not in FYP queue
+      const res = await app.request("/api/analytics/active-fyp-posts");
+      const data = (await parseResponse<Array<Record<string, unknown>>>(res)) as Array<Record<string, unknown>>;
+      expect(data).toHaveLength(0);
     });
 
     test("returns empty array when no active posts", async () => {

--- a/@fanslib/apps/server/src/features/posts/operations/post/delete.ts
+++ b/@fanslib/apps/server/src/features/posts/operations/post/delete.ts
@@ -1,13 +1,31 @@
+import { In } from "typeorm";
 import { db } from "../../../../lib/db";
-import { Post } from "../../entity";
+import { FanslyAnalyticsAggregate } from "../../../analytics/entity";
+import { Post, PostMedia } from "../../entity";
 
 export const deletePost = async (id: string): Promise<boolean> => {
   const dataSource = await db();
-  const repository = dataSource.getRepository(Post);
-  const post = await repository.findOne({ where: { id } });
+  const postRepo = dataSource.getRepository(Post);
+  const postMediaRepo = dataSource.getRepository(PostMedia);
+  const aggregateRepo = dataSource.getRepository(FanslyAnalyticsAggregate);
+
+  const post = await postRepo.findOne({
+    where: { id },
+    relations: ["postMedia"],
+  });
   if (!post) {
     return false;
   }
-  await repository.delete({ id });
+
+  // Explicitly delete analytics aggregates and PostMedia before the post,
+  // rather than relying on DB-level FK cascades which may not fire in SQLite
+  // without PRAGMA foreign_keys = ON.
+  const postMediaIds = post.postMedia.map((pm) => pm.id);
+  if (postMediaIds.length > 0) {
+    await aggregateRepo.delete({ postMediaId: In(postMediaIds) });
+    await postMediaRepo.delete({ id: In(postMediaIds) });
+  }
+
+  await postRepo.delete({ id });
   return true;
 };

--- a/@fanslib/apps/server/src/lib/db.ts
+++ b/@fanslib/apps/server/src/lib/db.ts
@@ -142,6 +142,10 @@ export const db = async () => {
     const driver = await loadSqlJsDriver();
     const source = createAppDataSource(driver);
     await source.initialize();
+
+    // Enable SQLite foreign key enforcement so ON DELETE CASCADE works
+    await source.query("PRAGMA foreign_keys = ON");
+
     initialized = true;
   }
 


### PR DESCRIPTION
## Summary
- Explicitly delete analytics aggregates and PostMedia before deleting a post, instead of relying on SQLite FK cascades
- Enable `PRAGMA foreign_keys = ON` at DB initialization as a safety net
- Root cause: SQLite doesn't enforce `ON DELETE CASCADE` by default without `PRAGMA foreign_keys = ON`

## Test plan
- [x] New test: `deleting a post removes its PostMedia and analytics aggregate` — verifies cascade works end-to-end through the `deletePost` operation
- [x] Existing delete tests pass (returns 200, returns 404 for missing)
- [x] All FYP active-posts tests pass
- [x] Lint and typecheck clean

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)