### PR TITLE
refactor: extract CombinedMediaSelection drag/click handlers

### DIFF
--- a/@fanslib/apps/web/src/features/library/components/CombinedMediaSelection/CombinedMediaSelection.tsx
+++ b/@fanslib/apps/web/src/features/library/components/CombinedMediaSelection/CombinedMediaSelection.tsx
@@ -1,5 +1,5 @@
 import type { Media, MediaFilter } from "@fanslib/server/schemas";
-import { Check, ChevronLeftIcon, ChevronRightIcon, GripVertical } from "lucide-react";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { MediaFilterSummary } from "~/components/MediaFilterSummary";
 import { Button } from "~/components/ui/Button";
@@ -7,9 +7,11 @@ import { ScrollArea } from "~/components/ui/ScrollArea";
 import { FilterPresetProvider } from "~/contexts/FilterPresetContext";
 import { cn } from "~/lib/cn";
 import { useBulkMediaPostingHistoryQuery, useMediaListQuery } from "~/lib/queries/library";
-import { MediaFilters } from "./MediaFilters/MediaFilters";
-import { MediaFiltersProvider } from "./MediaFilters/MediaFiltersContext";
-import { MediaTileLite } from "./MediaTile/MediaTileLite";
+import { MediaFilters } from "../MediaFilters/MediaFilters";
+import { MediaFiltersProvider } from "../MediaFilters/MediaFiltersContext";
+import { MediaSelectionGrid } from "./MediaSelectionGrid";
+import { useMediaClickSelection } from "./useMediaClickSelection";
+import { useMediaDragReorder } from "./useMediaDragReorder";
 
 type MediaFilterType = MediaFilter;
 
