### PR TITLE
fix: correct chrome extension popup title

### DIFF
--- a/@fanslib/apps/chrome-extension/popup.html
+++ b/@fanslib/apps/chrome-extension/popup.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>FansLib Queue</title>
+    <title>FansLib</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Change popup.html title from "FansLib Queue" to "FansLib"

## Test plan
- [x] Lint, typecheck, tests all pass

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)