### PR TITLE
refactor: extract PostPreview drag and virtual post logic

### DIFF
--- a/@fanslib/apps/web/src/features/posts/components/PostPreview/PostPreview.tsx
+++ b/@fanslib/apps/web/src/features/posts/components/PostPreview/PostPreview.tsx
@@ -1,24 +1,13 @@
 import type { Media, PostWithRelations } from "@fanslib/server/schemas";
 import { Link } from "@tanstack/react-router";
-import { format } from "date-fns";
-import { Camera, Plus, Trash2, X } from "lucide-react";
-import { useState } from "react";
-import { ChannelBadge } from "~/components/ChannelBadge";
-import { ContentScheduleBadge } from "~/components/ContentScheduleBadge";
-import { StatusIcon } from "~/components/StatusIcon";
 
-import { usePostDrag } from "~/contexts/PostDragContext";
-import { usePostPreferences } from "~/contexts/PostPreferencesContext";
-import { MediaTile } from "~/features/library/components/MediaTile";
-import { cn } from "~/lib/cn";
-import { useSkipScheduleSlotMutation } from "~/lib/queries/content-schedules";
 import { isVirtualPost, type VirtualPost } from "~/lib/virtual-posts";
-import { useCreatePostFromVirtualSlot } from "../../hooks/useCreatePostFromVirtualSlot";
 import { useVirtualPostClick } from "../../hooks/useVirtualPostClick";
-import { getCaptionPreview } from "../../lib/captions";
 import { PostTimelineDropZone } from "../PostTimelineDropZone";
-import { VirtualPostOverlay } from "../VirtualPostOverlay";
+import { PostPreviewCard } from "./PostPreviewCard";
+import { usePostDropOnVirtualSlot } from "./usePostDropOnVirtualSlot";
 import { usePostPreviewDrag } from "./usePostPreviewDrag";
+import { useSkipSlotConfirmation } from "./useSkipSlotConfirmation";
 
 type Post = PostWithRelations;
 