@@ -41,9 +43,6 @@ export const CombinedMediaSelection = ({
   const [activePreviewId, setActivePreviewId] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [userFilters, setUserFilters] = useState<MediaFilterType>([]);
-  const [draggedItem, setDraggedItem] = useState<Media | null>(null);
-  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
-  const [lastClickedIndex, setLastClickedIndex] = useState<number | null>(null);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
   // Reset user filters when panel closes
@@ -111,97 +110,20 @@ export const CombinedMediaSelection = ({
 
   const isSelected = (mediaId: string) => selectedMedia.some((m) => m.id === mediaId);
 
-  const handleDragStart = (e: React.DragEvent, item: Media) => {
-    if (!isSelected(item.id)) return;
-    setDraggedItem(item);
-    e.dataTransfer.effectAllowed = "move";
-  };
-
-  const handleDragOver = (e: React.DragEvent, targetIndex: number) => {
-    e.preventDefault();
-    if (!draggedItem) return;
-    setDragOverIndex(targetIndex);
-  };
-
-  const handleDragEnd = () => {
-    setDraggedItem(null);
-    setDragOverIndex(null);
-  };
-
-  const handleDrop = (e: React.DragEvent, targetItem: Media, targetIndex: number) => {
-    e.preventDefault();
-    if (!draggedItem || draggedItem.id === targetItem.id) {
-      setDraggedItem(null);
-      setDragOverIndex(null);
-      return;
-    }
-
-    // Get indices of dragged item and target
-    const draggedIndex = combinedMedia.findIndex((m) => m.id === draggedItem.id);
-    if (draggedIndex === -1) return;
-
-    // Reorder by removing dragged item and inserting at new position
-    const newOrder = [...combinedMedia];
-    newOrder.splice(draggedIndex, 1);
-    newOrder.splice(targetIndex, 0, draggedItem);
-
-    // Update selection order
-    const selectedIds = new Set(selectedMedia.map((m) => m.id));
-    const reorderedSelected = newOrder.filter((m) => selectedIds.has(m.id));
-
-    // Call onMediaSelect for each selected item in new order
-    reorderedSelected.forEach((media) => {
-      onMediaSelect(media);
+  const { draggedItem, dragOverIndex, handleDragStart, handleDragOver, handleDragEnd, handleDrop } =
+    useMediaDragReorder({
+      combinedMedia,
+      selectedMedia,
+      onMediaSelect,
+      isSelected,
     });
 
-    setDraggedItem(null);
-    setDragOverIndex(null);
-  };
-
-  const handleMediaClick = (e: React.MouseEvent, item: Media, itemIndex: number) => {
-    // Don't trigger selection if clicking on drag handle
-    if ((e.target as HTMLElement).closest(".drag-handle")) {
-      return;
-    }
-
-    const isCtrlOrCmd = e.ctrlKey || e.metaKey;
-    const isShift = e.shiftKey;
-    const itemIsSelected = isSelected(item.id);
-
-    // Shift-click for range selection
-    if (isShift && lastClickedIndex !== null) {
-      const start = Math.min(lastClickedIndex, itemIndex);
-      const end = Math.max(lastClickedIndex, itemIndex);
-      const rangeItems = combinedMedia.slice(start, end + 1);
-
-      // Add all items in range to selection
-      rangeItems.forEach((media) => {
-        if (!isSelected(media.id)) {
-          onMediaSelect(media);
-        }
-      });
-      return;
-    }
-
-    // Cmd/Ctrl-click for multi-select (toggle individual item)
-    if (isCtrlOrCmd) {
-      onMediaSelect(item);
-      setLastClickedIndex(itemIndex);
-      return;
-    }
-
-    // Regular click - if item is already selected and there are multiple selected items,
-    // clear all others and keep only this one. If not selected, toggle it.
-    if (itemIsSelected && selectedMedia.length > 1) {
-      // Clear all other selections, keep only this one
-      selectedMedia.filter((m) => m.id !== item.id).forEach((m) => onMediaSelect(m));
-    } else {
-      // Toggle this item
-      onMediaSelect(item);
-    }
-
-    setLastClickedIndex(itemIndex);
-  };
+  const { handleMediaClick } = useMediaClickSelection({
+    combinedMedia,
+    selectedMedia,
+    onMediaSelect,
+    isSelected,
+  });
 
   return (
     <div className={cn("flex flex-col", className)}>
@@ -243,60 +165,30 @@ export const CombinedMediaSelection = ({
       <div>
         <ScrollArea className="h-[400px] border rounded-md" ref={scrollAreaRef}>
           <div className="p-4">
-            <div className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4">
-              {combinedMedia.map((item, index) => {
-                const itemIsSelected = isSelected(item.id);
-                const postingHistory = postingHistoryMap?.get(item.id);
-
-                const isDragging = draggedItem?.id === item.id;
-                const isDragOver = dragOverIndex === index;
-
-                return (
-                  <div
-                    key={item.id}
-                    className={cn(
-                      "relative aspect-square cursor-pointer rounded-lg overflow-hidden transition-all",
-                      itemIsSelected ? "ring-2 ring-primary" : "hover:ring-2 hover:ring-primary",
-                      isDragging && "opacity-50",
-                      isDragOver && "ring-2 ring-primary ring-offset-2",
-                    )}
-                    draggable={itemIsSelected}
-                    onDragStart={(e) => handleDragStart(e, item)}
-                    onDragOver={(e) => handleDragOver(e, index)}
-                    onDragEnd={handleDragEnd}
-                    onDrop={(e) => handleDrop(e, item, index)}
-                    onClick={(e) => handleMediaClick(e, item, index)}
-                    onMouseEnter={() => {
-                      if (item.type === "video") {
-                        setActivePreviewId(item.id);
-                      }
-                    }}
-                    onMouseLeave={() => {
-                      if (item.type === "video") {
-                        setActivePreviewId(null);
-                      }
-                    }}
-                  >
-                    <MediaTileLite
-                      media={item}
-                      isActivePreview={item.id === activePreviewId}
-                      postingHistory={postingHistory}
-                      currentChannelId={channelId}
-                    />
-                    {itemIsSelected && (
-                      <>
-                        <div className="absolute top-1 right-1 w-5 h-5 rounded-full bg-primary flex items-center justify-center z-10">
-                          <Check className="w-3 h-3 text-primary-foreground" />
-                        </div>
-                        <div className="drag-handle absolute top-1 left-1 w-6 h-6 rounded bg-base-100/90 flex items-center justify-center z-10 cursor-grab active:cursor-grabbing">
-                          <GripVertical className="w-4 h-4 text-base-content/70" />
-                        </div>
-                      </>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
+            <MediaSelectionGrid
+              combinedMedia={combinedMedia}
+              activePreviewId={activePreviewId}
+              postingHistoryMap={postingHistoryMap}
+              channelId={channelId}
+              draggedItem={draggedItem}
+              dragOverIndex={dragOverIndex}
+              isSelected={isSelected}
+              onDragStart={handleDragStart}
+              onDragOver={handleDragOver}
+              onDragEnd={handleDragEnd}
+              onDrop={handleDrop}
+              onMediaClick={handleMediaClick}
+              onMouseEnter={(item) => {
+                if (item.type === "video") {
+                  setActivePreviewId(item.id);
+                }
+              }}
+              onMouseLeave={(item) => {
+                if (item.type === "video") {
+                  setActivePreviewId(null);
+                }
+              }}
+            />
             {combinedMedia.length === 0 && totalItems === 0 && (
               <div className="col-span-full text-center py-8 space-y-3">
                 <h3 className="text-lg font-semibold text-base-content/80">

--- a/@fanslib/apps/web/src/features/library/components/CombinedMediaSelection/MediaSelectionGrid.tsx
+++ b/@fanslib/apps/web/src/features/library/components/CombinedMediaSelection/MediaSelectionGrid.tsx
@@ -1,0 +1,89 @@
+import type { Media } from "@fanslib/server/schemas";
+import type React from "react";
+import type { ComponentProps } from "react";
+import { Check, GripVertical } from "lucide-react";
+import { cn } from "~/lib/cn";
+import { MediaTileLite } from "../MediaTile/MediaTileLite";
+
+type PostingHistory = ComponentProps<typeof MediaTileLite>["postingHistory"];
+
+type MediaSelectionGridProps = {
+  combinedMedia: Media[];
+  activePreviewId: string | null;
+  postingHistoryMap: Map<string, NonNullable<PostingHistory>> | undefined;
+  channelId?: string;
+  draggedItem: Media | null;
+  dragOverIndex: number | null;
+  isSelected: (mediaId: string) => boolean;
+  onDragStart: (e: React.DragEvent, item: Media) => void;
+  onDragOver: (e: React.DragEvent, targetIndex: number) => void;
+  onDragEnd: () => void;
+  onDrop: (e: React.DragEvent, targetItem: Media, targetIndex: number) => void;
+  onMediaClick: (e: React.MouseEvent, item: Media, itemIndex: number) => void;
+  onMouseEnter: (item: Media) => void;
+  onMouseLeave: (item: Media) => void;
+};
+
+export const MediaSelectionGrid = ({
+  combinedMedia,
+  activePreviewId,
+  postingHistoryMap,
+  channelId,
+  draggedItem,
+  dragOverIndex,
+  isSelected,
+  onDragStart,
+  onDragOver,
+  onDragEnd,
+  onDrop,
+  onMediaClick,
+  onMouseEnter,
+  onMouseLeave,
+}: MediaSelectionGridProps) => (
+  <div className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4">
+    {combinedMedia.map((item, index) => {
+      const itemIsSelected = isSelected(item.id);
+      const postingHistory = postingHistoryMap?.get(item.id);
+
+      const isDragging = draggedItem?.id === item.id;
+      const isDragOver = dragOverIndex === index;
+
+      return (
+        <div
+          key={item.id}
+          className={cn(
+            "relative aspect-square cursor-pointer rounded-lg overflow-hidden transition-all",
+            itemIsSelected ? "ring-2 ring-primary" : "hover:ring-2 hover:ring-primary",
+            isDragging && "opacity-50",
+            isDragOver && "ring-2 ring-primary ring-offset-2",
+          )}
+          draggable={itemIsSelected}
+          onDragStart={(e) => onDragStart(e, item)}
+          onDragOver={(e) => onDragOver(e, index)}
+          onDragEnd={onDragEnd}
+          onDrop={(e) => onDrop(e, item, index)}
+          onClick={(e) => onMediaClick(e, item, index)}
+          onMouseEnter={() => onMouseEnter(item)}
+          onMouseLeave={() => onMouseLeave(item)}
+        >
+          <MediaTileLite
+            media={item}
+            isActivePreview={item.id === activePreviewId}
+            postingHistory={postingHistory}
+            currentChannelId={channelId}
+          />
+          {itemIsSelected && (
+            <>
+              <div className="absolute top-1 right-1 w-5 h-5 rounded-full bg-primary flex items-center justify-center z-10">
+                <Check className="w-3 h-3 text-primary-foreground" />
+              </div>
+              <div className="drag-handle absolute top-1 left-1 w-6 h-6 rounded bg-base-100/90 flex items-center justify-center z-10 cursor-grab active:cursor-grabbing">
+                <GripVertical className="w-4 h-4 text-base-content/70" />
+              </div>
+            </>
+          )}
+        </div>
+      );
+    })}
+  </div>
+);

--- a/@fanslib/apps/web/src/features/library/components/CombinedMediaSelection/index.tsx
+++ b/@fanslib/apps/web/src/features/library/components/CombinedMediaSelection/index.tsx
@@ -1,0 +1,1 @@
+export { CombinedMediaSelection } from "./CombinedMediaSelection";

--- a/@fanslib/apps/web/src/features/library/components/CombinedMediaSelection/useMediaClickSelection.ts
+++ b/@fanslib/apps/web/src/features/library/components/CombinedMediaSelection/useMediaClickSelection.ts
@@ -1,0 +1,65 @@
+import type { Media } from "@fanslib/server/schemas";
+import { useState } from "react";
+
+type UseMediaClickSelectionArgs = {
+  combinedMedia: Media[];
+  selectedMedia: Media[];
+  onMediaSelect: (media: Media) => void;
+  isSelected: (mediaId: string) => boolean;
+};
+
+export const useMediaClickSelection = ({
+  combinedMedia,
+  selectedMedia,
+  onMediaSelect,
+  isSelected,
+}: UseMediaClickSelectionArgs) => {
+  const [lastClickedIndex, setLastClickedIndex] = useState<number | null>(null);
+
+  const handleMediaClick = (e: React.MouseEvent, item: Media, itemIndex: number) => {
+    // Don't trigger selection if clicking on drag handle
+    if ((e.target as HTMLElement).closest(".drag-handle")) {
+      return;
+    }
+
+    const isCtrlOrCmd = e.ctrlKey || e.metaKey;
+    const isShift = e.shiftKey;
+    const itemIsSelected = isSelected(item.id);
+
+    // Shift-click for range selection
+    if (isShift && lastClickedIndex !== null) {
+      const start = Math.min(lastClickedIndex, itemIndex);
+      const end = Math.max(lastClickedIndex, itemIndex);
+      const rangeItems = combinedMedia.slice(start, end + 1);
+
+      // Add all items in range to selection
+      rangeItems.forEach((media) => {
+        if (!isSelected(media.id)) {
+          onMediaSelect(media);
+        }
+      });
+      return;
+    }
+
+    // Cmd/Ctrl-click for multi-select (toggle individual item)
+    if (isCtrlOrCmd) {
+      onMediaSelect(item);
+      setLastClickedIndex(itemIndex);
+      return;
+    }
+
+    // Regular click - if item is already selected and there are multiple selected items,
+    // clear all others and keep only this one. If not selected, toggle it.
+    if (itemIsSelected && selectedMedia.length > 1) {
+      // Clear all other selections, keep only this one
+      selectedMedia.filter((m) => m.id !== item.id).forEach((m) => onMediaSelect(m));
+    } else {
+      // Toggle this item
+      onMediaSelect(item);
+    }
+
+    setLastClickedIndex(itemIndex);
+  };
+
+  return { handleMediaClick };
+};

--- a/@fanslib/apps/web/src/features/library/components/CombinedMediaSelection/useMediaDragReorder.ts
+++ b/@fanslib/apps/web/src/features/library/components/CombinedMediaSelection/useMediaDragReorder.ts
@@ -1,0 +1,75 @@
+import type { Media } from "@fanslib/server/schemas";
+import { useState } from "react";
+
+type UseMediaDragReorderArgs = {
+  combinedMedia: Media[];
+  selectedMedia: Media[];
+  onMediaSelect: (media: Media) => void;
+  isSelected: (mediaId: string) => boolean;
+};
+
+export const useMediaDragReorder = ({
+  combinedMedia,
+  selectedMedia,
+  onMediaSelect,
+  isSelected,
+}: UseMediaDragReorderArgs) => {
+  const [draggedItem, setDraggedItem] = useState<Media | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+
+  const handleDragStart = (e: React.DragEvent, item: Media) => {
+    if (!isSelected(item.id)) return;
+    setDraggedItem(item);
+    e.dataTransfer.effectAllowed = "move";
+  };
+
+  const handleDragOver = (e: React.DragEvent, targetIndex: number) => {
+    e.preventDefault();
+    if (!draggedItem) return;
+    setDragOverIndex(targetIndex);
+  };
+
+  const handleDragEnd = () => {
+    setDraggedItem(null);
+    setDragOverIndex(null);
+  };
+
+  const handleDrop = (e: React.DragEvent, targetItem: Media, targetIndex: number) => {
+    e.preventDefault();
+    if (!draggedItem || draggedItem.id === targetItem.id) {
+      setDraggedItem(null);
+      setDragOverIndex(null);
+      return;
+    }
+
+    // Get indices of dragged item and target
+    const draggedIndex = combinedMedia.findIndex((m) => m.id === draggedItem.id);
+    if (draggedIndex === -1) return;
+
+    // Reorder by removing dragged item and inserting at new position
+    const newOrder = [...combinedMedia];
+    newOrder.splice(draggedIndex, 1);
+    newOrder.splice(targetIndex, 0, draggedItem);
+
+    // Update selection order
+    const selectedIds = new Set(selectedMedia.map((m) => m.id));
+    const reorderedSelected = newOrder.filter((m) => selectedIds.has(m.id));
+
+    // Call onMediaSelect for each selected item in new order
+    reorderedSelected.forEach((media) => {
+      onMediaSelect(media);
+    });
+
+    setDraggedItem(null);
+    setDragOverIndex(null);
+  };
+
+  return {
+    draggedItem,
+    dragOverIndex,
+    handleDragStart,
+    handleDragOver,
+    handleDragEnd,
+    handleDrop,
+  };
+};


### PR DESCRIPTION
## Summary

- Split 356-line `CombinedMediaSelection.tsx` into:
  - `useMediaDragReorder.ts` — drag-and-drop state and handlers
  - `useMediaClickSelection.ts` — shift/ctrl/regular click selection logic
  - `MediaSelectionGrid.tsx` — grid rendering with tiles
  - `CombinedMediaSelection.tsx` — main component using hooks
  - `index.tsx` — barrel re-export
- No behavior changes, no interface changes
- All 4 consumers continue to import unchanged

Closes #183

## Test plan

- [x] Typecheck clean
- [x] Lint clean
- [ ] Manual: verify drag-and-drop and click selection work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)