### PR TITLE
refactor: extract CreatePostDialog into subcomponents and hooks

### DIFF
--- a/@fanslib/apps/web/src/features/library/components/CreatePostDialog/CreatePostActions.tsx
+++ b/@fanslib/apps/web/src/features/library/components/CreatePostDialog/CreatePostActions.tsx
@@ -1,0 +1,88 @@
+import { Link } from "@tanstack/react-router";
+import { Button } from "~/components/ui/Button";
+import { cn } from "~/lib/cn";
+import type { VirtualPost } from "~/lib/virtual-posts";
+
+type CreatePostActionsProps = {
+  scheduleId?: string;
+  selectedMediaCount: number;
+  disabled: boolean;
+  confirmSkip: boolean;
+  virtualPost?: VirtualPost;
+  onNavigateToSlot?: (post: VirtualPost) => void;
+  onSkipSlot: () => void;
+  onConfirmSkipLeave: () => void;
+  onCreatePost: (shouldNavigateToNext: boolean) => void;
+  onClose: () => void;
+};
+
+export const CreatePostActions = ({
+  scheduleId,
+  selectedMediaCount,
+  disabled,
+  confirmSkip,
+  virtualPost,
+  onNavigateToSlot,
+  onSkipSlot,
+  onConfirmSkipLeave,
+  onCreatePost,
+  onClose,
+}: CreatePostActionsProps) => (
+  <div className="flex flex-col gap-2 flex-shrink-0 mt-2">
+    <div className="flex gap-2 w-full">
+      {scheduleId && selectedMediaCount === 0 && (
+        <Button
+          variant="ghost"
+          onPress={onSkipSlot}
+          className="flex-1"
+          onMouseLeave={onConfirmSkipLeave}
+        >
+          {confirmSkip ? "Click again to confirm skip" : "Skip This Slot"}
+        </Button>
+      )}
+      {virtualPost && onNavigateToSlot ? (
+        <>
+          <Button
+            onPress={() => {
+              onCreatePost(false);
+              onClose();
+            }}
+            className="flex-1"
+            isDisabled={disabled}
+          >
+            Create Post
+          </Button>
+          <Button
+            onPress={() => {
+              onCreatePost(true);
+            }}
+            className="flex-1"
+            isDisabled={disabled}
+          >
+            Create & Next
+          </Button>
+        </>
+      ) : (
+        <Button
+          onPress={() => {
+            onCreatePost(false);
+            onClose();
+          }}
+          className={cn(scheduleId && selectedMediaCount === 0 ? "flex-1" : "w-full")}
+          isDisabled={disabled}
+        >
+          Create post
+        </Button>
+      )}
+    </div>
+    {virtualPost && (
+      <Link
+        to="/content/library"
+        className="text-sm text-center text-base-content/60 hover:text-base-content underline"
+        onClick={onClose}
+      >
+        Browse Full Library
+      </Link>
+    )}
+  </div>
+);