@@ -53,17 +42,16 @@ export const PostPreview = ({
   matchedPostMediaIds,
 }: PostPreviewProps) => {
   const isVirtual = isVirtualPost(post);
-  const { preferences } = usePostPreferences();
-  const { createPostFromVirtualSlot } = useCreatePostFromVirtualSlot();
+
   const {
-    startPostDrag,
-    endPostDrag: stopPostDrag,
-    isDragging: isPostDragging,
-    draggedPost,
-  } = usePostDrag();
-  const [hasSkipConfirmation, setHasSkipConfirmation] = useState(false);
-  const skipSlotMutation = useSkipScheduleSlotMutation();
-  const captionPreview = post.caption ? getCaptionPreview(post.caption) : "";
+    hasSkipConfirmation,
+    skipScheduleSlot,
+    resetSkipConfirmation,
+    isSkipPending,
+  } = useSkipSlotConfirmation({
+    post: isVirtual ? post : ({} as VirtualPost),
+    onUpdate,
+  });
 
   const virtualPostClick = useVirtualPostClick({
     post: isVirtual ? post : ({} as VirtualPost),
@@ -86,86 +74,22 @@ export const PostPreview = ({
       onOpenCreateDialog({ ...data, initialMediaSelectionExpanded: true }),
   });
 
-  const dragProps = isVirtual
-    ? {}
-    : {
-        draggable: true,
-        onDragStart: (e: React.DragEvent<HTMLDivElement>) => startPostDrag(e, post),
-        onDragEnd: stopPostDrag,
-      };
+  const {
+    isPostDragging,
+    isPostDraggedOver,
+    setIsPostDraggedOver,
+    dragProps,
+    updatePostDraggedOver,
+    onDropOnVirtualPost,
+  } = usePostDropOnVirtualSlot({
+    post,
+    onUpdate,
+    onOpenCreateDialog,
+  });
 
-  const [isPostDraggedOver, setIsPostDraggedOver] = useState(false);
   const isAnyDragging = isMediaDragging || isPostDragging;
   const isAnyDraggedOver =
     (isMediaDragging && isDraggedOver) || (isPostDragging && isPostDraggedOver);
-
-  const updatePostDraggedOver = (e: React.DragEvent<HTMLDivElement>, nextValue: boolean) => {
-    if (!isPostDragging) return;
-    const relatedTarget = e.relatedTarget as Node | null;
-    if (relatedTarget && e.currentTarget.contains(relatedTarget)) return;
-    setIsPostDraggedOver(nextValue);
-  };
-
-  const onDropOnVirtualPost = (e: React.DragEvent<HTMLDivElement>) => {
-    if (!isPostDragging || !draggedPost || !isVirtualPost(post)) return false;
-    e.preventDefault();
-    e.stopPropagation();
-
-    setIsPostDraggedOver(false);
-    const media = draggedPost.postMedia.map((pm) => pm.media);
-    const caption = draggedPost.caption ?? undefined;
-    const initialDate = new Date(post.date);
-    const initialChannelId = post.channelId;
-    const scheduleId = post.scheduleId ?? undefined;
-
-    if (preferences.view.openDialogOnDrop) {
-      onOpenCreateDialog({
-        media,
-        initialCaption: caption,
-        initialDate,
-        initialChannelId,
-        scheduleId,
-      });
-      stopPostDrag();
-      return true;
-    }
-
-    stopPostDrag();
-    void createPostFromVirtualSlot({
-      virtualPost: post,
-      mediaIds: media.map((m) => m.id),
-      caption,
-      onUpdate,
-    });
-    return true;
-  };
-
-  const skipScheduleSlot = async (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    if (!isVirtual) {
-      return;
-    }
-
-    if (!hasSkipConfirmation) {
-      setHasSkipConfirmation(true);
-      return;
-    }
-
-    if (!post.scheduleId) {
-      setHasSkipConfirmation(false);
-      return;
-    }
-
-    await skipSlotMutation.mutateAsync({
-      scheduleId: post.scheduleId,
-      date: post.date,
-    });
-
-    await onUpdate();
-    setHasSkipConfirmation(false);
-  };
 
   const shouldShowInsertionZones = isDraggedOver || isPostDragging;
   const isPreviousVirtual = previousPostInList ? isVirtualPost(previousPostInList) : false;
@@ -188,8 +112,6 @@ export const PostPreview = ({
       onOpenCreateDialog={onOpenCreateDialog}
     />
   );
-
-  const status = post.status ?? "draft";
 
   const content = (
     <div
@@ -216,131 +138,17 @@ export const PostPreview = ({
     >
       <div className="relative">
         {previousDropZone}
-        <div
-          className={cn(
-            "border border-base-content rounded-xl relative group transition-all bg-base-100",
-            isVirtual && "opacity-60",
-            isAnyDragging &&
-              isAnyDraggedOver &&
-              "border-2 border-dashed border-primary bg-primary/10 opacity-100",
-          )}
-          onMouseLeave={() => setHasSkipConfirmation(false)}
-        >
-          {isVirtual && !isAnyDragging && (
-            <VirtualPostOverlay onClick={virtualPostClick.handleClick} />
-          )}
-
-          {isVirtual && !isAnyDragging && (
-            <button
-              type="button"
-              onClick={skipScheduleSlot}
-              disabled={skipSlotMutation.isPending}
-              className={cn(
-                "absolute top-2 right-2 p-1 rounded-md transition-all",
-                "opacity-0 group-hover:opacity-100",
-                "z-10",
-                hasSkipConfirmation
-                  ? "bg-error/80 hover:bg-error text-error-content"
-                  : "bg-base-200/80 hover:bg-base-300 text-base-content/60 hover:text-base-content",
-                skipSlotMutation.isPending && "opacity-60 cursor-not-allowed",
-              )}
-              title={
-                skipSlotMutation.isPending
-                  ? "Skipping..."
-                  : hasSkipConfirmation
-                    ? "Click again to confirm skip"
-                    : "Skip this slot"
-              }
-            >
-              {hasSkipConfirmation ? <Trash2 size={14} /> : <X size={14} />}
-            </button>
-          )}
-
-          <div className="flex items-stretch justify-between p-4 gap-4">
-            <div className="flex flex-col justify-between gap-2 flex-1">
-              <div className="flex flex-col gap-2">
-                <div className="flex items-start gap-2">
-                  <div className="mt-1">
-                    <StatusIcon status={status as "posted" | "scheduled" | "draft"} />
-                  </div>
-                  <div className="flex flex-col">
-                    <span className="text-base font-semibold text-base-content">
-                      {format(new Date(post.date), "MMMM d")}
-                    </span>
-                    <span className="text-sm font-medium text-base-content/60">
-                      {format(new Date(post.date), "HH:mm")}
-                    </span>
-                  </div>
-                </div>
-                {preferences.view.showCaptions && captionPreview && (
-                  <div className="text-sm leading-snug text-base-content line-clamp-2">
-                    {captionPreview}
-                  </div>
-                )}
-              </div>
-              <div className="flex items-center gap-0.5">
-                <ChannelBadge
-                  name={post.channel.name}
-                  typeId={post.channel.type?.id ?? post.channel.typeId}
-                  size="sm"
-                  selected
-                  borderStyle="none"
-                  className="justify-center"
-                  responsive={false}
-                />
-                {isVirtual ? (
-                  <ContentScheduleBadge
-                    name={post.schedule?.name ?? ""}
-                    emoji={post.schedule?.emoji ?? undefined}
-                    color={post.schedule?.color ?? undefined}
-                    size="sm"
-                    selected
-                    borderStyle="none"
-                    className="justify-center"
-                    responsive={false}
-                  />
-                ) : post.schedule ? (
-                  <ContentScheduleBadge
-                    name={post.schedule.name}
-                    emoji={post.schedule.emoji ?? undefined}
-                    color={post.schedule.color ?? undefined}
-                    size="sm"
-                    selected
-                    borderStyle="none"
-                    className="justify-center"
-                    responsive={false}
-                  />
-                ) : null}
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              {isVirtual ? (
-                <div className="w-24 h-24 rounded-md border-2 border-dashed border-base-300 bg-base-200/30 flex flex-col items-center justify-center">
-                  <Camera className="w-6 h-6 text-base-content/20" />
-                </div>
-              ) : (
-                post.postMedia.map((pm) => {
-                  const isMatched = matchedPostMediaIds?.has(pm.id) ?? false;
-                  return (
-                    <MediaTile
-                      key={pm.id}
-                      media={pm.media}
-                      index={post.postMedia.indexOf(pm)}
-                      className={cn("size-24", isMatched && "opacity-30")}
-                      withPreview
-                      withDuration
-                    />
-                  );
-                })
-              )}
-            </div>
-          </div>
-          {isAnyDragging && isAnyDraggedOver && (
-            <div className="absolute inset-0 flex items-center justify-center bg-primary/10">
-              <Plus className="w-6 h-6 text-primary" />
-            </div>
-          )}
-        </div>
+        <PostPreviewCard
+          post={post}
+          isAnyDragging={isAnyDragging}
+          isAnyDraggedOver={isAnyDraggedOver}
+          hasSkipConfirmation={hasSkipConfirmation}
+          isSkipPending={isSkipPending}
+          onSkipScheduleSlot={skipScheduleSlot}
+          onResetSkipConfirmation={resetSkipConfirmation}
+          onVirtualPostClick={virtualPostClick.handleClick}
+          matchedPostMediaIds={matchedPostMediaIds}
+        />
         {nextDropZone}
       </div>
     </div>

--- a/@fanslib/apps/web/src/features/posts/components/PostPreview/PostPreviewCard.tsx
+++ b/@fanslib/apps/web/src/features/posts/components/PostPreview/PostPreviewCard.tsx
@@ -1,0 +1,169 @@
+import type { PostWithRelations } from "@fanslib/server/schemas";
+import { format } from "date-fns";
+import { Camera, Plus, Trash2, X } from "lucide-react";
+import { ChannelBadge } from "~/components/ChannelBadge";
+import { ContentScheduleBadge } from "~/components/ContentScheduleBadge";
+import { StatusIcon } from "~/components/StatusIcon";
+import { usePostPreferences } from "~/contexts/PostPreferencesContext";
+import { MediaTile } from "~/features/library/components/MediaTile";
+import { cn } from "~/lib/cn";
+import { isVirtualPost, type VirtualPost } from "~/lib/virtual-posts";
+import { getCaptionPreview } from "../../lib/captions";
+import { VirtualPostOverlay } from "../VirtualPostOverlay";
+
+type PostPreviewCardProps = {
+  post: PostWithRelations | VirtualPost;
+  isAnyDragging: boolean;
+  isAnyDraggedOver: boolean;
+  hasSkipConfirmation: boolean;
+  isSkipPending: boolean;
+  onSkipScheduleSlot: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onResetSkipConfirmation: () => void;
+  onVirtualPostClick: () => void;
+  matchedPostMediaIds?: Set<string>;
+};
+
+export const PostPreviewCard = ({
+  post,
+  isAnyDragging,
+  isAnyDraggedOver,
+  hasSkipConfirmation,
+  isSkipPending,
+  onSkipScheduleSlot,
+  onResetSkipConfirmation,
+  onVirtualPostClick,
+  matchedPostMediaIds,
+}: PostPreviewCardProps) => {
+  const isVirtual = isVirtualPost(post);
+  const { preferences } = usePostPreferences();
+  const captionPreview = post.caption ? getCaptionPreview(post.caption) : "";
+  const status = post.status ?? "draft";
+
+  return (
+    <div
+      className={cn(
+        "border border-base-content rounded-xl relative group transition-all bg-base-100",
+        isVirtual && "opacity-60",
+        isAnyDragging &&
+          isAnyDraggedOver &&
+          "border-2 border-dashed border-primary bg-primary/10 opacity-100",
+      )}
+      onMouseLeave={onResetSkipConfirmation}
+    >
+      {isVirtual && !isAnyDragging && (
+        <VirtualPostOverlay onClick={onVirtualPostClick} />
+      )}
+
+      {isVirtual && !isAnyDragging && (
+        <button
+          type="button"
+          onClick={onSkipScheduleSlot}
+          disabled={isSkipPending}
+          className={cn(
+            "absolute top-2 right-2 p-1 rounded-md transition-all",
+            "opacity-0 group-hover:opacity-100",
+            "z-10",
+            hasSkipConfirmation
+              ? "bg-error/80 hover:bg-error text-error-content"
+              : "bg-base-200/80 hover:bg-base-300 text-base-content/60 hover:text-base-content",
+            isSkipPending && "opacity-60 cursor-not-allowed",
+          )}
+          title={
+            isSkipPending
+              ? "Skipping..."
+              : hasSkipConfirmation
+                ? "Click again to confirm skip"
+                : "Skip this slot"
+          }
+        >
+          {hasSkipConfirmation ? <Trash2 size={14} /> : <X size={14} />}
+        </button>
+      )}
+
+      <div className="flex items-stretch justify-between p-4 gap-4">
+        <div className="flex flex-col justify-between gap-2 flex-1">
+          <div className="flex flex-col gap-2">
+            <div className="flex items-start gap-2">
+              <div className="mt-1">
+                <StatusIcon status={status as "posted" | "scheduled" | "draft"} />
+              </div>
+              <div className="flex flex-col">
+                <span className="text-base font-semibold text-base-content">
+                  {format(new Date(post.date), "MMMM d")}
+                </span>
+                <span className="text-sm font-medium text-base-content/60">
+                  {format(new Date(post.date), "HH:mm")}
+                </span>
+              </div>
+            </div>
+            {preferences.view.showCaptions && captionPreview && (
+              <div className="text-sm leading-snug text-base-content line-clamp-2">
+                {captionPreview}
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-0.5">
+            <ChannelBadge
+              name={post.channel.name}
+              typeId={post.channel.type?.id ?? post.channel.typeId}
+              size="sm"
+              selected
+              borderStyle="none"
+              className="justify-center"
+              responsive={false}
+            />
+            {isVirtual ? (
+              <ContentScheduleBadge
+                name={post.schedule?.name ?? ""}
+                emoji={post.schedule?.emoji ?? undefined}
+                color={post.schedule?.color ?? undefined}
+                size="sm"
+                selected
+                borderStyle="none"
+                className="justify-center"
+                responsive={false}
+              />
+            ) : post.schedule ? (
+              <ContentScheduleBadge
+                name={post.schedule.name}
+                emoji={post.schedule.emoji ?? undefined}
+                color={post.schedule.color ?? undefined}
+                size="sm"
+                selected
+                borderStyle="none"
+                className="justify-center"
+                responsive={false}
+              />
+            ) : null}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {isVirtual ? (
+            <div className="w-24 h-24 rounded-md border-2 border-dashed border-base-300 bg-base-200/30 flex flex-col items-center justify-center">
+              <Camera className="w-6 h-6 text-base-content/20" />
+            </div>
+          ) : (
+            post.postMedia.map((pm) => {
+              const isMatched = matchedPostMediaIds?.has(pm.id) ?? false;
+              return (
+                <MediaTile
+                  key={pm.id}
+                  media={pm.media}
+                  index={post.postMedia.indexOf(pm)}
+                  className={cn("size-24", isMatched && "opacity-30")}
+                  withPreview
+                  withDuration
+                />
+              );
+            })
+          )}
+        </div>
+      </div>
+      {isAnyDragging && isAnyDraggedOver && (
+        <div className="absolute inset-0 flex items-center justify-center bg-primary/10">
+          <Plus className="w-6 h-6 text-primary" />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/features/posts/components/PostPreview/usePostDropOnVirtualSlot.ts
+++ b/@fanslib/apps/web/src/features/posts/components/PostPreview/usePostDropOnVirtualSlot.ts
@@ -1,0 +1,98 @@
+import type { Media, PostWithRelations } from "@fanslib/server/schemas";
+import { useState } from "react";
+import { usePostDrag } from "~/contexts/PostDragContext";
+import { usePostPreferences } from "~/contexts/PostPreferencesContext";
+import { isVirtualPost, type VirtualPost } from "~/lib/virtual-posts";
+import { useCreatePostFromVirtualSlot } from "../../hooks/useCreatePostFromVirtualSlot";
+
+type CreatePostDialogData = {
+  media: Media[];
+  initialDate?: Date;
+  initialChannelId?: string;
+  scheduleId?: string;
+  initialCaption?: string;
+  initialMediaSelectionExpanded?: boolean;
+};
+
+type UsePostDropOnVirtualSlotProps = {
+  post: PostWithRelations | VirtualPost;
+  onUpdate: () => Promise<void>;
+  onOpenCreateDialog: (data: CreatePostDialogData) => void;
+};
+
+export const usePostDropOnVirtualSlot = ({
+  post,
+  onUpdate,
+  onOpenCreateDialog,
+}: UsePostDropOnVirtualSlotProps) => {
+  const { preferences } = usePostPreferences();
+  const { createPostFromVirtualSlot } = useCreatePostFromVirtualSlot();
+  const {
+    startPostDrag,
+    endPostDrag: stopPostDrag,
+    isDragging: isPostDragging,
+    draggedPost,
+  } = usePostDrag();
+
+  const isVirtual = isVirtualPost(post);
+  const [isPostDraggedOver, setIsPostDraggedOver] = useState(false);
+
+  const dragProps = isVirtual
+    ? {}
+    : {
+        draggable: true as const,
+        onDragStart: (e: React.DragEvent<HTMLDivElement>) => startPostDrag(e, post),
+        onDragEnd: stopPostDrag,
+      };
+
+  const updatePostDraggedOver = (e: React.DragEvent<HTMLDivElement>, nextValue: boolean) => {
+    if (!isPostDragging) return;
+    const relatedTarget = e.relatedTarget as Node | null;
+    if (relatedTarget && e.currentTarget.contains(relatedTarget)) return;
+    setIsPostDraggedOver(nextValue);
+  };
+
+  const onDropOnVirtualPost = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!isPostDragging || !draggedPost || !isVirtualPost(post)) return false;
+    e.preventDefault();
+    e.stopPropagation();
+
+    setIsPostDraggedOver(false);
+    const media = draggedPost.postMedia.map((pm) => pm.media);
+    const caption = draggedPost.caption ?? undefined;
+    const initialDate = new Date(post.date);
+    const initialChannelId = post.channelId;
+    const scheduleId = post.scheduleId ?? undefined;
+
+    if (preferences.view.openDialogOnDrop) {
+      onOpenCreateDialog({
+        media,
+        initialCaption: caption,
+        initialDate,
+        initialChannelId,
+        scheduleId,
+      });
+      stopPostDrag();
+      return true;
+    }
+
+    stopPostDrag();
+    void createPostFromVirtualSlot({
+      virtualPost: post,
+      mediaIds: media.map((m) => m.id),
+      caption,
+      onUpdate,
+    });
+    return true;
+  };
+
+  return {
+    isPostDragging,
+    isPostDraggedOver,
+    setIsPostDraggedOver,
+    dragProps,
+    updatePostDraggedOver,
+    onDropOnVirtualPost,
+    stopPostDrag,
+  };
+};

--- a/@fanslib/apps/web/src/features/posts/components/PostPreview/useSkipSlotConfirmation.ts
+++ b/@fanslib/apps/web/src/features/posts/components/PostPreview/useSkipSlotConfirmation.ts
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { useSkipScheduleSlotMutation } from "~/lib/queries/content-schedules";
+import type { VirtualPost } from "~/lib/virtual-posts";
+
+type UseSkipSlotConfirmationProps = {
+  post: VirtualPost;
+  onUpdate: () => Promise<void>;
+};
+
+export const useSkipSlotConfirmation = ({ post, onUpdate }: UseSkipSlotConfirmationProps) => {
+  const [hasSkipConfirmation, setHasSkipConfirmation] = useState(false);
+  const skipSlotMutation = useSkipScheduleSlotMutation();
+
+  const skipScheduleSlot = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (!hasSkipConfirmation) {
+      setHasSkipConfirmation(true);
+      return;
+    }
+
+    if (!post.scheduleId) {
+      setHasSkipConfirmation(false);
+      return;
+    }
+
+    await skipSlotMutation.mutateAsync({
+      scheduleId: post.scheduleId,
+      date: post.date,
+    });
+
+    await onUpdate();
+    setHasSkipConfirmation(false);
+  };
+
+  const resetSkipConfirmation = () => setHasSkipConfirmation(false);
+
+  return {
+    hasSkipConfirmation,
+    skipScheduleSlot,
+    resetSkipConfirmation,
+    isSkipPending: skipSlotMutation.isPending,
+  };
+};


### PR DESCRIPTION
## Summary

- Extract from 358-line `PostPreview.tsx`:
  - `useSkipSlotConfirmation.ts` — two-click skip confirmation state machine
  - `usePostDropOnVirtualSlot.ts` — virtual slot drop handling
  - `PostPreviewCard.tsx` — inner visual card (status, dates, badges, media, caption)
- `PostPreview.tsx` slimmed to ~150-line orchestrator
- No behavior changes, no interface changes

Closes #186

## Test plan

- [x] Typecheck clean
- [x] Lint clean
- [ ] Manual: verify post preview drag/drop and skip slot work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)