### PR TITLE
feat: asset library — image assets for watermarks

### DIFF
--- a/@fanslib/apps/server/src/features/assets/entity.ts
+++ b/@fanslib/apps/server/src/features/assets/entity.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+
+export type AssetType = "image" | "audio";
+
+@Entity("asset")
+export class Asset {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ type: "varchar", name: "name" })
+  name!: string;
+
+  @Column({ type: "varchar", name: "type" })
+  type!: AssetType;
+
+  @Column({ type: "varchar", name: "filename" })
+  filename!: string;
+
+  @CreateDateColumn({ type: "datetime", name: "createdAt" })
+  createdAt!: Date;
+}
+
+export const AssetTypeSchema = z.enum(["image", "audio"]);
+
+export const AssetSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: AssetTypeSchema,
+  filename: z.string(),
+  createdAt: z.coerce.date(),
+});

--- a/@fanslib/apps/server/src/features/assets/operations/asset/delete.ts
+++ b/@fanslib/apps/server/src/features/assets/operations/asset/delete.ts
@@ -1,0 +1,20 @@
+import { existsSync, unlinkSync } from "fs";
+import { join } from "path";
+import { db } from "../../../../lib/db";
+import { appdataPath } from "../../../../lib/env";
+import { Asset } from "../../entity";
+
+export const deleteAsset = async (id: string): Promise<boolean> => {
+  const database = await db();
+  const repo = database.getRepository(Asset);
+
+  const asset = await repo.findOne({ where: { id } });
+  if (!asset) return false;
+
+  // Delete file from disk
+  const filePath = join(appdataPath(), "assets", asset.filename);
+  if (existsSync(filePath)) unlinkSync(filePath);
+
+  await repo.delete(id);
+  return true;
+};

--- a/@fanslib/apps/server/src/features/assets/operations/asset/fetch-all.ts
+++ b/@fanslib/apps/server/src/features/assets/operations/asset/fetch-all.ts
@@ -1,0 +1,13 @@
+import type { FindOptionsWhere } from "typeorm";
+import { db } from "../../../../lib/db";
+import { Asset, type AssetType } from "../../entity";
+
+export const fetchAllAssets = async (type?: AssetType): Promise<Asset[]> => {
+  const database = await db();
+  const repo = database.getRepository(Asset);
+
+  const where: FindOptionsWhere<Asset> = {};
+  if (type) where.type = type;
+
+  return repo.find({ where, order: { createdAt: "DESC" } });
+};

--- a/@fanslib/apps/server/src/features/assets/operations/asset/fetch-by-id.ts
+++ b/@fanslib/apps/server/src/features/assets/operations/asset/fetch-by-id.ts
@@ -1,0 +1,8 @@
+import { db } from "../../../../lib/db";
+import { Asset } from "../../entity";
+
+export const fetchAssetById = async (id: string): Promise<Asset | null> => {
+  const database = await db();
+  const repo = database.getRepository(Asset);
+  return repo.findOne({ where: { id } });
+};

--- a/@fanslib/apps/server/src/features/assets/operations/asset/update.ts
+++ b/@fanslib/apps/server/src/features/assets/operations/asset/update.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { db } from "../../../../lib/db";
+import { Asset } from "../../entity";
+
+export const UpdateAssetRequestBodySchema = z.object({
+  name: z.string(),
+});
+
+export const updateAsset = async (
+  id: string,
+  payload: z.infer<typeof UpdateAssetRequestBodySchema>,
+): Promise<Asset | null> => {
+  const database = await db();
+  const repo = database.getRepository(Asset);
+
+  const asset = await repo.findOne({ where: { id } });
+  if (!asset) return null;
+
+  asset.name = payload.name;
+  await repo.save(asset);
+
+  return repo.findOne({ where: { id } });
+};

