### PR TITLE
feat: add link/unlink channel API endpoints for schedules

### DIFF
--- a/@fanslib/apps/server/src/features/content-schedules/operations/schedule-channel/link.ts
+++ b/@fanslib/apps/server/src/features/content-schedules/operations/schedule-channel/link.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { db } from "../../../../lib/db";
+import { ContentSchedule, ScheduleChannel } from "../../entity";
+import { fetchContentScheduleById } from "../content-schedule/fetch-by-id";
+
+export const LinkChannelRequestBodySchema = z.object({
+  channelId: z.string(),
+});
+
+export const linkChannelToSchedule = async (scheduleId: string, channelId: string) => {
+  const dataSource = await db();
+  const scheduleRepo = dataSource.getRepository(ContentSchedule);
+  const scheduleChannelRepo = dataSource.getRepository(ScheduleChannel);
+
+  const schedule = await scheduleRepo.findOne({ where: { id: scheduleId } });
+  if (!schedule) return { error: "not-found" as const };
+
+  const existing = await scheduleChannelRepo.findOne({
+    where: { scheduleId, channelId },
+  });
+  if (existing) return { error: "already-linked" as const };
+
+  const entity = new ScheduleChannel();
+  Object.assign(entity, {
+    scheduleId,
+    channelId,
+    sortOrder: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  await scheduleChannelRepo.save(entity);
+
+  return { data: await fetchContentScheduleById(scheduleId) };
+};

--- a/@fanslib/apps/server/src/features/content-schedules/operations/schedule-channel/unlink.ts
+++ b/@fanslib/apps/server/src/features/content-schedules/operations/schedule-channel/unlink.ts
@@ -1,0 +1,21 @@
+import { db } from "../../../../lib/db";
+import { ContentSchedule, ScheduleChannel } from "../../entity";
+import { fetchContentScheduleById } from "../content-schedule/fetch-by-id";
+
+export const unlinkChannelFromSchedule = async (scheduleId: string, channelId: string) => {
+  const dataSource = await db();
+  const scheduleRepo = dataSource.getRepository(ContentSchedule);
+  const scheduleChannelRepo = dataSource.getRepository(ScheduleChannel);
+
+  const schedule = await scheduleRepo.findOne({ where: { id: scheduleId } });
+  if (!schedule) return { error: "not-found" as const };
+
+  const existing = await scheduleChannelRepo.findOne({
+    where: { scheduleId, channelId },
+  });
+  if (!existing) return { error: "not-linked" as const };
+
+  await scheduleChannelRepo.remove(existing);
+
+  return { data: await fetchContentScheduleById(scheduleId) };
+};

--- a/@fanslib/apps/server/src/features/content-schedules/routes.test.ts
+++ b/@fanslib/apps/server/src/features/content-schedules/routes.test.ts
@@ -212,6 +212,107 @@ describe("Content Schedules Routes", () => {
     });
   });
 
