### PR TITLE
refactor: extract CaptionItem into subcomponents

### DIFF
--- a/@fanslib/apps/web/src/features/pipeline/components/CaptioningStep/CaptionItem.tsx
+++ b/@fanslib/apps/web/src/features/pipeline/components/CaptioningStep/CaptionItem.tsx
@@ -1,35 +1,18 @@
 import type { CaptionQueueItem, Media, PostStatus } from "@fanslib/server/schemas";
 import type { Key } from "@react-types/shared";
-import { format } from "date-fns";
-import { ExternalLink, Link2, MoreVertical, Trash2 } from "lucide-react";
-import { Link } from "@tanstack/react-router";
 import type { KeyboardEvent } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQueries } from "@tanstack/react-query";
-import { SnippetSelector } from "~/components/SnippetSelector";
-import { HashtagButton } from "~/components/HashtagButton";
-import { MediaView } from "~/components/MediaView";
-import { Button } from "~/components/ui/Button";
-import { Textarea } from "~/components/ui/Textarea";
-import { ChannelBadge } from "~/components/ChannelBadge";
-import { ContentScheduleBadge } from "~/components/ContentScheduleBadge";
+import { Link2 } from "lucide-react";
 import { DeleteConfirmDialog } from "~/components/ui/DeleteConfirmDialog";
-import {
-  DropdownMenu,
-  DropdownMenuItem,
-  DropdownMenuPopover,
-  DropdownMenuTrigger,
-} from "~/components/ui/DropdownMenu";
 import { useDebounce } from "~/hooks/useDebounce";
 import { usePrefersReducedMotion } from "~/hooks/usePrefersReducedMotion";
 import { cn } from "~/lib/cn";
 import { api } from "~/lib/api/hono-client";
 import { useDeletePostMutation, useUpdatePostMutation } from "~/lib/queries/posts";
-import { MediaTileLite } from "~/features/library/components/MediaTile/MediaTileLite";
-import { TagBadge } from "~/features/library/components/MediaTagEditor/DimensionTagSelector/TagBadge";
-import { CaptionSyncControl } from "~/features/pipeline/components/CaptionSyncControl";
-import { RelatedCaptionsPanel } from "~/features/pipeline/components/RelatedCaptionsPanel";
 import { useLinkedPostsContext } from "./LinkedPostsContext";
+import { CaptionItemHeader } from "./CaptionItemHeader";
+import { CaptionItemEditor } from "./CaptionItemEditor";
 
 const getCompletionStatus = (channelTypeId: string): PostStatus =>
   ["bluesky", "reddit"].includes(channelTypeId) ? "scheduled" : "ready";
@@ -193,165 +176,28 @@ export const CaptionItem = ({ item, isExpanded, onExpand, onAdvance }: CaptionIt
             isLinkedToExpanded ? "ring-2 ring-primary border-primary" : "border-black",
           )}
         >
