### PR TITLE
feat: add refresh button to credentials status tooltip

### DIFF
--- a/@fanslib/apps/web/src/components/CredentialStatusBadge.test.tsx
+++ b/@fanslib/apps/web/src/components/CredentialStatusBadge.test.tsx
@@ -1,0 +1,44 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+
+const mockRefetch = vi.fn();
+vi.mock("~/lib/queries/settings", () => ({
+  useFanslyCredentialStatusQuery: () => ({
+    data: { status: "green", lastUpdated: Date.now() - 3600_000 },
+    isLoading: false,
+    refetch: mockRefetch,
+  }),
+}));
+
+vi.mock("~/components/ui/Tooltip", () => ({
+  Tooltip: ({
+    children,
+    content,
+  }: {
+    children: React.ReactNode;
+    content: React.ReactNode;
+    placement?: string;
+  }) => (
+    <div>
+      {children}
+      <div data-testid="tooltip-content">{content}</div>
+    </div>
+  ),
+}));
+
+import { CredentialStatusBadge } from "./CredentialStatusBadge";
+
+describe("CredentialStatusBadge", () => {
+  test("renders a refresh button in the tooltip that calls refetch", async () => {
+    const user = userEvent.setup();
+    render(<CredentialStatusBadge />);
+
+    const refreshButton = screen.getByRole("button", { name: /refresh/i });
+    expect(refreshButton).toBeInTheDocument();
+
+    await user.click(refreshButton);
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+});

--- a/@fanslib/apps/web/src/components/CredentialStatusBadge.tsx
+++ b/@fanslib/apps/web/src/components/CredentialStatusBadge.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, CheckCircle, Clock, ExternalLink, XCircle } from "lucide-react";
+import { AlertTriangle, CheckCircle, Clock, ExternalLink, RefreshCw, XCircle } from "lucide-react";
 import { useFanslyCredentialStatusQuery } from "~/lib/queries/settings";
 import { Tooltip } from "~/components/ui/Tooltip";
 
@@ -41,10 +41,12 @@ const TooltipContent = ({
   config,
   status,
   lastUpdated,
+  onRefresh,
 }: {
   config: (typeof statusConfig)[keyof typeof statusConfig];
   status: string;
   lastUpdated: number | null;
+  onRefresh: () => void;
 }) => {
   const Icon = config.icon;
 
@@ -58,6 +60,14 @@ const TooltipContent = ({
       <div className="text-base-content/50 flex items-center gap-1">
         <Clock className="h-3 w-3" />
         <span>Last refreshed: {formatAge(lastUpdated)}</span>
+        <button
+          type="button"
+          onClick={onRefresh}
+          className="ml-1 p-0.5 rounded hover:bg-base-content/10 transition-colors"
+          aria-label="Refresh credentials"
+        >
+          <RefreshCw className="h-3 w-3" />
+        </button>
       </div>
       {status === "red" && (
         <a
@@ -75,7 +85,7 @@ const TooltipContent = ({
 };
 
 export const CredentialStatusBadge = () => {
-  const { data, isLoading } = useFanslyCredentialStatusQuery();
+  const { data, isLoading, refetch } = useFanslyCredentialStatusQuery();
 
   if (isLoading || !data) return null;
 
@@ -85,7 +95,7 @@ export const CredentialStatusBadge = () => {
   return (
     <Tooltip
       content={
-        <TooltipContent config={config} status={status} lastUpdated={data.lastUpdated} />
+        <TooltipContent config={config} status={status} lastUpdated={data.lastUpdated} onRefresh={() => refetch()} />
       }
       placement="bottom"
     >


### PR DESCRIPTION
## Summary
- Add a refresh button inside the credential status tooltip, next to the "Last refreshed" text
- Clicking the button re-fetches credential status via `useFanslyCredentialStatusQuery`
- Prevents the indicator from showing stale/outdated credential state

## Test plan
- [x] New test: refresh button exists in tooltip and calls refetch when clicked
- [x] Lint clean
- [x] Typecheck clean
- [x] All tests pass

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)