+  describe("POST /api/content-schedules/:id/link-channel", () => {
+    test("links a channel to a schedule and returns updated schedule", async () => {
+      const fixtureSchedule = CONTENT_SCHEDULE_FIXTURES[0];
+      if (!fixtureSchedule) {
+        throw new Error("No content schedule fixtures available");
+      }
+
+      // Use a channel that is NOT already linked to this schedule
+      const unlinkedChannel = fixtures.channels.channels.find(
+        (c) => c.id !== fixtureSchedule.fixtureChannelId,
+      );
+      if (!unlinkedChannel) {
+        throw new Error("No unlinked channel available");
+      }
+
+      const response = await app.request(
+        `/api/content-schedules/${fixtureSchedule.id}/link-channel`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ channelId: unlinkedChannel.id }),
+        },
+      );
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<ScheduleResponse>(response);
+      expect(data?.id).toBe(fixtureSchedule.id);
+      expect(data?.scheduleChannels?.some((sc) => sc.channelId === unlinkedChannel.id)).toBe(true);
+    });
+
+    test("returns 409 when channel is already linked", async () => {
+      const fixtureSchedule = CONTENT_SCHEDULE_FIXTURES[0];
+      if (!fixtureSchedule) {
+        throw new Error("No content schedule fixtures available");
+      }
+
+      // The fixture channel is already linked via seed data
+      const response = await app.request(
+        `/api/content-schedules/${fixtureSchedule.id}/link-channel`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ channelId: fixtureSchedule.fixtureChannelId }),
+        },
+      );
+      expect(response.status).toBe(409);
+
+      const data = await parseResponse<{ error: string }>(response);
+      expect(data?.error).toBe("Channel already linked to this schedule");
+    });
+  });
+
+  describe("DELETE /api/content-schedules/:id/unlink-channel/:channelId", () => {
+    test("unlinks a channel from a schedule and returns updated schedule", async () => {
+      const fixtureSchedule = CONTENT_SCHEDULE_FIXTURES[0];
+      if (!fixtureSchedule) {
+        throw new Error("No content schedule fixtures available");
+      }
+
+      // First link a new channel so we can unlink it
+      const unlinkedChannel = fixtures.channels.channels.find(
+        (c) => c.id !== fixtureSchedule.fixtureChannelId,
+      );
+      if (!unlinkedChannel) {
+        throw new Error("No unlinked channel available");
+      }
+
+      await app.request(`/api/content-schedules/${fixtureSchedule.id}/link-channel`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ channelId: unlinkedChannel.id }),
+      });
+
+      const response = await app.request(
+        `/api/content-schedules/${fixtureSchedule.id}/unlink-channel/${unlinkedChannel.id}`,
+        { method: "DELETE" },
+      );
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<ScheduleResponse>(response);
+      expect(data?.id).toBe(fixtureSchedule.id);
+      expect(data?.scheduleChannels?.some((sc) => sc.channelId === unlinkedChannel.id)).toBe(false);
+    });
+
+    test("returns 404 when channel is not linked", async () => {
+      const fixtureSchedule = CONTENT_SCHEDULE_FIXTURES[0];
+      if (!fixtureSchedule) {
+        throw new Error("No content schedule fixtures available");
+      }
+
+      const response = await app.request(
+        `/api/content-schedules/${fixtureSchedule.id}/unlink-channel/non-existent-channel`,
+        { method: "DELETE" },
+      );
+      expect(response.status).toBe(404);
+
+      const data = await parseResponse<{ error: string }>(response);
+      expect(data?.error).toBe("Channel is not linked to this schedule");
+    });
+  });
+
   describe("GET /api/content-schedules/virtual-posts", () => {
     test("returns virtual posts for channel ids as comma-separated string", async () => {
       const channel = fixtures.channels.channels[0];

--- a/@fanslib/apps/server/src/features/content-schedules/routes.ts
+++ b/@fanslib/apps/server/src/features/content-schedules/routes.ts
@@ -18,6 +18,11 @@ import {
   fetchVirtualPosts,
 } from "./operations/generate-virtual-posts";
 import {
+  LinkChannelRequestBodySchema,
+  linkChannelToSchedule,
+} from "./operations/schedule-channel/link";
+import { unlinkChannelFromSchedule } from "./operations/schedule-channel/unlink";
+import {
   CreateSkippedSlotRequestBodySchema,
   createSkippedSlot,
 } from "./operations/skipped-slots/create";
@@ -80,6 +85,30 @@ export const contentSchedulesRoutes = new Hono()
       return notFound(c, "Content schedule not found");
     }
     return c.json({ success: true });
+  })
+  .post(
+    "/:id/link-channel",
+    zValidator("json", LinkChannelRequestBodySchema, validationError),
+    async (c) => {
+      const id = c.req.param("id");
+      const { channelId } = c.req.valid("json");
+      const result = await linkChannelToSchedule(id, channelId);
+      if ("error" in result) {
+        if (result.error === "not-found") return notFound(c, "Content schedule not found");
+        return c.json({ error: "Channel already linked to this schedule" }, 409);
+      }
+      return c.json(result.data);
+    },
+  )
+  .delete("/:id/unlink-channel/:channelId", async (c) => {
+    const id = c.req.param("id");
+    const channelId = c.req.param("channelId");
+    const result = await unlinkChannelFromSchedule(id, channelId);
+    if ("error" in result) {
+      if (result.error === "not-found") return notFound(c, "Content schedule not found");
+      return notFound(c, "Channel is not linked to this schedule");
+    }
+    return c.json(result.data);
   })
   .post(
     "/skipped-slots",

--- a/@fanslib/apps/web/src/lib/queries/content-schedules.ts
+++ b/@fanslib/apps/web/src/lib/queries/content-schedules.ts
@@ -125,6 +125,43 @@ export const useDeleteContentScheduleMutation = () => {
   });
 };
 
+export const useLinkChannelToScheduleMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ scheduleId, channelId }: { scheduleId: string; channelId: string }) => {
+      const result = await api.api["content-schedules"][":id"]["link-channel"].$post({
+        param: { id: scheduleId },
+        json: { channelId },
+      });
+      return result.json();
+    },
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.contentSchedules.all() });
+      queryClient.setQueryData(QUERY_KEYS.contentSchedules.byId(variables.scheduleId), data);
+    },
+  });
+};
+
+export const useUnlinkChannelFromScheduleMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ scheduleId, channelId }: { scheduleId: string; channelId: string }) => {
+      const result = await api.api["content-schedules"][":id"]["unlink-channel"][
+        ":channelId"
+      ].$delete({
+        param: { id: scheduleId, channelId },
+      });
+      return result.json();
+    },
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.contentSchedules.all() });
+      queryClient.setQueryData(QUERY_KEYS.contentSchedules.byId(variables.scheduleId), data);
+    },
+  });
+};
+
 export const useSkipScheduleSlotMutation = () => {
   const queryClient = useQueryClient();
 


### PR DESCRIPTION
## Summary

- Add `POST /api/content-schedules/:id/link-channel` — creates ScheduleChannel row, returns 409 if already linked
- Add `DELETE /api/content-schedules/:id/unlink-channel/:channelId` — removes ScheduleChannel row, returns 404 if not linked
- Add `useLinkChannelToScheduleMutation()` and `useUnlinkChannelFromScheduleMutation()` web hooks
- 4 new TDD tests covering happy paths and error cases

Closes #192

## Test plan

- [x] Test: link channel returns updated schedule (200)
- [x] Test: link already-linked channel returns 409
- [x] Test: unlink channel returns updated schedule (200)
- [x] Test: unlink non-linked channel returns 404
- [x] All 16 content-schedule tests pass
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)