### PR TITLE
feat: add shoot sidebar to library page

### DIFF
--- a/@fanslib/apps/web/src/contexts/LibraryPreferencesContext.tsx
+++ b/@fanslib/apps/web/src/contexts/LibraryPreferencesContext.tsx
@@ -8,9 +8,14 @@ type MediaFilters = MediaFilter;
 
 export type GridSize = "small" | "large";
 
+export type ShootSortBy = "date" | "alphabetical";
+
 type ViewPreferences = {
   gridSize: GridSize;
   filtersCollapsed: boolean;
+  sidebarCollapsed: boolean;
+  sidebarShootId: string | null;
+  sidebarSortBy: ShootSortBy;
 };
 
 type SortPreferences = MediaSort;
@@ -31,6 +36,9 @@ const defaultPreferences: LibraryPreferences = {
   view: {
     gridSize: "large",
     filtersCollapsed: false,
+    sidebarCollapsed: false,
+    sidebarShootId: null,
+    sidebarSortBy: "date",
   },
   filter: [],
   sort: {

--- a/@fanslib/apps/web/src/features/library/components/LibraryContent.tsx
+++ b/@fanslib/apps/web/src/features/library/components/LibraryContent.tsx
@@ -1,5 +1,5 @@
 import type { Media, MediaFilter } from "@fanslib/server/schemas";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { FilterPresetProvider } from "~/contexts/FilterPresetContext";
 import { useLibraryPreferences } from "~/contexts/LibraryPreferencesContext";
 import { useScan } from "~/hooks/useScan";
@@ -14,6 +14,7 @@ import { MediaFilters as MediaFiltersComponent } from "./MediaFilters/MediaFilte
 import { MediaFiltersProvider } from "./MediaFilters/MediaFiltersContext";
 import { ScanButton } from "./ScanButton";
 import { ScanProgress } from "./ScanProgress";
+import { ShootSidebar } from "./ShootSidebar/ShootSidebar";
 import { UploadDialog } from "./UploadDialog/UploadDialog";
 import { cn } from "~/lib/cn";
 
@@ -26,6 +27,21 @@ type LibraryContentProps = {
 
 export const LibraryContent = ({ showScan = true, contentClassName }: LibraryContentProps) => {
   const { preferences, updatePreferences } = useLibraryPreferences();
+  const sidebarShootId = preferences.view.sidebarShootId;
+
+  const effectiveFilters: MediaFilter = useMemo(() => {
+    const base = preferences.filter ?? [];
+    if (!sidebarShootId) return base;
+
+    if (sidebarShootId === "__none__") {
+      // "No shoot" = exclude all shoots = media not in any shoot
+      return [...base, { include: false, items: [{ type: "shoot" as const, id: "" }] }];
+    }
+
+    // Specific shoot = include media from that shoot
+    return [...base, { include: true, items: [{ type: "shoot" as const, id: sidebarShootId }] }];
+  }, [preferences.filter, sidebarShootId]);
+
   const {
     data: mediaList,
     error,
@@ -35,7 +51,7 @@ export const LibraryContent = ({ showScan = true, contentClassName }: LibraryCon
     page: preferences.pagination.page,
     limit: preferences.pagination.limit,
     sort: preferences.sort,
-    filters: preferences.filter,
+    filters: effectiveFilters,
   });
   const { isScanning, scanProgress, handleScan, scanResult } = useScan();
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
@@ -58,7 +74,9 @@ export const LibraryContent = ({ showScan = true, contentClassName }: LibraryCon
   return (
     <FilterPresetProvider onFiltersChange={updateFilters}>
       <MediaFiltersProvider value={preferences.filter} onChange={updateFilters}>
-        <div className="flex h-full w-full flex-col overflow-hidden">
+        <div className="flex h-full w-full overflow-hidden">
+          <ShootSidebar />
+          <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
           <div className={cn("flex-1 min-h-0 px-6 pb-6 flex flex-col", contentClassName)}>
             <div className="mb-4">
               <div className="flex items-center justify-end gap-2 pt-2 mb-4">
@@ -110,6 +128,7 @@ export const LibraryContent = ({ showScan = true, contentClassName }: LibraryCon
               totalItems={mediaList?.total ?? 0}
             />
           </div>
+        </div>
         </div>
         <UploadDialog open={uploadDialogOpen} onOpenChange={setUploadDialogOpen} />
       </MediaFiltersProvider>

--- a/@fanslib/apps/web/src/features/library/components/ShootSidebar/ShootSidebar.tsx
+++ b/@fanslib/apps/web/src/features/library/components/ShootSidebar/ShootSidebar.tsx
@@ -1,0 +1,145 @@
+import { ArrowUpDown, ChevronLeft, ChevronRight, Link, Search, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { useLibraryPreferences, type ShootSortBy } from "~/contexts/LibraryPreferencesContext";
+import { useShootsQuery } from "~/lib/queries/shoots";
+import { cn } from "~/lib/cn";
+import { filterAndSortShoots } from "./filter-and-sort-shoots";
+
+export const ShootSidebar = () => {
+  const navigate = useNavigate();
+  const { preferences, updatePreferences } = useLibraryPreferences();
+  const { data: shootsData } = useShootsQuery({ limit: 500 });
+  const [search, setSearch] = useState("");
+
+  const collapsed = preferences.view.sidebarCollapsed;
+  const selectedShootId = preferences.view.sidebarShootId;
+  const sortBy = preferences.view.sidebarSortBy;
+
+  const shoots = useMemo(() => {
+    const raw = (shootsData as { items?: { id: string; name: string; shootDate: string | Date }[] })?.items ?? [];
+    const items = raw.map((s) => ({ ...s, shootDate: new Date(s.shootDate) }));
+    return filterAndSortShoots(items, { search, sortBy });
+  }, [shootsData, search, sortBy]);
+
+  const toggleCollapsed = () => {
+    updatePreferences({ view: { sidebarCollapsed: !collapsed } });
+  };
+
+  const toggleSort = () => {
+    const next: ShootSortBy = sortBy === "date" ? "alphabetical" : "date";
+    updatePreferences({ view: { sidebarSortBy: next } });
+  };
+
+  const selectShoot = (shootId: string | null) => {
+    const newId = shootId === selectedShootId ? null : shootId;
+    updatePreferences({ view: { sidebarShootId: newId } });
+  };
+
+  if (collapsed) {
+    return (
+      <div className="flex flex-col items-center py-2 border-r border-base-300 w-10">
+        <button
+          type="button"
+          onClick={toggleCollapsed}
+          className="p-1 hover:bg-base-200 rounded transition-colors"
+          title="Expand sidebar"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col w-56 border-r border-base-300 bg-base-100 overflow-hidden">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-base-300">
+        <span className="text-sm font-medium">Shoots</span>
+        <button
+          type="button"
+          onClick={toggleCollapsed}
+          className="p-1 hover:bg-base-200 rounded transition-colors"
+          title="Collapse sidebar"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="px-2 py-2 flex items-center gap-1">
+        <div className="flex-1 relative">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-base-content/40" />
+          <input
+            type="text"
+            placeholder="Search..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full pl-6 pr-2 py-1 text-xs bg-base-200 rounded border-0 outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={toggleSort}
+          className="p-1 hover:bg-base-200 rounded transition-colors"
+          title={sortBy === "date" ? "Sort alphabetically" : "Sort by date"}
+        >
+          <ArrowUpDown className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        <button
+          type="button"
+          onClick={() => selectShoot("__none__")}
+          className={cn(
+            "w-full text-left px-3 py-1.5 text-xs hover:bg-base-200 transition-colors flex items-center gap-2",
+            selectedShootId === "__none__" && "bg-primary/10 text-primary font-medium",
+          )}
+        >
+          <span className="italic text-base-content/60">No shoot</span>
+        </button>
+
+        {shoots.map((shoot) => (
+          <div
+            key={shoot.id}
+            className={cn(
+              "flex items-center group hover:bg-base-200 transition-colors",
+              selectedShootId === shoot.id && "bg-primary/10",
+            )}
+          >
+            <button
+              type="button"
+              onClick={() => selectShoot(shoot.id)}
+              className={cn(
+                "flex-1 text-left px-3 py-1.5 text-xs truncate",
+                selectedShootId === shoot.id && "text-primary font-medium",
+              )}
+            >
+              {shoot.name}
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate({ to: "/shoots/$shootId", params: { shootId: shoot.id } })}
+              className="hidden group-hover:flex p-1 mr-1 hover:bg-base-300 rounded"
+              title="Go to shoot detail"
+            >
+              <Link className="h-3 w-3" />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {selectedShootId && (
+        <div className="border-t border-base-300 px-3 py-2">
+          <button
+            type="button"
+            onClick={() => selectShoot(null)}
+            className="flex items-center gap-1 text-xs text-base-content/60 hover:text-base-content transition-colors"
+          >
+            <X className="h-3 w-3" />
+            Clear selection
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/features/library/components/ShootSidebar/filter-and-sort-shoots.ts
+++ b/@fanslib/apps/web/src/features/library/components/ShootSidebar/filter-and-sort-shoots.ts
@@ -1,0 +1,22 @@
+type ShootLike = { id: string; name: string; shootDate: Date };
+
+type FilterAndSortOptions = {
+  search: string;
+  sortBy: "date" | "alphabetical";
+};
+
+export const filterAndSortShoots = <T extends ShootLike>(
+  shoots: T[],
+  options: FilterAndSortOptions,
+): T[] => {
+  const filtered = options.search
+    ? shoots.filter((s) => s.name.toLowerCase().includes(options.search.toLowerCase()))
+    : shoots;
+
+  return [...filtered].sort((a, b) => {
+    if (options.sortBy === "alphabetical") {
+      return a.name.localeCompare(b.name);
+    }
+    return new Date(b.shootDate).getTime() - new Date(a.shootDate).getTime();
+  });
+};

--- a/@fanslib/apps/web/src/features/library/components/ShootSidebar/filter-and-sort-shoots.vitest.ts
+++ b/@fanslib/apps/web/src/features/library/components/ShootSidebar/filter-and-sort-shoots.vitest.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import { filterAndSortShoots } from "./filter-and-sort-shoots";
+
+type ShootLike = { id: string; name: string; shootDate: Date };
+
+const makeShoot = (overrides: Partial<ShootLike> & { id: string; name: string }): ShootLike => ({
+  shootDate: new Date("2024-01-01"),
+  ...overrides,
+});
+
+describe("filterAndSortShoots", () => {
+  test("sorts by date newest-first by default", () => {
+    const shoots = [
+      makeShoot({ id: "a", name: "Old", shootDate: new Date("2024-01-01") }),
+      makeShoot({ id: "b", name: "New", shootDate: new Date("2024-06-01") }),
+      makeShoot({ id: "c", name: "Mid", shootDate: new Date("2024-03-01") }),
+    ];
+
+    const result = filterAndSortShoots(shoots, { search: "", sortBy: "date" });
+
+    expect(result.map((s) => s.id)).toEqual(["b", "c", "a"]);
+  });
+
+  test("sorts alphabetically when sortBy is alphabetical", () => {
+    const shoots = [
+      makeShoot({ id: "a", name: "Charlie" }),
+      makeShoot({ id: "b", name: "Alpha" }),
+      makeShoot({ id: "c", name: "Bravo" }),
+    ];
+
+    const result = filterAndSortShoots(shoots, { search: "", sortBy: "alphabetical" });
+
+    expect(result.map((s) => s.name)).toEqual(["Alpha", "Bravo", "Charlie"]);
+  });
+
+  test("filters by name case-insensitively", () => {
+    const shoots = [
+      makeShoot({ id: "a", name: "Spring 2024" }),
+      makeShoot({ id: "b", name: "Summer 2024" }),
+      makeShoot({ id: "c", name: "spring bonus" }),
+    ];
+
+    const result = filterAndSortShoots(shoots, { search: "spring", sortBy: "date" });
+
+    expect(result).toHaveLength(2);
+    expect(result.map((s) => s.id).sort()).toEqual(["a", "c"]);
+  });
+
+  test("returns empty array when no shoots match search", () => {
+    const shoots = [makeShoot({ id: "a", name: "Summer" })];
+
+    const result = filterAndSortShoots(shoots, { search: "winter", sortBy: "date" });
+
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array for empty input", () => {
+    expect(filterAndSortShoots([], { search: "", sortBy: "date" })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add collapsible shoot sidebar to the library page with search, sort toggle (date/alphabetical), and shoot selection
- `filterAndSortShoots` pure function handles sorting and filtering logic
- "No shoot" pseudo-item filters gallery to media not assigned to any shoot
- Clicking a shoot filters gallery to that shoot's media; clicking again deselects
- Each shoot entry has a link to its detail page
- Sidebar state (collapsed, selected shoot, sort mode) persists via `LibraryPreferencesContext`
- Sidebar shoot selection is independent from existing filter bar

Closes #229

## Test plan

- [x] Sorts by date newest-first by default
- [x] Sorts alphabetically when toggled
- [x] Filters by name case-insensitively
- [x] Returns empty when no shoots match search
- [x] Handles empty input
- [ ] Visual check: sidebar renders, collapses/expands, search works
- [ ] Visual check: "No shoot" filters correctly
- [ ] Visual check: shoot selection filters gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)