### PR TITLE
feat: add title input to post detail page

### DIFF
--- a/@fanslib/apps/web/src/features/library/components/CreatePostDialog.tsx
+++ b/@fanslib/apps/web/src/features/library/components/CreatePostDialog.tsx
@@ -21,6 +21,7 @@ import { Textarea } from "~/components/ui/Textarea";
 import { CombinedMediaSelection } from "~/features/library/components/CombinedMediaSelection";
 import { RecentPostsPanel } from "~/features/posts/components/RecentPostsPanel";
 import { usePrefersReducedMotion } from "~/hooks/usePrefersReducedMotion";
+import { TITLE_CHANNEL_TYPES } from "~/lib/channel-types";
 import { cn } from "~/lib/cn";
 import { findNextUnfilledSlot } from "~/lib/find-next-unfilled-slot";
 import { useChannelsQuery } from "~/lib/queries/channels";
@@ -50,8 +51,6 @@ type CreatePostDialogProps = {
 };
 
 const toast = () => {};
-
-const TITLE_CHANNEL_TYPES = new Set(["manyvids", "clips4sale"]);
 
 const CAPTION_MAX_LENGTH: Record<string, number> = {
   reddit: 40000,

--- a/@fanslib/apps/web/src/features/posts/components/post-detail/PostDetailTitleInput.tsx
+++ b/@fanslib/apps/web/src/features/posts/components/post-detail/PostDetailTitleInput.tsx
@@ -1,0 +1,92 @@
+import type { PostWithRelations } from "@fanslib/server/schemas";
+import { Check, Copy } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "~/components/ui/Button";
+import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import { useDebounce } from "~/hooks/useDebounce";
+import { useUpdatePostMutation } from "~/lib/queries/posts";
+
+type PostDetailTitleInputProps = {
+  post: PostWithRelations;
+};
+
+export const PostDetailTitleInput = ({ post }: PostDetailTitleInputProps) => {
+  const [localTitle, setLocalTitle] = useState(post.title ?? "");
+  const [isSaving, setIsSaving] = useState(false);
+  const { isCopied, copy } = useCopyToClipboard();
+  const updatePostMutation = useUpdatePostMutation();
+
+  useEffect(() => {
+    setLocalTitle(post.title ?? "");
+  }, [post.id, post.title]);
+
+  const saveTitle = async (title: string) => {
+    setIsSaving(true);
+    try {
+      await updatePostMutation.mutateAsync({
+        id: post.id,
+        updates: {
+          title: title.trim() || null,
+        },
+      });
+    } catch (error) {
+      console.error("Failed to update title:", error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const debouncedSaveTitle = useDebounce(saveTitle, 1000);
+
+  const updateTitle = (newTitle: string) => {
+    setLocalTitle(newTitle);
+    debouncedSaveTitle(newTitle);
+  };
+
+  const copyCurrentTitle = () => {
+    copy(localTitle);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <label htmlFor="post-title" className="text-sm font-medium">
+          Title
+        </label>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={copyCurrentTitle}
+          isDisabled={!localTitle.trim()}
+        >
+          {isCopied ? (
+            <>
+              <Check className="h-3 w-3 mr-1" />
+              Copied
+            </>
+          ) : (
+            <>
+              <Copy className="h-3 w-3 mr-1" />
+              Copy
+            </>
+          )}
+        </Button>
+      </div>
+      <div className="relative">
+        <input
+          id="post-title"
+          type="text"
+          placeholder="Add a title..."
+          value={localTitle}
+          onChange={(e) => updateTitle(e.target.value)}
+          className="input input-bordered w-full"
+        />
+        {isSaving && (
+          <div className="absolute right-2 top-1/2 -translate-y-1/2 bg-base-100 p-1 rounded text-xs">
+            Saving...
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/lib/channel-types.ts
+++ b/@fanslib/apps/web/src/lib/channel-types.ts
@@ -47,3 +47,5 @@ export const CHANNEL_TYPES = {
 } as const;
 
 export type ChannelTypeId = keyof typeof CHANNEL_TYPES;
+
+export const TITLE_CHANNEL_TYPES = new Set<string>(["manyvids", "clips4sale"]);

--- a/@fanslib/apps/web/src/routes/posts/$postId.tsx
+++ b/@fanslib/apps/web/src/routes/posts/$postId.tsx
@@ -6,6 +6,7 @@ import { ChannelBadge } from "~/components/ChannelBadge";
 import { Button } from "~/components/ui/Button";
 import { MediaDragProvider } from "~/contexts/MediaDragContext";
 import { PostDetailCaptionInput } from "~/features/posts/components/post-detail/PostDetailCaptionInput";
+import { PostDetailTitleInput } from "~/features/posts/components/post-detail/PostDetailTitleInput";
 import { PostDetailDateTimeInputs } from "~/features/posts/components/post-detail/PostDetailDateTimeInputs";
 import { PostDetailAnalytics } from "~/features/posts/components/post-detail/PostDetailAnalytics";
 import { PostDetailMedia } from "~/features/posts/components/post-detail/PostDetailMedia";
@@ -15,6 +16,7 @@ import { PostDetailScheduleSelect } from "~/features/posts/components/post-detai
 import { PostDetailStatusButtons } from "~/features/posts/components/post-detail/PostDetailStatusButtons";
 import { PostDetailTemporalContext } from "~/features/posts/components/post-detail/PostDetailTemporalContext";
 import { PostDetailUrlInput } from "~/features/posts/components/post-detail/PostDetailUrlInput";
+import { TITLE_CHANNEL_TYPES } from "~/lib/channel-types";
 import { usePostQuery } from "~/lib/queries/posts";
 
 type Post = PostWithRelations;
@@ -94,6 +96,9 @@ const PostDetailRoute = () => {
               <PostDetailScheduleSelect post={normalizedPost} />
               <PostDetailDateTimeInputs post={normalizedPost} />
               <PostDetailUrlInput post={normalizedPost} />
+              {TITLE_CHANNEL_TYPES.has(normalizedPost.channel.type.id) && (
+                <PostDetailTitleInput post={normalizedPost} />
+              )}
               <PostDetailCaptionInput post={normalizedPost} />
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Add `PostDetailTitleInput` component with debounced auto-save, copy-to-clipboard, and "Saving..." indicator
- Conditionally render title input above caption on post detail page for ManyVids/Clips4Sale channels
- Extract `TITLE_CHANNEL_TYPES` to shared `~/lib/channel-types.ts` module (used by both CreatePostDialog and post detail)

Closes #174

## Test plan

- [x] Typecheck clean
- [x] Lint clean
- [x] All post route tests pass (19/19)
- [ ] Manual: verify title input appears on ManyVids/Clips4Sale post detail pages
- [ ] Manual: verify title input is hidden for other channel types
- [ ] Manual: verify debounced auto-save and copy button work

🤖 Generated with [Claude Code](https://claude.com/claude-code)