--- a/@fanslib/apps/web/src/features/library/components/CreatePostDialog/OtherCaptionsSection.tsx
+++ b/@fanslib/apps/web/src/features/library/components/CreatePostDialog/OtherCaptionsSection.tsx
@@ -1,0 +1,68 @@
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChannelBadge } from "~/components/ChannelBadge";
+import { Button } from "~/components/ui/Button";
+import { ScrollArea } from "~/components/ui/ScrollArea";
+
+type OtherCaption = {
+  caption?: string | null;
+  channel?: { id?: string; name?: string; typeId?: string } | null;
+};
+
+type OtherCaptionsSectionProps = {
+  otherCaptions: OtherCaption[];
+  isOpen: boolean;
+  onToggle: () => void;
+  onUseCaption: (caption: string) => void;
+};
+
+export const OtherCaptionsSection = ({
+  otherCaptions,
+  isOpen,
+  onToggle,
+  onUseCaption,
+}: OtherCaptionsSectionProps) => {
+  if (otherCaptions.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="flex w-full items-center justify-between p-2 text-sm font-medium"
+        onPress={onToggle}
+      >
+        Captions from other posts using this media
+        {isOpen ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+      </Button>
+      {isOpen && (
+        <ScrollArea className="h-[200px] rounded-md border p-2">
+          <div className="space-y-2">
+            {otherCaptions.map((otherCaption) =>
+              !otherCaption?.caption ? null : (
+                <div
+                  key={otherCaption.channel?.id ?? otherCaption.caption}
+                  className="group relative min-h-8 flex flex-col rounded-md border p-2"
+                >
+                  <ChannelBadge
+                    className="self-start"
+                    name={otherCaption.channel?.name ?? ""}
+                    typeId={otherCaption.channel?.typeId ?? ""}
+                  />
+                  <p className="text-sm pt-2">{otherCaption.caption}</p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="absolute right-2 top-1 opacity-0 group-hover:opacity-100"
+                    onPress={() => onUseCaption(otherCaption.caption ?? "")}
+                  >
+                    Use
+                  </Button>
+                </div>
+              ),
+            )}
+          </div>
+        </ScrollArea>
+      )}
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/features/library/components/CreatePostDialog/VirtualPostHeader.tsx
+++ b/@fanslib/apps/web/src/features/library/components/CreatePostDialog/VirtualPostHeader.tsx
@@ -1,0 +1,40 @@
+import { format } from "date-fns";
+import { ChannelBadge } from "~/components/ChannelBadge";
+import { ContentScheduleBadge } from "~/components/ContentScheduleBadge";
+import type { VirtualPost } from "~/lib/virtual-posts";
+
+type VirtualPostHeaderProps = {
+  virtualPost: VirtualPost;
+};
+
+export const VirtualPostHeader = ({ virtualPost }: VirtualPostHeaderProps) => (
+  <div className="flex flex-col gap-2">
+    <div className="flex items-start justify-between">
+      <div className="flex flex-col gap-1">
+        <h2 className="font-bold text-lg">
+          {format(new Date(virtualPost.date), "EEEE, MMMM d")}
+        </h2>
+        <div className="text-sm text-base-content/60 font-medium">
+          {format(new Date(virtualPost.date), "h:mm a")}
+        </div>
+      </div>
+    </div>
+    <div className="flex items-center gap-1">
+      <ChannelBadge
+        name={virtualPost.channel.name}
+        typeId={virtualPost.channel.type?.id ?? virtualPost.channel.typeId}
+        size="sm"
+        borderStyle="visible"
+      />
+      {virtualPost.schedule && (
+        <ContentScheduleBadge
+          name={virtualPost.schedule.name}
+          emoji={virtualPost.schedule.emoji ?? undefined}
+          color={virtualPost.schedule.color ?? undefined}
+          size="sm"
+          borderStyle="visible"
+        />
+      )}
+    </div>
+  </div>
+);

--- a/@fanslib/apps/web/src/features/library/components/CreatePostDialog/index.tsx
+++ b/@fanslib/apps/web/src/features/library/components/CreatePostDialog/index.tsx
@@ -1,12 +1,9 @@
 import type { Media, PostStatus, PostWithRelations } from "@fanslib/server/schemas";
-import { Link, useNavigate } from "@tanstack/react-router";
-import { format } from "date-fns";
+import { useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
-import { ChevronDown, ChevronUp, X } from "lucide-react";
+import { X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ChannelBadge } from "~/components/ChannelBadge";
 import { ChannelSelect } from "~/components/ChannelSelect";
-import { ContentScheduleBadge } from "~/components/ContentScheduleBadge";
 import { ContentScheduleSelect } from "~/components/ContentScheduleSelect";
 import { DateTimePicker } from "~/components/DateTimePicker";
 import { HashtagButton } from "~/components/HashtagButton";
@@ -30,6 +27,11 @@ import {
 } from "~/lib/queries/content-schedules";
 import { useCreatePostMutation } from "~/lib/queries/posts";
 import type { VirtualPost } from "~/lib/virtual-posts";
+
+import { CreatePostActions } from "./CreatePostActions";
+import { OtherCaptionsSection } from "./OtherCaptionsSection";
+import { useResetOnOpen } from "./useResetOnOpen";
+import { VirtualPostHeader } from "./VirtualPostHeader";
 
 type CreatePostDialogProps = {
   open: boolean;
@@ -85,33 +87,41 @@ export const CreatePostDialog = ({
   const [confirmSkip, setConfirmSkip] = useState(false);
   const prefersReducedMotion = usePrefersReducedMotion();
   const [showContent, setShowContent] = useState(false);
-
-  const [selectedChannel, setSelectedChannel] = useState<string[]>([]);
-  const [selectedSubreddits, setSelectedSubreddits] = useState<string[]>(
-    initialSubredditId ? [initialSubredditId] : [],
-  );
-  const [contentScheduleId, setContentScheduleId] = useState<string | null>(scheduleId ?? null);
-
-  const { data: contentSchedule } = useContentScheduleQuery(contentScheduleId ?? "");
-
-  const [selectedDate, setSelectedDate] = useState<Date>(() => {
-    if (initialDate) {
-      return new Date(initialDate);
-    }
-    const defaultDate = new Date();
-    defaultDate.setHours(12);
-    defaultDate.setMinutes(0);
-    defaultDate.setSeconds(0);
-    defaultDate.setMilliseconds(0);
-    return defaultDate;
-  });
-  const [status, setStatus] = useState<PostStatus>(initialStatus ?? "draft");
-  const [selectedMedia, setSelectedMedia] = useState<Media[]>(media);
-  const [caption, setCaption] = useState(initialCaption ?? "");
   const [isOtherCaptionsOpen, setIsOtherCaptionsOpen] = useState(false);
-  const [shouldRedirect, setShouldRedirect] = useState(initialShouldRedirect);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const {
+    selectedMedia,
+    setSelectedMedia,
+    caption,
+    setCaption,
+    selectedChannel,
+    setSelectedChannel,
+    selectedDate,
+    setSelectedDate,
+    status,
+    setStatus,
+    selectedSubreddits,
+    setSelectedSubreddits,
+    contentScheduleId,
+    setContentScheduleId,
+    shouldRedirect,
+    setShouldRedirect,
+  } = useResetOnOpen({
+    open,
+    media,
+    initialCaption,
+    initialChannelId,
+    initialDate,
+    initialStatus,
+    initialSubredditId,
+    initialShouldRedirect,
+    scheduleId,
+    channels,
+  });
+
+  const { data: contentSchedule } = useContentScheduleQuery(contentScheduleId ?? "");
 
   const otherCaptions = useMemo<
     Array<{
@@ -133,61 +143,6 @@ export const CreatePostDialog = ({
     selectedChannel.length === 0 ||
     selectedMedia.length === 0 ||
     (channelCaptionMaxLength !== Infinity && caption?.length >= channelCaptionMaxLength);
-
-  useEffect(() => {
-    if (!open) return;
-    setSelectedMedia(media);
-  }, [open, media]);
-
-  useEffect(() => {
-    if (!open) return;
-    setCaption(initialCaption ?? "");
-  }, [open, initialCaption]);
-
-  useEffect(() => {
-    if (!open) return;
-    if (initialChannelId) {
-      setSelectedChannel([initialChannelId]);
-    } else if (!channels?.length || channels.length > 1) {
-      setSelectedChannel([]);
-    } else {
-      setSelectedChannel([channels[0]?.id ?? ""]);
-    }
-  }, [channels, initialChannelId, open]);
-
-  useEffect(() => {
-    if (!open) return;
-    if (initialDate) {
-      setSelectedDate(new Date(initialDate));
-    } else {
-      const defaultDate = new Date();
-      defaultDate.setHours(12);
-      defaultDate.setMinutes(0);
-      defaultDate.setSeconds(0);
-      defaultDate.setMilliseconds(0);
-      setSelectedDate(defaultDate);
-    }
-  }, [open, initialDate]);
-
-  useEffect(() => {
-    if (!open) return;
-    setContentScheduleId(scheduleId ?? null);
-  }, [open, scheduleId]);
-
-  useEffect(() => {
-    if (!open) return;
-    setSelectedSubreddits(initialSubredditId ? [initialSubredditId] : []);
-  }, [open, initialSubredditId]);
-
-  useEffect(() => {
-    if (!open) return;
-    setStatus(initialStatus ?? "draft");
-  }, [open, initialStatus]);
-
-  useEffect(() => {
-    if (!open) return;
-    setShouldRedirect(initialShouldRedirect);
-  }, [open, initialShouldRedirect]);
 
   useEffect(() => {
     if (!isRedditChannel) {
@@ -443,35 +398,7 @@ export const CreatePostDialog = ({
             >
               <div className="flex-shrink-0 mb-2">
                 {virtualPost ? (
-                  <div className="flex flex-col gap-2">
-                    <div className="flex items-start justify-between">
-                      <div className="flex flex-col gap-1">
-                        <h2 className="font-bold text-lg">
-                          {format(new Date(virtualPost.date), "EEEE, MMMM d")}
-                        </h2>
-                        <div className="text-sm text-base-content/60 font-medium">
-                          {format(new Date(virtualPost.date), "h:mm a")}
-                        </div>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <ChannelBadge
-                        name={virtualPost.channel.name}
-                        typeId={virtualPost.channel.type?.id ?? virtualPost.channel.typeId}
-                        size="sm"
-                        borderStyle="visible"
-                      />
-                      {virtualPost.schedule && (
-                        <ContentScheduleBadge
-                          name={virtualPost.schedule.name}
-                          emoji={virtualPost.schedule.emoji ?? undefined}
-                          color={virtualPost.schedule.color ?? undefined}
-                          size="sm"
-                          borderStyle="visible"
-                        />
-                      )}
-                    </div>
-                  </div>
+                  <VirtualPostHeader virtualPost={virtualPost} />
                 ) : (
                   <h2 className="font-bold text-lg">{title}</h2>
                 )}
@@ -598,52 +525,12 @@ export const CreatePostDialog = ({
                         </div>
                       </div>
                     </div>
-                    {otherCaptions.length > 0 && (
-                      <div className="flex flex-col gap-2">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="flex w-full items-center justify-between p-2 text-sm font-medium"
-                          onPress={() => setIsOtherCaptionsOpen(!isOtherCaptionsOpen)}
-                        >
-                          Captions from other posts using this media
-                          {isOtherCaptionsOpen ? (
-                            <ChevronUp className="h-4 w-4" />
-                          ) : (
-                            <ChevronDown className="h-4 w-4" />
-                          )}
-                        </Button>
-                        {isOtherCaptionsOpen && (
-                          <ScrollArea className="h-[200px] rounded-md border p-2">
-                            <div className="space-y-2">
-                              {otherCaptions.map((otherCaption) =>
-                                !otherCaption?.caption ? null : (
-                                  <div
-                                    key={otherCaption.channel?.id ?? otherCaption.caption}
-                                    className="group relative min-h-8 flex flex-col rounded-md border p-2"
-                                  >
-                                    <ChannelBadge
-                                      className="self-start"
-                                      name={otherCaption.channel?.name ?? ""}
-                                      typeId={otherCaption.channel?.typeId ?? ""}
-                                    />
-                                    <p className="text-sm pt-2">{otherCaption.caption}</p>
-                                    <Button
-                                      variant="outline"
-                                      size="sm"
-                                      className="absolute right-2 top-1 opacity-0 group-hover:opacity-100"
-                                      onPress={() => setCaption(otherCaption.caption ?? "")}
-                                    >
-                                      Use
-                                    </Button>
-                                  </div>
-                                ),
-                              )}
-                            </div>
-                          </ScrollArea>
-                        )}
-                      </div>
-                    )}
+                    <OtherCaptionsSection
+                      otherCaptions={otherCaptions}
+                      isOpen={isOtherCaptionsOpen}
+                      onToggle={() => setIsOtherCaptionsOpen(!isOtherCaptionsOpen)}
+                      onUseCaption={setCaption}
+                    />
                   </div>
                 </div>
               </ScrollArea>
@@ -658,63 +545,18 @@ export const CreatePostDialog = ({
                 </Checkbox>
               </div>
 
-              <div className="flex flex-col gap-2 flex-shrink-0 mt-2">
-                <div className="flex gap-2 w-full">
-                  {scheduleId && selectedMedia.length === 0 && (
-                    <Button
-                      variant="ghost"
-                      onPress={handleSkipSlot}
-                      className="flex-1"
-                      onMouseLeave={() => setConfirmSkip(false)}
-                    >
-                      {confirmSkip ? "Click again to confirm skip" : "Skip This Slot"}
-                    </Button>
-                  )}
-                  {virtualPost && onNavigateToSlot ? (
-                    <>
-                      <Button
-                        onPress={() => {
-                          handleCreatePost(false);
-                          onOpenChange(false);
-                        }}
-                        className="flex-1"
-                        isDisabled={disabled}
-                      >
-                        Create Post
-                      </Button>
-                      <Button
-                        onPress={() => {
-                          handleCreatePost(true);
-                        }}
-                        className="flex-1"
-                        isDisabled={disabled}
-                      >
-                        Create & Next
-                      </Button>
-                    </>
-                  ) : (
-                    <Button
-                      onPress={() => {
-                        handleCreatePost(false);
-                        onOpenChange(false);
-                      }}
-                      className={cn(scheduleId && selectedMedia.length === 0 ? "flex-1" : "w-full")}
-                      isDisabled={disabled}
-                    >
-                      Create post
-                    </Button>
-                  )}
-                </div>
-                {virtualPost && (
-                  <Link
-                    to="/content/library"
-                    className="text-sm text-center text-base-content/60 hover:text-base-content underline"
-                    onClick={() => onOpenChange(false)}
-                  >
-                    Browse Full Library
-                  </Link>
-                )}
-              </div>
+              <CreatePostActions
+                scheduleId={scheduleId}
+                selectedMediaCount={selectedMedia.length}
+                disabled={disabled}
+                confirmSkip={confirmSkip}
+                virtualPost={virtualPost}
+                onNavigateToSlot={onNavigateToSlot}
+                onSkipSlot={handleSkipSlot}
+                onConfirmSkipLeave={() => setConfirmSkip(false)}
+                onCreatePost={handleCreatePost}
+                onClose={() => onOpenChange(false)}
+              />
             </motion.div>
           </motion.div>
         </>

--- a/@fanslib/apps/web/src/features/library/components/CreatePostDialog/useResetOnOpen.ts
+++ b/@fanslib/apps/web/src/features/library/components/CreatePostDialog/useResetOnOpen.ts
@@ -1,0 +1,123 @@
+import type { Media, PostStatus } from "@fanslib/server/schemas";
+import { useEffect, useState } from "react";
+
+type UseResetOnOpenParams = {
+  open: boolean;
+  media: Media[];
+  initialCaption?: string;
+  initialChannelId?: string;
+  initialDate?: Date;
+  initialStatus?: PostStatus;
+  initialSubredditId?: string;
+  initialShouldRedirect: boolean;
+  scheduleId?: string;
+  channels: Array<{ id: string }>;
+};
+
+export const useResetOnOpen = ({
+  open,
+  media,
+  initialCaption,
+  initialChannelId,
+  initialDate,
+  initialStatus,
+  initialSubredditId,
+  initialShouldRedirect,
+  scheduleId,
+  channels,
+}: UseResetOnOpenParams) => {
+  const [selectedMedia, setSelectedMedia] = useState<Media[]>(media);
+  const [caption, setCaption] = useState(initialCaption ?? "");
+  const [selectedChannel, setSelectedChannel] = useState<string[]>([]);
+  const [selectedDate, setSelectedDate] = useState<Date>(() => {
+    if (initialDate) {
+      return new Date(initialDate);
+    }
+    const defaultDate = new Date();
+    defaultDate.setHours(12);
+    defaultDate.setMinutes(0);
+    defaultDate.setSeconds(0);
+    defaultDate.setMilliseconds(0);
+    return defaultDate;
+  });
+  const [status, setStatus] = useState<PostStatus>(initialStatus ?? "draft");
+  const [selectedSubreddits, setSelectedSubreddits] = useState<string[]>(
+    initialSubredditId ? [initialSubredditId] : [],
+  );
+  const [contentScheduleId, setContentScheduleId] = useState<string | null>(scheduleId ?? null);
+  const [shouldRedirect, setShouldRedirect] = useState(initialShouldRedirect);
+
+  useEffect(() => {
+    if (!open) return;
+    setSelectedMedia(media);
+  }, [open, media]);
+
+  useEffect(() => {
+    if (!open) return;
+    setCaption(initialCaption ?? "");
+  }, [open, initialCaption]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (initialChannelId) {
+      setSelectedChannel([initialChannelId]);
+    } else if (!channels?.length || channels.length > 1) {
+      setSelectedChannel([]);
+    } else {
+      setSelectedChannel([channels[0]?.id ?? ""]);
+    }
+  }, [channels, initialChannelId, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (initialDate) {
+      setSelectedDate(new Date(initialDate));
+    } else {
+      const defaultDate = new Date();
+      defaultDate.setHours(12);
+      defaultDate.setMinutes(0);
+      defaultDate.setSeconds(0);
+      defaultDate.setMilliseconds(0);
+      setSelectedDate(defaultDate);
+    }
+  }, [open, initialDate]);
+
+  useEffect(() => {
+    if (!open) return;
+    setContentScheduleId(scheduleId ?? null);
+  }, [open, scheduleId]);
+
+  useEffect(() => {
+    if (!open) return;
+    setSelectedSubreddits(initialSubredditId ? [initialSubredditId] : []);
+  }, [open, initialSubredditId]);
+
+  useEffect(() => {
+    if (!open) return;
+    setStatus(initialStatus ?? "draft");
+  }, [open, initialStatus]);
+
+  useEffect(() => {
+    if (!open) return;
+    setShouldRedirect(initialShouldRedirect);
+  }, [open, initialShouldRedirect]);
+
+  return {
+    selectedMedia,
+    setSelectedMedia,
+    caption,
+    setCaption,
+    selectedChannel,
+    setSelectedChannel,
+    selectedDate,
+    setSelectedDate,
+    status,
+    setStatus,
+    selectedSubreddits,
+    setSelectedSubreddits,
+    contentScheduleId,
+    setContentScheduleId,
+    shouldRedirect,
+    setShouldRedirect,
+  };
+};


### PR DESCRIPTION
## Summary

- Split 724-line `CreatePostDialog.tsx` into focused modules:
  - `VirtualPostHeader.tsx` — date/channel/schedule header for virtual posts
  - `OtherCaptionsSection.tsx` — collapsible captions from other posts
  - `CreatePostActions.tsx` — bottom action bar (skip, create, create & next)
  - `useResetOnOpen.ts` — consolidates 7 identical reset `useEffect` blocks
  - `index.tsx` — orchestrator, re-exports `CreatePostDialog`
- No behavior changes, no interface changes
- All 10 consuming files continue to import unchanged

Closes #178

## Test plan

- [x] Typecheck clean
- [x] Lint clean
- [ ] Manual: verify CreatePostDialog behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)