-          <div className="absolute top-3 right-3 flex items-center gap-2">
-            <Link
-              to="/posts/$postId"
-              params={{ postId: item.post.id }}
-              className="text-base-content/60 hover:text-base-content transition-colors"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <ExternalLink className="w-4 h-4" />
-            </Link>
-            <DropdownMenuTrigger>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-6 w-6 text-base-content/60 hover:text-base-content hover:bg-base-200"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <MoreVertical className="h-4 w-4" />
-              </Button>
-              <DropdownMenuPopover placement="bottom end" className="w-48">
-                <DropdownMenu onAction={handleMenuAction}>
-                  <DropdownMenuItem
-                    id="delete"
-                    className="flex items-center gap-2 text-sm font-medium text-destructive"
-                  >
-                    <Trash2 className="h-4 w-4 shrink-0" />
-                    Delete Post
-                  </DropdownMenuItem>
-                </DropdownMenu>
-              </DropdownMenuPopover>
-            </DropdownMenuTrigger>
-          </div>
-          <button
-            type="button"
-            onClick={onExpand}
-            className="w-full text-left px-4 py-3 flex items-center gap-3"
-          >
-            <div className="flex-1 space-y-1 min-w-0">
-              <div className="flex items-baseline gap-2">
-                <span className="text-base font-semibold">
-                  {format(new Date(item.post.date), "EEE, MMM d")}
-                </span>
-                <span className="text-sm font-medium text-base-content/60">
-                  {format(new Date(item.post.date), "HH:mm")}
-                </span>
-              </div>
-              <div className="flex items-center gap-2 flex-wrap">
-                {schedule && (
-                  <ContentScheduleBadge
-                    name={schedule.name}
-                    emoji={schedule.emoji}
-                    color={schedule.color}
-                    size="sm"
-                    borderStyle="none"
-                    responsive={false}
-                  />
-                )}
-                {channel && (
-                  <ChannelBadge
-                    name={channelName}
-                    typeId={channel.type?.id ?? channel.typeId}
-                    size="sm"
-                    borderStyle="none"
-                    responsive={false}
-                  />
-                )}
-              </div>
-            </div>
-          </button>
+          <CaptionItemHeader
+            postId={item.post.id}
+            date={item.post.date}
+            channel={channel}
+            channelName={channelName}
+            schedule={schedule}
+            onExpand={onExpand}
+            onMenuAction={handleMenuAction}
+          />
           {isExpanded && (
-            <div className="p-4 space-y-4">
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                <div className="space-y-3">
-                  {postMedia.length > 0 && (
-                    <div className="space-y-3">
-                      {postMedia.map((pm, index) => {
-                        const media = pm.media;
-                        const mediaTags = mediaTagQueries[index]?.data ?? [];
-
-                        return (
-                          <div key={pm.id} className="flex gap-4 items-start">
-                            <div className="w-full aspect-square max-w-xs flex-shrink-0">
-                              {media.type === "video" ? (
-                                <MediaView media={media as unknown as Media} controls />
-                              ) : (
-                                <MediaTileLite media={media as unknown as Media} />
-                              )}
-                            </div>
-                            <div className="flex flex-wrap gap-2 pt-2">
-                              {mediaTags
-                                .filter(
-                                  (tag) => tag.stickerDisplay && tag.stickerDisplay !== "none",
-                                )
-                                .map((tag) => (
-                                  <TagBadge
-                                    key={tag.id}
-                                    tag={{
-                                      id: tag.tagDefinitionId,
-                                      color: tag.color,
-                                      displayName:
-                                        tag.shortRepresentation ??
-                                        tag.tagDisplayName ??
-                                        tag.tagValue,
-                                    }}
-                                    size="md"
-                                    selectionMode="radio"
-                                  />
-                                ))}
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                  <div className="relative">
-                    <Textarea
-                      value={localCaption}
-                      onChange={updateCaption}
-                      onKeyDown={onKeyDown}
-                      rows={10}
-                      className="pr-10"
-                      placeholder="Write a caption..."
-                    />
-                    <div className="absolute right-2 top-2 flex gap-1">
-                      <SnippetSelector
-                        channelId={item.post.channel.id}
-                        caption={localCaption}
-                        onCaptionChange={updateCaption}
-                        className="text-base-content/60 hover:text-base-content"
-                      />
-                      <HashtagButton
-                        channel={item.post.channel}
-                        caption={localCaption}
-                        onCaptionChange={updateCaption}
-                        className="text-base-content/60 hover:text-base-content"
-                      />
-                    </div>
-                  </div>
-                  <CaptionSyncControl
-                    linkedPosts={item.linkedPosts}
-                    selectedPostIds={selectedLinkedPostIds}
-                    onSelectionChange={handleLinkedPostSelectionChange}
-                  />
-                  <div className="flex items-center justify-end gap-2">
-                    <Button variant="ghost" size="sm" onClick={onAdvance}>
-                      Skip
-                    </Button>
-                    <Button size="sm" onClick={saveAndAdvance}>
-                      Save & Next
-                    </Button>
-                  </div>
-                </div>
-                <RelatedCaptionsPanel
-                  relatedByMedia={item.relatedByMedia}
-                  relatedByShoot={item.relatedByShoot}
-                  currentCaption={localCaption}
-                  onUseCaption={updateCaption}
-                />
-              </div>
-            </div>
+            <CaptionItemEditor
+              item={item}
+              postMedia={postMedia as unknown as Array<{ id: string; media: Media }>}
+              mediaTagQueries={mediaTagQueries}
+              localCaption={localCaption}
+              updateCaption={updateCaption}
+              onKeyDown={onKeyDown}
+              selectedLinkedPostIds={selectedLinkedPostIds}
+              onLinkedPostSelectionChange={handleLinkedPostSelectionChange}
+              onAdvance={onAdvance}
+              onSaveAndAdvance={saveAndAdvance}
+            />
           )}
         </div>
       </div>

--- a/@fanslib/apps/web/src/features/pipeline/components/CaptioningStep/CaptionItemEditor.tsx
+++ b/@fanslib/apps/web/src/features/pipeline/components/CaptioningStep/CaptionItemEditor.tsx
@@ -1,0 +1,87 @@
+import type { CaptionQueueItem, Media } from "@fanslib/server/schemas";
+import type { KeyboardEvent } from "react";
+import { SnippetSelector } from "~/components/SnippetSelector";
+import { HashtagButton } from "~/components/HashtagButton";
+import { Button } from "~/components/ui/Button";
+import { Textarea } from "~/components/ui/Textarea";
+import { CaptionSyncControl } from "~/features/pipeline/components/CaptionSyncControl";
+import { RelatedCaptionsPanel } from "~/features/pipeline/components/RelatedCaptionsPanel";
+import type { MediaTagResult } from "./MediaPreviewWithTags";
+import { MediaPreviewWithTags } from "./MediaPreviewWithTags";
+
+type CaptionItemEditorProps = {
+  item: CaptionQueueItem;
+  postMedia: Array<{ id: string; media: Media }>;
+  mediaTagQueries: { data?: MediaTagResult[] | undefined }[];
+  localCaption: string;
+  updateCaption: (caption: string) => void;
+  onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+  selectedLinkedPostIds: string[];
+  onLinkedPostSelectionChange: (ids: string[]) => void;
+  onAdvance: () => void;
+  onSaveAndAdvance: () => void;
+};
+
+export const CaptionItemEditor = ({
+  item,
+  postMedia,
+  mediaTagQueries,
+  localCaption,
+  updateCaption,
+  onKeyDown,
+  selectedLinkedPostIds,
+  onLinkedPostSelectionChange,
+  onAdvance,
+  onSaveAndAdvance,
+}: CaptionItemEditorProps) => (
+  <div className="p-4 space-y-4">
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <div className="space-y-3">
+        <MediaPreviewWithTags postMedia={postMedia} mediaTagQueries={mediaTagQueries} />
+        <div className="relative">
+          <Textarea
+            value={localCaption}
+            onChange={updateCaption}
+            onKeyDown={onKeyDown}
+            rows={10}
+            className="pr-10"
+            placeholder="Write a caption..."
+          />
+          <div className="absolute right-2 top-2 flex gap-1">
+            <SnippetSelector
+              channelId={item.post.channel.id}
+              caption={localCaption}
+              onCaptionChange={updateCaption}
+              className="text-base-content/60 hover:text-base-content"
+            />
+            <HashtagButton
+              channel={item.post.channel}
+              caption={localCaption}
+              onCaptionChange={updateCaption}
+              className="text-base-content/60 hover:text-base-content"
+            />
+          </div>
+        </div>
+        <CaptionSyncControl
+          linkedPosts={item.linkedPosts}
+          selectedPostIds={selectedLinkedPostIds}
+          onSelectionChange={onLinkedPostSelectionChange}
+        />
+        <div className="flex items-center justify-end gap-2">
+          <Button variant="ghost" size="sm" onClick={onAdvance}>
+            Skip
+          </Button>
+          <Button size="sm" onClick={onSaveAndAdvance}>
+            Save & Next
+          </Button>
+        </div>
+      </div>
+      <RelatedCaptionsPanel
+        relatedByMedia={item.relatedByMedia}
+        relatedByShoot={item.relatedByShoot}
+        currentCaption={localCaption}
+        onUseCaption={updateCaption}
+      />
+    </div>
+  </div>
+);

--- a/@fanslib/apps/web/src/features/pipeline/components/CaptioningStep/CaptionItemHeader.tsx
+++ b/@fanslib/apps/web/src/features/pipeline/components/CaptioningStep/CaptionItemHeader.tsx
@@ -1,0 +1,104 @@
+import type { Key } from "@react-types/shared";
+import { format } from "date-fns";
+import { ExternalLink, MoreVertical, Trash2 } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { Button } from "~/components/ui/Button";
+import { ChannelBadge } from "~/components/ChannelBadge";
+import { ContentScheduleBadge } from "~/components/ContentScheduleBadge";
+import {
+  DropdownMenu,
+  DropdownMenuItem,
+  DropdownMenuPopover,
+  DropdownMenuTrigger,
+} from "~/components/ui/DropdownMenu";
+
+type CaptionItemHeaderProps = {
+  postId: string;
+  date: string | Date;
+  channel: { name: string; id: string; typeId: string; type?: { id: string } } | undefined;
+  channelName: string;
+  schedule: { name: string; emoji: string | null; color: string | null } | null | undefined;
+  onExpand: () => void;
+  onMenuAction: (key: Key) => void;
+};
+
+export const CaptionItemHeader = ({
+  postId,
+  date,
+  channel,
+  channelName,
+  schedule,
+  onExpand,
+  onMenuAction,
+}: CaptionItemHeaderProps) => (
+  <>
+    <div className="absolute top-3 right-3 flex items-center gap-2">
+      <Link
+        to="/posts/$postId"
+        params={{ postId }}
+        className="text-base-content/60 hover:text-base-content transition-colors"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <ExternalLink className="w-4 h-4" />
+      </Link>
+      <DropdownMenuTrigger>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 text-base-content/60 hover:text-base-content hover:bg-base-200"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <MoreVertical className="h-4 w-4" />
+        </Button>
+        <DropdownMenuPopover placement="bottom end" className="w-48">
+          <DropdownMenu onAction={onMenuAction}>
+            <DropdownMenuItem
+              id="delete"
+              className="flex items-center gap-2 text-sm font-medium text-destructive"
+            >
+              <Trash2 className="h-4 w-4 shrink-0" />
+              Delete Post
+            </DropdownMenuItem>
+          </DropdownMenu>
+        </DropdownMenuPopover>
+      </DropdownMenuTrigger>
+    </div>
+    <button
+      type="button"
+      onClick={onExpand}
+      className="w-full text-left px-4 py-3 flex items-center gap-3"
+    >
+      <div className="flex-1 space-y-1 min-w-0">
+        <div className="flex items-baseline gap-2">
+          <span className="text-base font-semibold">
+            {format(new Date(date), "EEE, MMM d")}
+          </span>
+          <span className="text-sm font-medium text-base-content/60">
+            {format(new Date(date), "HH:mm")}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          {schedule && (
+            <ContentScheduleBadge
+              name={schedule.name}
+              emoji={schedule.emoji}
+              color={schedule.color}
+              size="sm"
+              borderStyle="none"
+              responsive={false}
+            />
+          )}
+          {channel && (
+            <ChannelBadge
+              name={channelName}
+              typeId={channel.type?.id ?? channel.typeId}
+              size="sm"
+              borderStyle="none"
+              responsive={false}
+            />
+          )}
+        </div>
+      </div>
+    </button>
+  </>
+);

--- a/@fanslib/apps/web/src/features/pipeline/components/CaptioningStep/MediaPreviewWithTags.tsx
+++ b/@fanslib/apps/web/src/features/pipeline/components/CaptioningStep/MediaPreviewWithTags.tsx
@@ -1,0 +1,68 @@
+import type { Media } from "@fanslib/server/schemas";
+import { MediaView } from "~/components/MediaView";
+import { MediaTileLite } from "~/features/library/components/MediaTile/MediaTileLite";
+import { TagBadge } from "~/features/library/components/MediaTagEditor/DimensionTagSelector/TagBadge";
+
+/** Minimal media tag shape needed for display. */
+export type MediaTagResult = {
+  id: number;
+  tagDefinitionId: number;
+  color: string | null;
+  stickerDisplay: string;
+  shortRepresentation: string | null;
+  tagDisplayName: string;
+  tagValue: string;
+};
+
+type PostMediaItem = {
+  id: string;
+  media: Media;
+};
+
+type MediaPreviewWithTagsProps = {
+  postMedia: PostMediaItem[];
+  /** Query results whose data arrays contain at least the MediaTagResult fields. */
+  mediaTagQueries: { data?: MediaTagResult[] | undefined }[];
+};
+
+export const MediaPreviewWithTags = ({ postMedia, mediaTagQueries }: MediaPreviewWithTagsProps) => {
+  if (postMedia.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      {postMedia.map((pm, index) => {
+        const media = pm.media;
+        const mediaTags = mediaTagQueries[index]?.data ?? [];
+
+        return (
+          <div key={pm.id} className="flex gap-4 items-start">
+            <div className="w-full aspect-square max-w-xs flex-shrink-0">
+              {media.type === "video" ? (
+                <MediaView media={media as unknown as Media} controls />
+              ) : (
+                <MediaTileLite media={media as unknown as Media} />
+              )}
+            </div>
+            <div className="flex flex-wrap gap-2 pt-2">
+              {mediaTags
+                .filter((tag) => tag.stickerDisplay && tag.stickerDisplay !== "none")
+                .map((tag) => (
+                  <TagBadge
+                    key={tag.id}
+                    tag={{
+                      id: tag.tagDefinitionId,
+                      color: tag.color,
+                      displayName:
+                        tag.shortRepresentation ?? tag.tagDisplayName ?? tag.tagValue,
+                    }}
+                    size="md"
+                    selectionMode="radio"
+                  />
+                ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

- Extract from 369-line `CaptionItem.tsx`:
  - `CaptionItemHeader.tsx` — collapsed row with date, badges, dropdown menu
  - `CaptionItemEditor.tsx` — expanded editing panel with textarea, sync, actions
  - `MediaPreviewWithTags.tsx` — media grid with tag badges
- `CaptionItem.tsx` slimmed to orchestrator with state management
- No behavior changes, no interface changes

Closes #187

## Test plan

- [x] Typecheck clean
- [x] Lint clean
- [ ] Manual: verify caption queue item expand/collapse and editing work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)