### PR TITLE
feat: include title in post search

### DIFF
--- a/@fanslib/apps/server/src/features/posts/operations/post/fetch-all.ts
+++ b/@fanslib/apps/server/src/features/posts/operations/post/fetch-all.ts
@@ -34,7 +34,7 @@ export const fetchAllPosts = async (
     .leftJoinAndSelect("post.schedule", "schedule");
 
   if (filters?.search) {
-    queryBuilder.andWhere("(post.caption LIKE :search OR channel.name LIKE :search)", {
+    queryBuilder.andWhere("(post.caption LIKE :search OR post.title LIKE :search OR channel.name LIKE :search)", {
       search: `%${filters.search}%`,
     });
   }

--- a/@fanslib/apps/server/src/features/posts/routes.test.ts
+++ b/@fanslib/apps/server/src/features/posts/routes.test.ts
@@ -62,6 +62,45 @@ describe("Posts Routes", () => {
         expect(post.status).toBe("draft");
       });
     });
+
+    test("search matches against post caption", async () => {
+      const filters = JSON.stringify({ search: "amazing content" });
+      const response = await app.request(`/api/posts/all?filters=${encodeURIComponent(filters)}`);
+      const data = await parseResponse<{ posts: Post[] }>(response);
+
+      expect(data?.posts?.length).toBeGreaterThanOrEqual(1);
+      expect(data?.posts?.some((p: Post) => p.caption?.includes("amazing content"))).toBe(true);
+    });
+
+    test("search matches against post title", async () => {
+      const channel = fixtures.channels.channels.find((c) => c.typeId === "manyvids");
+      if (!channel) {
+        throw new Error("No manyvids channel fixture available");
+      }
+
+      // Create a post with a unique title
+      const createResponse = await app.request("/api/posts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "UniqueSearchableTitle",
+          caption: "Some unrelated caption",
+          status: "draft" as const,
+          channelId: channel.id,
+          date: new Date().toISOString(),
+          mediaIds: [],
+        }),
+      });
+      expect(createResponse.status).toBe(200);
+
+      // Search for the title
+      const filters = JSON.stringify({ search: "UniqueSearchableTitle" });
+      const response = await app.request(`/api/posts/all?filters=${encodeURIComponent(filters)}`);
+      const data = await parseResponse<{ posts: Post[] }>(response);
+
+      expect(data?.posts?.length).toBeGreaterThanOrEqual(1);
+      expect(data?.posts?.some((p: Post) => p.title === "UniqueSearchableTitle")).toBe(true);
+    });
   });
 
   describe("GET /api/posts/by-id/:id", () => {


### PR DESCRIPTION
## Summary

- Add `post.title` to the search LIKE query in `fetchAllPosts`, alongside existing `post.caption` and `channel.name` matching
- Add tests: search by title returns matching post, search by caption still works

Closes #176

## Test plan

- [x] New test: search by title returns matching post
- [x] New test: search by caption still works (existing behavior)
- [x] All 21 post route tests pass
- [x] Lint clean
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)