### PR TITLE
feat: display content rating and role badges on MediaTile

### DIFF
--- a/@fanslib/apps/web/src/features/library/components/MediaTile/MediaTile.tsx
+++ b/@fanslib/apps/web/src/features/library/components/MediaTile/MediaTile.tsx
@@ -7,7 +7,7 @@ import { cn } from "~/lib/cn";
 import { MediaTileImage } from "./MediaTileImage";
 import { MediaTilePostsPopover } from "./MediaTilePostsPopover";
 import { MediaTileSelectionCircle } from "./MediaTileSelectionCircle";
-import { MediaTileTagBadges } from "./MediaTileTagBadges";
+import { MediaTileBadges } from "./MediaTileBadges";
 import { MediaTileTypeSticker } from "./MediaTileTypeSticker";
 import { MediaTileVideo } from "./MediaTileVideo";
 import type { MediaTileProps } from "./types";
@@ -182,7 +182,13 @@ export const MediaTile = memo((props: MediaTileProps) => {
           {(withTags || withPostsPopover || withTypeIcon) && (
             <div className="flex items-center gap-2">
               <div className="flex flex-wrap gap-1 flex-1 min-w-0">
-                {withTags && <MediaTileTagBadges tags={tags} />}
+                {withTags && (
+                  <MediaTileBadges
+                    contentRating={media.contentRating ?? null}
+                    role={media.role ?? null}
+                    tags={tags}
+                  />
+                )}
                 {withTypeIcon && <MediaTileTypeSticker media={media} />}
               </div>
               {withPostsPopover && <MediaTilePostsPopover media={media} />}

--- a/@fanslib/apps/web/src/features/library/components/MediaTile/MediaTileBadges.tsx
+++ b/@fanslib/apps/web/src/features/library/components/MediaTile/MediaTileBadges.tsx
@@ -1,0 +1,45 @@
+import type { Media, MediaTag } from "@fanslib/server/schemas";
+import { MediaTileTagBadges } from "./MediaTileTagBadges";
+
+type ContentRating = NonNullable<Media["contentRating"]>;
+
+const CONTENT_RATING_COLORS: Record<ContentRating, string> = {
+  xt: "bg-red-500",
+  uc: "bg-orange-500",
+  cn: "bg-yellow-500",
+  sg: "bg-green-500",
+  sf: "bg-blue-500",
+};
+
+type MediaTileBadgesProps = {
+  contentRating: ContentRating | null;
+  role: string | null;
+  tags: MediaTag[];
+};
+
+export const MediaTileBadges = ({ contentRating, role, tags }: MediaTileBadgesProps) => {
+  if (contentRating || role) {
+    return (
+      <>
+        {contentRating && (
+          <span
+            data-testid="content-rating-badge"
+            className={`${CONTENT_RATING_COLORS[contentRating]} text-white text-[9px] font-bold leading-none px-1.5 py-0.5 rounded-full pointer-events-none`}
+          >
+            {contentRating.toUpperCase()}
+          </span>
+        )}
+        {role && (
+          <span
+            data-testid="role-badge"
+            className="bg-base-300 text-base-content text-[9px] font-bold leading-none px-1.5 py-0.5 rounded-full pointer-events-none"
+          >
+            {role}
+          </span>
+        )}
+      </>
+    );
+  }
+
+  return <MediaTileTagBadges tags={tags} />;
+};

--- a/@fanslib/apps/web/src/features/library/components/MediaTile/MediaTileBadges.vitest.tsx
+++ b/@fanslib/apps/web/src/features/library/components/MediaTile/MediaTileBadges.vitest.tsx
@@ -1,0 +1,92 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import type { MediaTag } from "@fanslib/server/schemas";
+import { MediaTileBadges } from "./MediaTileBadges";
+
+const makeStickerTag = (overrides: Partial<MediaTag> = {}): MediaTag => ({
+  id: 1,
+  mediaId: "media-1",
+  tagDefinitionId: 10,
+  dimensionId: 1,
+  dimensionName: "mood",
+  dataType: "categorical",
+  tagValue: "happy",
+  tagDisplayName: "Happy",
+  color: "#ff0000",
+  stickerDisplay: "short",
+  shortRepresentation: "H",
+  numericValue: null,
+  booleanValue: null,
+  confidence: null,
+  source: "manual",
+  assignedAt: new Date(),
+  ...overrides,
+});
+
+describe("MediaTileBadges", () => {
+  test("shows content rating badge when contentRating is set", () => {
+    render(<MediaTileBadges contentRating="xt" role={null} tags={[]} />);
+
+    expect(screen.getByText("XT")).toBeInTheDocument();
+  });
+
+  test("shows role badge when role is set", () => {
+    render(<MediaTileBadges contentRating={null} role="solo" tags={[]} />);
+
+    expect(screen.getByText("solo")).toBeInTheDocument();
+  });
+
+  test("shows both badges when contentRating and role are set", () => {
+    render(<MediaTileBadges contentRating="sg" role="b/g" tags={[]} />);
+
+    expect(screen.getByText("SG")).toBeInTheDocument();
+    expect(screen.getByText("b/g")).toBeInTheDocument();
+  });
+
+  test.each([
+    ["xt", "bg-red-500"],
+    ["uc", "bg-orange-500"],
+    ["cn", "bg-yellow-500"],
+    ["sg", "bg-green-500"],
+    ["sf", "bg-blue-500"],
+  ] as const)("content rating %s has color class %s", (rating, colorClass) => {
+    render(<MediaTileBadges contentRating={rating} role={null} tags={[]} />);
+
+    const badge = screen.getByText(rating.toUpperCase());
+    expect(badge.closest("[data-testid='content-rating-badge']")).toHaveClass(colorClass);
+  });
+
+  test("falls back to tag badges when neither contentRating nor role is set", () => {
+    const tags = [makeStickerTag()];
+    render(<MediaTileBadges contentRating={null} role={null} tags={tags} />);
+
+    // Should show tag display name (via shortRepresentation)
+    expect(screen.getByText("H")).toBeInTheDocument();
+    // Should NOT show any content rating badge
+    expect(screen.queryByTestId("content-rating-badge")).not.toBeInTheDocument();
+  });
+
+  test("renders nothing when no contentRating, no role, and no displayable tags", () => {
+    const { container } = render(<MediaTileBadges contentRating={null} role={null} tags={[]} />);
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("does not show tag badges when role is set without contentRating", () => {
+    const tags = [makeStickerTag()];
+    render(<MediaTileBadges contentRating={null} role="solo" tags={tags} />);
+
+    expect(screen.getByText("solo")).toBeInTheDocument();
+    expect(screen.queryByText("H")).not.toBeInTheDocument();
+  });
+
+  test("does not show tag badges when contentRating is set", () => {
+    const tags = [makeStickerTag()];
+    render(<MediaTileBadges contentRating="xt" role={null} tags={tags} />);
+
+    expect(screen.getByText("XT")).toBeInTheDocument();
+    // Tag badge text should NOT appear
+    expect(screen.queryByText("H")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `MediaTileBadges` component that conditionally shows color-coded content rating badges (xt=red, uc=orange, cn=yellow, sg=green, sf=blue) and role badges on media tiles
- When neither `contentRating` nor `role` is set, falls back to existing tag badge display
- Rating/role badges and tag badges are never shown simultaneously

Closes #225

## Test plan

- [x] Content rating badge renders for each rating value
- [x] Each rating has correct color class
- [x] Role badge renders when role is set
- [x] Both badges render when both fields are set
- [x] Falls back to tag badges when neither field is set
- [x] Returns nothing when no fields set and no displayable tags
- [x] Tag badges suppressed when contentRating or role is present
- [ ] Visual check in browser that badges look correct on real media

🤖 Generated with [Claude Code](https://claude.com/claude-code)