### PR TITLE
feat: add title input to caption queue with sync

### DIFF
--- a/@fanslib/apps/web/src/features/pipeline/components/CaptioningStep/CaptionItem.tsx
+++ b/@fanslib/apps/web/src/features/pipeline/components/CaptioningStep/CaptionItem.tsx
@@ -22,6 +22,7 @@ import {
 } from "~/components/ui/DropdownMenu";
 import { useDebounce } from "~/hooks/useDebounce";
 import { usePrefersReducedMotion } from "~/hooks/usePrefersReducedMotion";
+import { TITLE_CHANNEL_TYPES } from "~/lib/channel-types";
 import { cn } from "~/lib/cn";
 import { api } from "~/lib/api/hono-client";
 import { useDeletePostMutation, useUpdatePostMutation } from "~/lib/queries/posts";
@@ -47,6 +48,7 @@ export const CaptionItem = ({ item, isExpanded, onExpand, onAdvance }: CaptionIt
   const updatePostMutation = useUpdatePostMutation();
   const deletePostMutation = useDeletePostMutation();
   const [localCaption, setLocalCaption] = useState(item.post.caption ?? "");
+  const [localTitle, setLocalTitle] = useState(item.post.title ?? "");
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
   const postMedia = item.post.postMedia ?? [];
@@ -74,7 +76,8 @@ export const CaptionItem = ({ item, isExpanded, onExpand, onAdvance }: CaptionIt
 
   useEffect(() => {
     setLocalCaption(item.post.caption ?? "");
-  }, [item.post.id, item.post.caption]);
+    setLocalTitle(item.post.title ?? "");
+  }, [item.post.id, item.post.caption, item.post.title]);
 
   useEffect(() => {
     setSelectedLinkedPostIds(linkedPostIds);
@@ -95,13 +98,16 @@ export const CaptionItem = ({ item, isExpanded, onExpand, onAdvance }: CaptionIt
 
   const isLinkedToExpanded = linkedPostIdsForExpanded.has(item.post.id);
 
-  const saveCaption = useCallback(
-    async (caption: string, syncToPostIds: string[]) => {
+  const showTitleInput = TITLE_CHANNEL_TYPES.has(item.post.channel.type.id);
+
+  const saveCaptionAndTitle = useCallback(
+    async (caption: string, title: string, syncToPostIds: string[]) => {
       try {
         await updatePostMutation.mutateAsync({
           id: item.post.id,
           updates: {
             caption: caption.trim() || null,
+            title: title.trim() || null,
             syncToPostIds: syncToPostIds.length > 0 ? syncToPostIds : undefined,
           },
         });
@@ -112,17 +118,23 @@ export const CaptionItem = ({ item, isExpanded, onExpand, onAdvance }: CaptionIt
     [item.post.id, updatePostMutation],
   );
 
-  const debouncedSaveCaption = useDebounce(saveCaption, 1000);
+  const debouncedSave = useDebounce(saveCaptionAndTitle, 1000);
 
   const updateCaption = (nextCaption: string) => {
     setLocalCaption(nextCaption);
-    debouncedSaveCaption(nextCaption, selectedLinkedPostIds);
+    debouncedSave(nextCaption, localTitle, selectedLinkedPostIds);
+  };
+
+  const updateTitle = (nextTitle: string) => {
+    setLocalTitle(nextTitle);
+    debouncedSave(localCaption, nextTitle, selectedLinkedPostIds);
   };
 
   const saveAndAdvance = async () => {
     const status = getCompletionStatus(item.post.channel.type.id);
     const updates = {
       caption: localCaption.trim() ? localCaption.trim() : null,
+      title: localTitle.trim() ? localTitle.trim() : null,
       status,
       syncToPostIds: selectedLinkedPostIds.length > 0 ? selectedLinkedPostIds : undefined,
     };
@@ -304,6 +316,18 @@ export const CaptionItem = ({ item, isExpanded, onExpand, onAdvance }: CaptionIt
                           </div>
                         );
                       })}
+                    </div>
+                  )}
+                  {showTitleInput && (
+                    <div className="flex flex-col gap-1">
+                      <label className="text-sm font-medium">Title</label>
+                      <input
+                        type="text"
+                        value={localTitle}
+                        onChange={(e) => updateTitle(e.target.value)}
+                        placeholder="Add a title..."
+                        className="input input-bordered w-full input-sm"
+                      />
                     </div>
                   )}
                   <div className="relative">

--- a/@fanslib/apps/web/src/lib/channel-types.ts
+++ b/@fanslib/apps/web/src/lib/channel-types.ts
@@ -47,3 +47,5 @@ export const CHANNEL_TYPES = {
 } as const;
 
 export type ChannelTypeId = keyof typeof CHANNEL_TYPES;
+
+export const TITLE_CHANNEL_TYPES = new Set<string>(["manyvids", "clips4sale"]);


### PR DESCRIPTION
## Summary

- Add title input above caption textarea in `CaptionItem` for ManyVids/Clips4Sale channels
- Title is included in debounced auto-save (alongside caption)
- "Save & Next" persists title alongside caption and status
- Title syncs to linked posts via existing `syncToPostIds` mechanism
- Add `TITLE_CHANNEL_TYPES` to shared `~/lib/channel-types.ts`

Closes #175

## Test plan

- [x] Typecheck clean
- [x] Lint clean
- [x] All post route tests pass (19/19)
- [ ] Manual: verify title input appears in caption queue for ManyVids/Clips4Sale posts
- [ ] Manual: verify title is hidden for other channel types
- [ ] Manual: verify debounced auto-save includes title
- [ ] Manual: verify Save & Next persists title
- [ ] Manual: verify title syncs to linked posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)