--- a/@fanslib/apps/server/src/features/assets/operations/asset/upload.ts
+++ b/@fanslib/apps/server/src/features/assets/operations/asset/upload.ts
@@ -1,0 +1,39 @@
+import { existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import { db } from "../../../../lib/db";
+import { appdataPath } from "../../../../lib/env";
+import { Asset } from "../../entity";
+
+const getAssetsDir = (): string => {
+  const dir = join(appdataPath(), "assets");
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return dir;
+};
+
+export const uploadAsset = async (
+  file: File,
+  name: string,
+): Promise<Asset> => {
+  const database = await db();
+  const repo = database.getRepository(Asset);
+
+  const ext = file.name?.split(".").pop() ?? "png";
+  const filename = `${randomUUID()}.${ext}`;
+  const assetsDir = getAssetsDir();
+  const filePath = join(assetsDir, filename);
+
+  const buffer = await file.arrayBuffer();
+  await Bun.write(filePath, buffer);
+
+  const asset = repo.create({
+    name,
+    type: "image",
+    filename,
+  });
+  await repo.save(asset);
+
+  const created = await repo.findOne({ where: { id: asset.id } });
+  if (!created) throw new Error(`Failed to fetch created asset with id ${asset.id}`);
+  return created;
+};

--- a/@fanslib/apps/server/src/features/assets/routes.test.ts
+++ b/@fanslib/apps/server/src/features/assets/routes.test.ts
@@ -1,0 +1,202 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { existsSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import "reflect-metadata";
+import { setupTestDatabase, teardownTestDatabase } from "../../lib/test-db";
+import { resetAllFixtures } from "../../lib/test-fixtures";
+import { devalueMiddleware } from "../../lib/devalue-middleware";
+import { parseResponse } from "../../test-utils/setup";
+import { assetsRoutes } from "./routes";
+
+// Use a temporary directory for test assets
+const TEST_ASSETS_DIR = join(import.meta.dir, "..", "..", "..", "tests", "fixtures", "assets");
+
+// Minimal valid PNG (1x1 pixel, transparent)
+const VALID_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+describe("Assets Routes", () => {
+  // eslint-disable-next-line functional/no-let
+  let app: Hono;
+
+  beforeAll(async () => {
+    process.env.APPDATA_PATH = join(import.meta.dir, "..", "..", "..", "tests", "fixtures");
+    await setupTestDatabase();
+    await resetAllFixtures();
+    app = new Hono().use("*", devalueMiddleware()).route("/", assetsRoutes);
+    if (!existsSync(TEST_ASSETS_DIR)) mkdirSync(TEST_ASSETS_DIR, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+    if (existsSync(TEST_ASSETS_DIR)) rmSync(TEST_ASSETS_DIR, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    await resetAllFixtures();
+    // Clean assets directory between tests
+    if (existsSync(TEST_ASSETS_DIR)) rmSync(TEST_ASSETS_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_ASSETS_DIR, { recursive: true });
+  });
+
+  describe("POST /api/assets/upload", () => {
+    test("uploads a PNG asset and returns entity with name and type", async () => {
+      const formData = new FormData();
+      formData.append("file", new Blob([VALID_PNG], { type: "image/png" }), "watermark.png");
+      formData.append("name", "My Watermark");
+
+      const response = await app.request("/api/assets/upload", {
+        method: "POST",
+        body: formData,
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{
+        id: string;
+        name: string;
+        type: string;
+        filename: string;
+        createdAt: string;
+      }>(response);
+
+      expect(data?.id).toBeDefined();
+      expect(data?.name).toBe("My Watermark");
+      expect(data?.type).toBe("image");
+      expect(data?.filename).toBeDefined();
+    });
+  });
+
+  describe("GET /api/assets", () => {
+    test("returns all assets", async () => {
+      // Upload an asset first
+      const formData = new FormData();
+      formData.append("file", new Blob([VALID_PNG], { type: "image/png" }), "test.png");
+      formData.append("name", "Test Asset");
+      await app.request("/api/assets/upload", { method: "POST", body: formData });
+
+      const response = await app.request("/api/assets");
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ id: string; name: string; type: string }[]>(response);
+      expect(data).toHaveLength(1);
+      expect(data?.[0]?.name).toBe("Test Asset");
+    });
+
+    test("filters by type query parameter", async () => {
+      // Upload an image asset
+      const formData = new FormData();
+      formData.append("file", new Blob([VALID_PNG], { type: "image/png" }), "test.png");
+      formData.append("name", "Image Asset");
+      await app.request("/api/assets/upload", { method: "POST", body: formData });
+
+      const imageResponse = await app.request("/api/assets?type=image");
+      const imageData = await parseResponse<{ type: string }[]>(imageResponse);
+      expect(imageData).toHaveLength(1);
+
+      const audioResponse = await app.request("/api/assets?type=audio");
+      const audioData = await parseResponse<{ type: string }[]>(audioResponse);
+      expect(audioData).toHaveLength(0);
+    });
+  });
+
+  describe("GET /api/assets/:id/file", () => {
+    test("streams the uploaded file", async () => {
+      const formData = new FormData();
+      formData.append("file", new Blob([VALID_PNG], { type: "image/png" }), "test.png");
+      formData.append("name", "File Test");
+      const createResponse = await app.request("/api/assets/upload", { method: "POST", body: formData });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const response = await app.request(`/api/assets/${created?.id}/file`);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toContain("image/png");
+
+      const body = await response.arrayBuffer();
+      expect(body.byteLength).toBeGreaterThan(0);
+    });
+
+    test("returns 404 for non-existent asset", async () => {
+      const response = await app.request("/api/assets/non-existent-id/file");
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("PATCH /api/assets/:id", () => {
+    test("renames an asset", async () => {
+      const formData = new FormData();
+      formData.append("file", new Blob([VALID_PNG], { type: "image/png" }), "test.png");
+      formData.append("name", "Original Name");
+      const createResponse = await app.request("/api/assets/upload", { method: "POST", body: formData });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const response = await app.request(`/api/assets/${created?.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "New Name" }),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ id: string; name: string }>(response);
+      expect(data?.name).toBe("New Name");
+    });
+
+    test("returns 404 for non-existent asset", async () => {
+      const response = await app.request("/api/assets/non-existent-id", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "New Name" }),
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("DELETE /api/assets/:id", () => {
+    test("deletes asset entity and file from disk", async () => {
+      const formData = new FormData();
+      formData.append("file", new Blob([VALID_PNG], { type: "image/png" }), "test.png");
+      formData.append("name", "To Delete");
+      const createResponse = await app.request("/api/assets/upload", { method: "POST", body: formData });
+      const created = await parseResponse<{ id: string; filename: string }>(createResponse);
+
+      // File should exist after upload
+      const filePath = join(TEST_ASSETS_DIR, created?.filename ?? "");
+      expect(existsSync(filePath)).toBe(true);
+
+      const response = await app.request(`/api/assets/${created?.id}`, { method: "DELETE" });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ success: boolean }>(response);
+      expect(data?.success).toBe(true);
+
+      // File should be removed from disk
+      expect(existsSync(filePath)).toBe(false);
+
+      // Entity should be gone
+      const getResponse = await app.request("/api/assets");
+      const assets = await parseResponse<unknown[]>(getResponse);
+      expect(assets).toHaveLength(0);
+    });
+
+    test("returns 404 for non-existent asset", async () => {
+      const response = await app.request("/api/assets/non-existent-id", { method: "DELETE" });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Upload validation", () => {
+    test("rejects non-PNG files", async () => {
+      const formData = new FormData();
+      formData.append("file", new Blob(["not a png"], { type: "text/plain" }), "test.txt");
+      formData.append("name", "Invalid");
+
+      const response = await app.request("/api/assets/upload", { method: "POST", body: formData });
+      expect(response.status).toBe(422);
+
+      const data = await parseResponse<{ error: string }>(response);
+      expect(data?.error).toContain("PNG");
+    });
+  });
+});

--- a/@fanslib/apps/server/src/features/assets/routes.ts
+++ b/@fanslib/apps/server/src/features/assets/routes.ts
@@ -1,0 +1,76 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { validationError, notFound } from "../../lib/hono-utils";
+import { appdataPath } from "../../lib/env";
+import type { AssetType } from "./entity";
+import { deleteAsset } from "./operations/asset/delete";
+import { fetchAllAssets } from "./operations/asset/fetch-all";
+import { fetchAssetById } from "./operations/asset/fetch-by-id";
+import { UpdateAssetRequestBodySchema, updateAsset } from "./operations/asset/update";
+import { uploadAsset } from "./operations/asset/upload";
+
+// PNG magic bytes: 137 80 78 71 13 10 26 10
+const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const isPng = (buffer: ArrayBuffer): boolean => {
+  const header = new Uint8Array(buffer, 0, 8);
+  return PNG_MAGIC.every((byte, i) => header[i] === byte);
+};
+
+export const assetsRoutes = new Hono()
+  .basePath("/api/assets")
+  .get("/", async (c) => {
+    const type = c.req.query("type") as AssetType | undefined;
+    const assets = await fetchAllAssets(type);
+    return c.json(assets);
+  })
+  .get("/:id/file", async (c) => {
+    const id = c.req.param("id");
+    const asset = await fetchAssetById(id);
+    if (!asset) return c.json({ error: "Asset not found" }, 404);
+
+    const filePath = join(appdataPath(), "assets", asset.filename);
+    if (!existsSync(filePath)) return c.json({ error: "File not found" }, 404);
+
+    const file = Bun.file(filePath);
+    return c.body(file.stream(), 200, {
+      "Content-Type": "image/png",
+      "Content-Length": file.size.toString(),
+    });
+  })
+  .post("/upload", async (c) => {
+    const formData = await c.req.formData();
+    const file = formData.get("file");
+    const name = formData.get("name");
+
+    if (!(file instanceof File)) {
+      return c.json({ error: "File is required" }, 422);
+    }
+
+    // Validate PNG format by checking magic bytes
+    const buffer = await file.arrayBuffer();
+    if (!isPng(buffer)) {
+      return c.json({ error: "Only PNG files are accepted" }, 422);
+    }
+
+    const assetName = typeof name === "string" ? name : file.name ?? "Untitled";
+    // Re-create the file from buffer since we already consumed it
+    const pngFile = new File([buffer], file.name ?? "asset.png", { type: "image/png" });
+    const result = await uploadAsset(pngFile, assetName);
+    return c.json(result);
+  })
+  .patch("/:id", zValidator("json", UpdateAssetRequestBodySchema, validationError), async (c) => {
+    const id = c.req.param("id");
+    const body = c.req.valid("json");
+    const asset = await updateAsset(id, body);
+    if (!asset) return notFound(c, "Asset not found");
+    return c.json(asset);
+  })
+  .delete("/:id", async (c) => {
+    const id = c.req.param("id");
+    const success = await deleteAsset(id);
+    if (!success) return notFound(c, "Asset not found");
+    return c.json({ success: true });
+  });

--- a/@fanslib/apps/server/src/index.ts
+++ b/@fanslib/apps/server/src/index.ts
@@ -6,6 +6,7 @@ import { isAppError } from "./lib/errors";
 import { blueskyRoutes } from "./features/api-bluesky/routes";
 import { postponeRoutes } from "./features/api-postpone/routes";
 import { analyticsRoutes } from "./features/analytics/routes";
+import { assetsRoutes } from "./features/assets/routes";
 import { candidatesRoutes } from "./features/analytics/candidates/routes";
 import { channelsRoutes } from "./features/channels/routes";
 import { contentSchedulesRoutes } from "./features/content-schedules/routes";
@@ -76,6 +77,7 @@ const app = new Hono()
   .get("/health", (c) => c.json({ status: "ok", timestamp: new Date() }))
   .route("/", settingsRoutes)
   .route("/", analyticsRoutes)
+  .route("/", assetsRoutes)
   .route("/", blueskyRoutes)
   .route("/", postponeRoutes)
   .route("/", hashtagsRoutes)

--- a/@fanslib/apps/server/src/lib/db.ts
+++ b/@fanslib/apps/server/src/lib/db.ts
@@ -6,6 +6,7 @@ import "reflect-metadata";
 // @ts-expect-error — sql.js has no type declarations
 import initSqlJs from "sql.js";
 import { DataSource } from "typeorm";
+import { Asset } from "../features/assets/entity";
 import { FanslyMediaCandidate } from "../features/analytics/candidate-entity";
 import { FanslyAnalyticsAggregate, FanslyAnalyticsDatapoint } from "../features/analytics/entity";
 import { Channel, ChannelType } from "../features/channels/entity";
@@ -77,6 +78,7 @@ const createAppDataSource = (driver?: Awaited<ReturnType<typeof initSqlJs>>) => 
     autoSave: true,
     ...(driver ? { driver } : {}),
     entities: [
+      Asset,
       Media,
       Post,
       PostMedia,

--- a/@fanslib/apps/server/src/lib/test-db.ts
+++ b/@fanslib/apps/server/src/lib/test-db.ts
@@ -1,6 +1,7 @@
 // @ts-expect-error — sql.js has no type declarations
 import initSqlJs from "sql.js";
 import { DataSource } from "typeorm";
+import { Asset } from "../features/assets/entity";
 import { FanslyMediaCandidate } from "../features/analytics/candidate-entity";
 import { FanslyAnalyticsAggregate, FanslyAnalyticsDatapoint } from "../features/analytics/entity";
 import { Channel, ChannelType } from "../features/channels/entity";
@@ -36,6 +37,7 @@ export const createTestDataSource = (driver?: Awaited<ReturnType<typeof initSqlJ
     type: "sqljs",
     ...(driver ? { driver } : {}),
     entities: [
+      Asset,
       Media,
       Post,
       PostMedia,
@@ -121,6 +123,7 @@ export const clearAllTables = async () => {
     "FilterPreset",
     "FanslyAnalyticsDatapoint",
     "FanslyAnalyticsAggregate",
+    "Asset",
   ];
 
   await entityClearOrder.reduce(

--- a/@fanslib/apps/web/src/features/analytics/components/QueueStatusBar.vitest.tsx
+++ b/@fanslib/apps/web/src/features/analytics/components/QueueStatusBar.vitest.tsx
@@ -6,13 +6,15 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 vi.mock("~/lib/queries/analytics", () => ({
   useQueueStateQuery: vi.fn(),
   useFetchFanslyDataMutation: vi.fn(),
+  useClearNextFetchMutation: vi.fn(),
 }));
 
-import { useQueueStateQuery, useFetchFanslyDataMutation } from "~/lib/queries/analytics";
+import { useQueueStateQuery, useFetchFanslyDataMutation, useClearNextFetchMutation } from "~/lib/queries/analytics";
 import { QueueStatusBar } from "./QueueStatusBar";
 
 const mockUseQueueStateQuery = vi.mocked(useQueueStateQuery);
 const mockUseFetchFanslyDataMutation = vi.mocked(useFetchFanslyDataMutation);
+const mockUseClearNextFetchMutation = vi.mocked(useClearNextFetchMutation);
 
 const defaultMutationReturn = {
   mutate: vi.fn(),
@@ -41,6 +43,8 @@ describe("QueueStatusBar", () => {
   beforeEach(() => {
     // oxlint-disable-next-line typescript/no-explicit-any
     mockUseFetchFanslyDataMutation.mockReturnValue(defaultMutationReturn as any);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    mockUseClearNextFetchMutation.mockReturnValue(defaultMutationReturn as any);
   });
 
   afterEach(() => {

--- a/@fanslib/apps/web/src/features/settings/components/SettingsLayout.tsx
+++ b/@fanslib/apps/web/src/features/settings/components/SettingsLayout.tsx
@@ -1,5 +1,5 @@
 import { Link, Outlet, useLocation } from "@tanstack/react-router";
-import { FileText, Filter, Palette, RefreshCw, Shield, Tags, Zap } from "lucide-react";
+import { FileText, Filter, ImageIcon, Palette, RefreshCw, Shield, Tags, Zap } from "lucide-react";
 import { cn } from "~/lib/cn";
 
 type SettingsNavItem = {
@@ -33,6 +33,12 @@ const settingsNavItems: SettingsNavItem[] = [
     href: "/settings/content-tags",
     icon: Tags,
     description: "Manage tag dimensions",
+  },
+  {
+    title: "Asset Library",
+    href: "/settings/assets",
+    icon: ImageIcon,
+    description: "Watermarks and overlay images",
   },
   {
     title: "Content Safety",

--- a/@fanslib/apps/web/src/lib/queries/assets.ts
+++ b/@fanslib/apps/web/src/lib/queries/assets.ts
@@ -1,0 +1,73 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { QUERY_KEYS } from "./query-keys";
+
+type Asset = {
+  id: string;
+  name: string;
+  type: "image" | "audio";
+  filename: string;
+  createdAt: Date;
+};
+
+export const useAssetsQuery = (type?: "image" | "audio") =>
+  useQuery({
+    queryKey: QUERY_KEYS.assets.all(type),
+    queryFn: async (): Promise<Asset[]> => {
+      const url = type ? `/api/assets?type=${type}` : "/api/assets";
+      const res = await fetch(url);
+      if (!res.ok) throw new Error("Failed to fetch assets");
+      return res.json();
+    },
+  });
+
+export const useUploadAssetMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ file, name }: { file: File; name: string }) => {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("name", name);
+      const res = await fetch("/api/assets/upload", { method: "POST", body: formData });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? "Upload failed");
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.assets.all() });
+    },
+  });
+};
+
+export const useRenameAssetMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, name }: { id: string; name: string }) => {
+      const res = await fetch(`/api/assets/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      if (!res.ok) throw new Error("Rename failed");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.assets.all() });
+    },
+  });
+};
+
+export const useDeleteAssetMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const res = await fetch(`/api/assets/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Delete failed");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.assets.all() });
+    },
+  });
+};

--- a/@fanslib/apps/web/src/lib/queries/query-keys.ts
+++ b/@fanslib/apps/web/src/lib/queries/query-keys.ts
@@ -163,6 +163,10 @@ export const QUERY_KEYS = {
     isRunning: () => ["automation", "is-running"] as const,
   },
 
+  assets: {
+    all: (type?: string) => ["assets", "list", type] as const,
+  },
+
   companion: {
     health: () => ["companion", "health"] as const,
   },

--- a/@fanslib/apps/web/src/routeTree.gen.ts
+++ b/@fanslib/apps/web/src/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as SettingsIntegrationsRouteImport } from './routes/settings/inte
 import { Route as SettingsFilterPresetsRouteImport } from './routes/settings/filter-presets'
 import { Route as SettingsContentTagsRouteImport } from './routes/settings/content-tags'
 import { Route as SettingsContentSafetyRouteImport } from './routes/settings/content-safety'
+import { Route as SettingsAssetsRouteImport } from './routes/settings/assets'
 import { Route as SettingsAppearanceRouteImport } from './routes/settings/appearance'
 import { Route as SchedulesIdRouteImport } from './routes/schedules/$id'
 import { Route as PostsPostIdRouteImport } from './routes/posts/$postId'
@@ -148,6 +149,11 @@ const SettingsContentSafetyRoute = SettingsContentSafetyRouteImport.update({
   path: '/content-safety',
   getParentRoute: () => SettingsRoute,
 } as any)
+const SettingsAssetsRoute = SettingsAssetsRouteImport.update({
+  id: '/assets',
+  path: '/assets',
+  getParentRoute: () => SettingsRoute,
+} as any)
 const SettingsAppearanceRoute = SettingsAppearanceRouteImport.update({
   id: '/appearance',
   path: '/appearance',
@@ -229,6 +235,7 @@ export interface FileRoutesByFullPath {
   '/posts/$postId': typeof PostsPostIdRoute
   '/schedules/$id': typeof SchedulesIdRoute
   '/settings/appearance': typeof SettingsAppearanceRoute
+  '/settings/assets': typeof SettingsAssetsRoute
   '/settings/content-safety': typeof SettingsContentSafetyRoute
   '/settings/content-tags': typeof SettingsContentTagsRoute
   '/settings/filter-presets': typeof SettingsFilterPresetsRoute
@@ -262,6 +269,7 @@ export interface FileRoutesByTo {
   '/posts/$postId': typeof PostsPostIdRoute
   '/schedules/$id': typeof SchedulesIdRoute
   '/settings/appearance': typeof SettingsAppearanceRoute
+  '/settings/assets': typeof SettingsAssetsRoute
   '/settings/content-safety': typeof SettingsContentSafetyRoute
   '/settings/content-tags': typeof SettingsContentTagsRoute
   '/settings/filter-presets': typeof SettingsFilterPresetsRoute
@@ -297,6 +305,7 @@ export interface FileRoutesById {
   '/posts/$postId': typeof PostsPostIdRoute
   '/schedules/$id': typeof SchedulesIdRoute
   '/settings/appearance': typeof SettingsAppearanceRoute
+  '/settings/assets': typeof SettingsAssetsRoute
   '/settings/content-safety': typeof SettingsContentSafetyRoute
   '/settings/content-tags': typeof SettingsContentTagsRoute
   '/settings/filter-presets': typeof SettingsFilterPresetsRoute
@@ -334,6 +343,7 @@ export interface FileRouteTypes {
     | '/posts/$postId'
     | '/schedules/$id'
     | '/settings/appearance'
+    | '/settings/assets'
     | '/settings/content-safety'
     | '/settings/content-tags'
     | '/settings/filter-presets'
@@ -367,6 +377,7 @@ export interface FileRouteTypes {
     | '/posts/$postId'
     | '/schedules/$id'
     | '/settings/appearance'
+    | '/settings/assets'
     | '/settings/content-safety'
     | '/settings/content-tags'
     | '/settings/filter-presets'
@@ -401,6 +412,7 @@ export interface FileRouteTypes {
     | '/posts/$postId'
     | '/schedules/$id'
     | '/settings/appearance'
+    | '/settings/assets'
     | '/settings/content-safety'
     | '/settings/content-tags'
     | '/settings/filter-presets'
@@ -588,6 +600,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsContentSafetyRouteImport
       parentRoute: typeof SettingsRoute
     }
+    '/settings/assets': {
+      id: '/settings/assets'
+      path: '/assets'
+      fullPath: '/settings/assets'
+      preLoaderRoute: typeof SettingsAssetsRouteImport
+      parentRoute: typeof SettingsRoute
+    }
     '/settings/appearance': {
       id: '/settings/appearance'
       path: '/appearance'
@@ -731,6 +750,7 @@ const SchedulesRouteWithChildren = SchedulesRoute._addFileChildren(
 
 interface SettingsRouteChildren {
   SettingsAppearanceRoute: typeof SettingsAppearanceRoute
+  SettingsAssetsRoute: typeof SettingsAssetsRoute
   SettingsContentSafetyRoute: typeof SettingsContentSafetyRoute
   SettingsContentTagsRoute: typeof SettingsContentTagsRoute
   SettingsFilterPresetsRoute: typeof SettingsFilterPresetsRoute
@@ -742,6 +762,7 @@ interface SettingsRouteChildren {
 
 const SettingsRouteChildren: SettingsRouteChildren = {
   SettingsAppearanceRoute: SettingsAppearanceRoute,
+  SettingsAssetsRoute: SettingsAssetsRoute,
   SettingsContentSafetyRoute: SettingsContentSafetyRoute,
   SettingsContentTagsRoute: SettingsContentTagsRoute,
   SettingsFilterPresetsRoute: SettingsFilterPresetsRoute,
@@ -777,12 +798,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}

--- a/@fanslib/apps/web/src/routes/settings/assets.tsx
+++ b/@fanslib/apps/web/src/routes/settings/assets.tsx
@@ -1,0 +1,158 @@
+import { useState, useRef } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { ImageIcon, Upload, Trash2, Pencil, Check, X } from "lucide-react";
+import { Button } from "~/components/ui/Button";
+import { Input } from "~/components/ui/Input";
+import {
+  useAssetsQuery,
+  useUploadAssetMutation,
+  useRenameAssetMutation,
+  useDeleteAssetMutation,
+} from "~/lib/queries/assets";
+import { DeleteConfirmDialog } from "~/components/ui/DeleteConfirmDialog";
+
+const AssetCard = ({
+  asset,
+}: {
+  asset: { id: string; name: string; filename: string };
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(asset.name);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const renameMutation = useRenameAssetMutation();
+  const deleteMutation = useDeleteAssetMutation();
+
+  const handleRename = () => {
+    if (editName.trim() && editName !== asset.name) {
+      renameMutation.mutate({ id: asset.id, name: editName.trim() });
+    }
+    setIsEditing(false);
+  };
+
+  return (
+    <div className="card bg-base-200 shadow-sm">
+      <figure className="px-4 pt-4">
+        <img
+          src={`/api/assets/${asset.id}/file`}
+          alt={asset.name}
+          className="h-32 w-full rounded-lg object-contain bg-base-300"
+        />
+      </figure>
+      <div className="card-body p-4 pt-2">
+        {isEditing ? (
+          <div className="flex items-center gap-1">
+            <Input
+              value={editName}
+              onChange={setEditName}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleRename();
+                if (e.key === "Escape") setIsEditing(false);
+              }}
+              className="h-8 text-sm"
+              autoFocus
+            />
+            <Button size="sm" variant="ghost" onPress={handleRename}>
+              <Check className="h-4 w-4" />
+            </Button>
+            <Button size="sm" variant="ghost" onPress={() => setIsEditing(false)}>
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium truncate">{asset.name}</span>
+            <div className="flex gap-1">
+              <Button
+                size="sm"
+                variant="ghost"
+                onPress={() => {
+                  setEditName(asset.name);
+                  setIsEditing(true);
+                }}
+              >
+                <Pencil className="h-3 w-3" />
+              </Button>
+              <Button size="sm" variant="ghost" onPress={() => setDeleteOpen(true)}>
+                <Trash2 className="h-3 w-3 text-error" />
+              </Button>
+              <DeleteConfirmDialog
+                open={deleteOpen}
+                onOpenChange={setDeleteOpen}
+                title="Delete Asset"
+                description={`Are you sure you want to delete "${asset.name}"? This cannot be undone.`}
+                onConfirm={() => deleteMutation.mutate(asset.id)}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const AssetsSettings = () => {
+  const { data: assets = [] } = useAssetsQuery("image");
+  const uploadMutation = useUploadAssetMutation();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const name = file.name.replace(/\.[^.]+$/, "");
+    uploadMutation.mutate({ file, name });
+
+    // Reset input so the same file can be re-selected
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold">
+            <ImageIcon /> Asset Library
+          </h1>
+          <p className="text-base-content/60">
+            Upload PNG images for use as watermarks and overlays
+          </p>
+        </div>
+        <div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".png,image/png"
+            className="hidden"
+            onChange={handleFileSelect}
+          />
+          <Button onPress={() => fileInputRef.current?.click()} isDisabled={uploadMutation.isPending}>
+            <Upload className="mr-2 h-4 w-4" />
+            {uploadMutation.isPending ? "Uploading..." : "Upload PNG"}
+          </Button>
+        </div>
+      </div>
+
+      {uploadMutation.isError && (
+        <div className="alert alert-error text-sm">{uploadMutation.error.message}</div>
+      )}
+
+      {assets.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-base-content/40">
+          <ImageIcon className="mb-4 h-12 w-12" />
+          <p>No assets uploaded yet</p>
+          <p className="text-sm">Upload a PNG file to get started</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+          {assets.map((asset) => (
+            <AssetCard key={asset.id} asset={asset} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const Route = createFileRoute("/settings/assets")({
+  component: AssetsSettings,
+});


### PR DESCRIPTION
## Summary
- Adds `Asset` TypeORM entity (id, name, type, filename, createdAt) registered in db.ts
- Server-side CRUD API: `POST /upload` (with PNG magic-byte validation), `GET /` (with `?type=` filter), `GET /:id/file` (streaming), `PATCH /:id` (rename), `DELETE /:id` (removes entity + file)
- Assets stored at `APPDATA_PATH/assets/` directory, created on first upload
- Frontend settings page at `/settings/assets` with grid view, upload button (PNG only), inline rename, and delete with confirmation dialog
- Navigation link added to settings sidebar
- 10 integration tests covering all endpoints and edge cases
- Fixes pre-existing QueueStatusBar test mock (missing `useClearNextFetchMutation`)

Closes #246

## Test plan
- [x] `bun test` — 336 tests pass (10 new asset tests)
- [x] `bun run lint` — 0 errors
- [x] `bun run typecheck` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)