### PR TITLE
feat: export dialog + render queue UI

### DIFF
--- a/@fanslib/apps/server/src/features/media-edits/operations/media-edit/fetch-queue.ts
+++ b/@fanslib/apps/server/src/features/media-edits/operations/media-edit/fetch-queue.ts
@@ -1,0 +1,13 @@
+import { Not } from "typeorm";
+import { db } from "../../../../lib/db";
+import { MediaEdit } from "../../entity";
+
+export const fetchMediaEditQueue = async (): Promise<MediaEdit[]> => {
+  const database = await db();
+  const repo = database.getRepository(MediaEdit);
+
+  return repo.find({
+    where: { status: Not("draft") },
+    order: { updatedAt: "DESC" },
+  });
+};

--- a/@fanslib/apps/server/src/features/media-edits/routes.test.ts
+++ b/@fanslib/apps/server/src/features/media-edits/routes.test.ts
@@ -352,6 +352,48 @@ describe("MediaEdit Routes", () => {
     });
   });
 
+  describe("GET /api/media-edits/queue", () => {
+    test("returns edits with non-draft statuses ordered by updatedAt", async () => {
+      const sourceMedia = await createTestMedia();
+
+      // Create a draft (should NOT appear)
+      await app.request("/api/media-edits", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sourceMediaId: sourceMedia.id, type: "transform", operations: [] }),
+      });
+
+      // Create and queue one (should appear)
+      const createResponse = await app.request("/api/media-edits", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sourceMediaId: sourceMedia.id,
+          type: "transform",
+          operations: [{ type: "watermark", assetId: "a1", x: 0.5, y: 0.5, width: 0.1, opacity: 1 }],
+        }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+      await app.request(`/api/media-edits/${created?.id}/queue`, { method: "POST" });
+
+      const response = await app.request("/api/media-edits/queue");
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ id: string; status: string }[]>(response);
+      expect(data?.length).toBeGreaterThanOrEqual(1);
+      // No drafts in queue
+      expect(data?.every((e) => e.status !== "draft")).toBe(true);
+    });
+
+    test("returns empty array when no non-draft edits exist", async () => {
+      const response = await app.request("/api/media-edits/queue");
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<unknown[]>(response);
+      expect(data).toHaveLength(0);
+    });
+  });
+
   describe("Validation", () => {
     test("rejects create with invalid type", async () => {
       const sourceMedia = await createTestMedia();

--- a/@fanslib/apps/server/src/features/media-edits/routes.ts
+++ b/@fanslib/apps/server/src/features/media-edits/routes.ts
@@ -4,6 +4,7 @@ import { validationError, notFound } from "../../lib/hono-utils";
 import { CreateMediaEditRequestBodySchema, createMediaEdit } from "./operations/media-edit/create";
 import { deleteMediaEdit } from "./operations/media-edit/delete";
 import { fetchMediaEditById } from "./operations/media-edit/fetch-by-id";
+import { fetchMediaEditQueue } from "./operations/media-edit/fetch-queue";
 import { fetchMediaEditsBySource } from "./operations/media-edit/fetch-by-source";
 import { queueMediaEdit } from "./operations/media-edit/queue";
 import { addRenderListener } from "./render-events";
@@ -35,6 +36,10 @@ export const mediaEditsRoutes = new Hono()
         Connection: "keep-alive",
       },
     });
+  })
+  .get("/queue", async (c) => {
+    const queue = await fetchMediaEditQueue();
+    return c.json(queue);
   })
   .post("/:id/queue", async (c) => {
     const id = c.req.param("id");

--- a/@fanslib/apps/web/src/components/AppLayout.tsx
+++ b/@fanslib/apps/web/src/components/AppLayout.tsx
@@ -2,6 +2,7 @@ import { useAtom } from "jotai";
 import { useHydrateAtoms } from "jotai/utils";
 import { type ReactNode, useEffect } from "react";
 import { CredentialStatusBadge } from "~/components/CredentialStatusBadge";
+import { RenderQueueBadge } from "~/features/editor/components/RenderQueueBadge";
 import { Logo } from "~/components/Logo";
 import { NavigationMenu } from "~/components/NavigationMenu";
 import { BurgerIcon } from "~/components/ui/BurgerIcon";
@@ -62,7 +63,8 @@ const LayoutContent = ({ children, initialSidebarCollapsed }: AppLayoutProps) =>
               <BurgerIcon />
             </label>
             <Logo isCollapsed={false} className="h-8" />
-            <div className="ml-auto">
+            <div className="ml-auto flex items-center gap-2">
+              <RenderQueueBadge />
               <CredentialStatusBadge />
             </div>
           </header>
@@ -89,10 +91,11 @@ const LayoutContent = ({ children, initialSidebarCollapsed }: AppLayoutProps) =>
 
             <div
               className={cn(
-                "mt-auto p-4 border-t border-base-300",
+                "mt-auto p-4 border-t border-base-300 flex items-center gap-2",
                 isCollapsed && "lg:flex lg:justify-center",
               )}
             >
+              <RenderQueueBadge />
               <CredentialStatusBadge />
             </div>
           </aside>

--- a/@fanslib/apps/web/src/features/editor/components/EditorToolbar.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/EditorToolbar.tsx
@@ -1,9 +1,10 @@
 import { useState, useRef, useEffect, useCallback } from "react";
-import { ArrowLeft, Undo2, Redo2, ImageIcon, Save } from "lucide-react";
+import { ArrowLeft, Undo2, Redo2, ImageIcon, Save, Upload } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { Button } from "~/components/ui/Button";
 import { useEditorStore } from "~/stores/editorStore";
 import { useAssetsQuery } from "~/lib/queries/assets";
+import { ExportDialog } from "./ExportDialog";
 
 type EditorToolbarProps = {
   mediaId: string;
@@ -24,6 +25,7 @@ export const EditorToolbar = ({ mediaId }: EditorToolbarProps) => {
 
   const [watermarkOpen, setWatermarkOpen] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [exportOpen, setExportOpen] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLDivElement>(null);
 
@@ -163,6 +165,20 @@ export const EditorToolbar = ({ mediaId }: EditorToolbarProps) => {
         <Save className="h-4 w-4" />
         <span className="ml-1 text-sm">{saving ? "Saving..." : "Save"}</span>
       </Button>
+
+      {/* Export button */}
+      <Button
+        size="sm"
+        variant="ghost"
+        onPress={() => setExportOpen(true)}
+        isDisabled={operations.length === 0}
+        aria-label="Export"
+      >
+        <Upload className="h-4 w-4" />
+        <span className="ml-1 text-sm">Export</span>
+      </Button>
+
+      <ExportDialog open={exportOpen} onOpenChange={setExportOpen} />
     </div>
   );
 };

--- a/@fanslib/apps/web/src/features/editor/components/ExportDialog.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/ExportDialog.tsx
@@ -1,0 +1,215 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Button } from "~/components/ui/Button";
+import { useEditorStore } from "~/stores/editorStore";
+import { QUERY_KEYS } from "~/lib/queries/query-keys";
+
+type ExportDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export const ExportDialog = ({ open, onOpenChange }: ExportDialogProps) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const queryClient = useQueryClient();
+
+  const editId = useEditorStore((s) => s.editId);
+  const sourceMediaId = useEditorStore((s) => s.sourceMediaId);
+  const operations = useEditorStore((s) => s.operations);
+  const setEditId = useEditorStore((s) => s.setEditId);
+  const markClean = useEditorStore((s) => s.markClean);
+
+  const [role, setRole] = useState("");
+  const [pkg, setPkg] = useState("");
+  const [contentRating, setContentRating] = useState("sg");
+  const [quality, setQuality] = useState("pretty");
+  const [exporting, setExporting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Sync dialog open/close with the `open` prop
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) {
+      dialog.showModal();
+      setSuccess(false);
+      setError(null);
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  // Listen for native close (e.g. Escape key)
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const handleClose = () => onOpenChange(false);
+    dialog.addEventListener("close", handleClose);
+    return () => dialog.removeEventListener("close", handleClose);
+  }, [onOpenChange]);
+
+  const handleExport = useCallback(async () => {
+    setExporting(true);
+    setError(null);
+    try {
+      // Step 1: Save the edit (create or update)
+      const currentEditId = await (async () => {
+        if (editId) {
+          const res = await fetch(`/api/media-edits/${editId}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ operations }),
+          });
+          if (!res.ok) throw new Error("Failed to save edit");
+          markClean();
+          return editId;
+        }
+        const res = await fetch("/api/media-edits", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sourceMediaId,
+            type: "transform",
+            operations,
+          }),
+        });
+        if (!res.ok) throw new Error("Failed to create edit");
+        const data = await res.json();
+        setEditId(data.id);
+        markClean();
+        return data.id as string;
+      })();
+
+      // Step 2: Queue the render
+      const queueRes = await fetch(`/api/media-edits/${currentEditId}/queue`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          role,
+          package: pkg,
+          contentRating,
+          quality,
+        }),
+      });
+      if (!queueRes.ok) throw new Error("Failed to queue render");
+
+      // Invalidate queue query
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.mediaEdits.queue(),
+      });
+
+      setSuccess(true);
+      setTimeout(() => {
+        onOpenChange(false);
+      }, 1500);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Export failed");
+    } finally {
+      setExporting(false);
+    }
+  }, [
+    editId,
+    sourceMediaId,
+    operations,
+    role,
+    pkg,
+    contentRating,
+    quality,
+    setEditId,
+    markClean,
+    onOpenChange,
+    queryClient,
+  ]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="modal-box bg-base-100 rounded-lg shadow-xl p-0 w-full max-w-md backdrop:bg-black/50"
+    >
+      <div className="p-6">
+        <h3 className="text-lg font-semibold mb-4">Export &amp; Render</h3>
+
+        {success ? (
+          <div className="text-success text-center py-8">
+            Queued for rendering!
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-base-content/70">Role</span>
+              <input
+                type="text"
+                className="input input-bordered input-sm w-full"
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+                placeholder="e.g. main, alt"
+              />
+            </label>
+
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-base-content/70">Package</span>
+              <input
+                type="text"
+                className="input input-bordered input-sm w-full"
+                value={pkg}
+                onChange={(e) => setPkg(e.target.value)}
+                placeholder="e.g. premium, free"
+              />
+            </label>
+
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-base-content/70">Content Rating</span>
+              <select
+                className="select select-bordered select-sm w-full"
+                value={contentRating}
+                onChange={(e) => setContentRating(e.target.value)}
+              >
+                <option value="sf">SF - Safe</option>
+                <option value="sg">SG - Suggestive</option>
+                <option value="cn">CN - Cautionary Nudity</option>
+                <option value="uc">UC - Uncensored</option>
+                <option value="xt">XT - Explicit</option>
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-base-content/70">Quality</span>
+              <select
+                className="select select-bordered select-sm w-full"
+                value={quality}
+                onChange={(e) => setQuality(e.target.value)}
+              >
+                <option value="fast">Fast</option>
+                <option value="pretty">Pretty</option>
+              </select>
+            </label>
+
+            {error && (
+              <div className="text-error text-sm">{error}</div>
+            )}
+
+            <div className="flex justify-end gap-2 mt-2">
+              <Button
+                size="sm"
+                variant="ghost"
+                onPress={() => onOpenChange(false)}
+                isDisabled={exporting}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                variant="primary"
+                onPress={handleExport}
+                isDisabled={exporting}
+              >
+                {exporting ? "Exporting..." : "Export"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </dialog>
+  );
+};

--- a/@fanslib/apps/web/src/features/editor/components/RenderQueueBadge.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/RenderQueueBadge.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { Clapperboard } from "lucide-react";
+import { Button } from "~/components/ui/Button";
+import { useMediaEditQueueQuery } from "~/lib/queries/media-edits";
+import { RenderQueueDrawer } from "./RenderQueueDrawer";
+
+export const RenderQueueBadge = () => {
+  const { data: queueItems = [] } = useMediaEditQueueQuery();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const activeCount = queueItems.filter(
+    (i) => i.status === "rendering" || i.status === "queued",
+  ).length;
+
+  if (activeCount === 0) return null;
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="ghost"
+        onPress={() => setDrawerOpen(true)}
+        aria-label={`Render queue: ${activeCount} active`}
+      >
+        <div className="relative">
+          <Clapperboard className="h-4 w-4" />
+          <span className="absolute -top-1.5 -right-1.5 bg-info text-info-content text-[10px] font-bold rounded-full min-w-[16px] h-4 flex items-center justify-center px-1">
+            {activeCount}
+          </span>
+        </div>
+      </Button>
+
+      <RenderQueueDrawer open={drawerOpen} onOpenChange={setDrawerOpen} />
+    </>
+  );
+};

--- a/@fanslib/apps/web/src/features/editor/components/RenderQueueDrawer.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/RenderQueueDrawer.tsx
@@ -1,0 +1,245 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { X, RefreshCw, ExternalLink, AlertTriangle, Loader2, CheckCircle } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Button } from "~/components/ui/Button";
+import { useMediaEditQueueQuery, type QueuedMediaEdit } from "~/lib/queries/media-edits";
+import { QUERY_KEYS } from "~/lib/queries/query-keys";
+
+type RenderQueueDrawerProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+type RenderProgress = {
+  editId: string;
+  progress: number;
+  status?: string;
+};
+
+export const RenderQueueDrawer = ({ open, onOpenChange }: RenderQueueDrawerProps) => {
+  const { data: queueItems = [], isLoading } = useMediaEditQueueQuery();
+  const queryClient = useQueryClient();
+  const [progressMap, setProgressMap] = useState<Record<string, number>>({});
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  // SSE connection for render progress
+  useEffect(() => {
+    if (!open) {
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+      return;
+    }
+
+    const es = new EventSource("/api/media-edits/render-progress");
+    eventSourceRef.current = es;
+
+    es.onmessage = (event) => {
+      try {
+        const data: RenderProgress = JSON.parse(event.data);
+        setProgressMap((prev) => ({
+          ...prev,
+          [data.editId]: data.progress,
+        }));
+
+        // If completed or failed, refetch the queue
+        if (data.status === "completed" || data.status === "failed") {
+          queryClient.invalidateQueries({
+            queryKey: QUERY_KEYS.mediaEdits.queue(),
+          });
+        }
+      } catch {
+        // Ignore parse errors from SSE
+      }
+    };
+
+    es.onerror = () => {
+      // EventSource will auto-reconnect
+    };
+
+    return () => {
+      es.close();
+      eventSourceRef.current = null;
+    };
+  }, [open, queryClient]);
+
+  const handleRetry = useCallback(
+    async (editId: string) => {
+      try {
+        const res = await fetch(`/api/media-edits/${editId}/queue`, {
+          method: "POST",
+        });
+        if (!res.ok) throw new Error("Failed to re-queue");
+        await queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.mediaEdits.queue(),
+        });
+      } catch (err) {
+        console.error("Retry failed:", err);
+      }
+    },
+    [queryClient],
+  );
+
+  const activeItems = queueItems.filter((i) => i.status === "rendering");
+  const queuedItems = queueItems.filter((i) => i.status === "queued");
+  const completedItems = queueItems.filter((i) => i.status === "completed");
+  const failedItems = queueItems.filter((i) => i.status === "failed");
+
+  return (
+    <>
+      {/* Backdrop */}
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/30 z-40"
+          onClick={() => onOpenChange(false)}
+        />
+      )}
+
+      {/* Drawer */}
+      <div
+        className={`fixed top-0 right-0 h-full w-80 bg-base-100 shadow-xl z-50 transform transition-transform duration-200 ${
+          open ? "translate-x-0" : "translate-x-full"
+        }`}
+      >
+        <div className="flex items-center justify-between p-4 border-b border-base-300">
+          <h3 className="font-semibold text-base">Render Queue</h3>
+          <Button size="sm" variant="ghost" onPress={() => onOpenChange(false)} aria-label="Close">
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div className="overflow-y-auto h-[calc(100%-57px)] p-4 flex flex-col gap-4">
+          {isLoading && (
+            <div className="text-center py-8 text-base-content/50">Loading...</div>
+          )}
+
+          {!isLoading && queueItems.length === 0 && (
+            <div className="text-center py-8 text-base-content/50 text-sm">
+              No items in the render queue.
+            </div>
+          )}
+
+          {/* Active / Rendering */}
+          {activeItems.length > 0 && (
+            <Section title="Rendering">
+              {activeItems.map((item) => (
+                <QueueItemCard key={item.id} item={item} progress={progressMap[item.id]} />
+              ))}
+            </Section>
+          )}
+
+          {/* Queued */}
+          {queuedItems.length > 0 && (
+            <Section title="Queued">
+              {queuedItems.map((item) => (
+                <QueueItemCard key={item.id} item={item} />
+              ))}
+            </Section>
+          )}
+
+          {/* Failed */}
+          {failedItems.length > 0 && (
+            <Section title="Failed">
+              {failedItems.map((item) => (
+                <FailedItemCard key={item.id} item={item} onRetry={handleRetry} />
+              ))}
+            </Section>
+          )}
+
+          {/* Completed */}
+          {completedItems.length > 0 && (
+            <Section title="Completed">
+              {completedItems.map((item) => (
+                <CompletedItemCard key={item.id} item={item} />
+              ))}
+            </Section>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <div>
+    <h4 className="text-xs font-semibold text-base-content/50 uppercase tracking-wider mb-2">
+      {title}
+    </h4>
+    <div className="flex flex-col gap-2">{children}</div>
+  </div>
+);
+
+const QueueItemCard = ({ item, progress }: { item: QueuedMediaEdit; progress?: number }) => {
+  const isRendering = item.status === "rendering";
+  const pct = progress ?? item.progress ?? 0;
+
+  return (
+    <div className="bg-base-200 rounded-lg p-3 text-sm">
+      <div className="flex items-center gap-2 mb-1">
+        {isRendering ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-info" />
+        ) : (
+          <div className="h-3.5 w-3.5 rounded-full bg-base-300" />
+        )}
+        <span className="truncate font-medium">{item.id.slice(0, 8)}...</span>
+      </div>
+      {isRendering && (
+        <div className="mt-2">
+          <div className="flex justify-between text-xs text-base-content/60 mb-1">
+            <span>Progress</span>
+            <span>{Math.round(pct)}%</span>
+          </div>
+          <div className="w-full bg-base-300 rounded-full h-1.5">
+            <div
+              className="bg-info h-1.5 rounded-full transition-all duration-300"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const FailedItemCard = ({
+  item,
+  onRetry,
+}: {
+  item: QueuedMediaEdit;
+  onRetry: (id: string) => void;
+}) => (
+  <div className="bg-error/10 border border-error/20 rounded-lg p-3 text-sm">
+    <div className="flex items-center gap-2 mb-1">
+      <AlertTriangle className="h-3.5 w-3.5 text-error" />
+      <span className="truncate font-medium">{item.id.slice(0, 8)}...</span>
+    </div>
+    {item.error && (
+      <p className="text-xs text-error/80 mt-1 line-clamp-2">{item.error}</p>
+    )}
+    <div className="mt-2">
+      <Button size="sm" variant="ghost" onPress={() => onRetry(item.id)}>
+        <RefreshCw className="h-3 w-3 mr-1" />
+        Retry
+      </Button>
+    </div>
+  </div>
+);
+
+const CompletedItemCard = ({ item }: { item: QueuedMediaEdit }) => (
+  <div className="bg-success/10 border border-success/20 rounded-lg p-3 text-sm">
+    <div className="flex items-center gap-2">
+      <CheckCircle className="h-3.5 w-3.5 text-success" />
+      <span className="truncate font-medium">{item.id.slice(0, 8)}...</span>
+      {item.outputMediaId && (
+        <a
+          href={`/content/library/media/${item.outputMediaId}`}
+          className="ml-auto text-success hover:text-success/80"
+          title="View output media"
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      )}
+    </div>
+  </div>
+);

--- a/@fanslib/apps/web/src/lib/queries/media-edits.ts
+++ b/@fanslib/apps/web/src/lib/queries/media-edits.ts
@@ -34,3 +34,18 @@ export const useMediaEditByIdQuery = (editId: string) =>
     },
     enabled: !!editId,
   });
+
+export type QueuedMediaEdit = MediaEdit & {
+  progress?: number;
+};
+
+export const useMediaEditQueueQuery = () =>
+  useQuery({
+    queryKey: QUERY_KEYS.mediaEdits.queue(),
+    queryFn: async (): Promise<QueuedMediaEdit[]> => {
+      const res = await fetch("/api/media-edits/queue");
+      if (!res.ok) throw new Error("Failed to fetch render queue");
+      return res.json();
+    },
+    refetchInterval: 10000,
+  });

--- a/@fanslib/apps/web/src/lib/queries/query-keys.ts
+++ b/@fanslib/apps/web/src/lib/queries/query-keys.ts
@@ -58,6 +58,7 @@ export const QUERY_KEYS = {
   mediaEdits: {
     bySource: (mediaId: string) => ["media-edits", "by-source", mediaId] as const,
     byId: (editId: string) => ["media-edits", editId] as const,
+    queue: () => ["media-edits", "queue"] as const,
   },
 
   tags: {


### PR DESCRIPTION
## Summary
- `GET /api/media-edits/queue` endpoint returns all non-draft edits ordered by updatedAt
- Export dialog in editor toolbar: role, package, content rating (sf/sg/cn/uc/xt), quality preset (fast/pretty)
- Export flow: saves edit (create or update) → queues render → closes dialog with success
- RenderQueueBadge in app layout (next to CredentialStatusBadge) showing active+queued count, hidden when empty
- RenderQueueDrawer with SSE connection to `/api/media-edits/render-progress`:
  - Rendering items with live progress bars
  - Queued items with pending status
  - Failed items with error display and retry button
  - Completed items with link to output media
- 2 new server tests for queue listing endpoint

**Stacked on:** #271 (Watermark tool)

Closes #250

## Test plan
- [x] 363 server tests pass (2 new)
- [x] 150 web tests pass
- [x] `bun run lint` — 0 errors (both server and web)
- [x] `bun run typecheck` — clean (both)
- [ ] CI (stacked PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)