### PR TITLE
feat: canvas region interaction — draggable/resizable overlays

### DIFF
--- a/@fanslib/apps/web/src/features/editor/components/EditorCanvas.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/EditorCanvas.tsx
@@ -1,5 +1,7 @@
+import { useRef } from "react";
 import { Player } from "@remotion/player";
 import { AbsoluteFill, Img } from "remotion";
+import { RegionOverlay } from "./RegionOverlay";
 
 /**
  * A simple preview composition that renders the source media with optional watermark overlay.
@@ -50,8 +52,10 @@ export const EditorCanvas = ({ mediaId, mediaType, operations }: EditorCanvasPro
 
   const isVideo = mediaType === "video";
 
+  const containerRef = useRef<HTMLDivElement>(null);
+
   return (
-    <div className="flex-1 flex items-center justify-center bg-base-300 overflow-hidden p-4">
+    <div ref={containerRef} className="flex-1 flex items-center justify-center bg-base-300 overflow-hidden p-4 relative">
       <Player
         component={PreviewComposition}
         inputProps={{
@@ -71,6 +75,7 @@ export const EditorCanvas = ({ mediaId, mediaType, operations }: EditorCanvasPro
         controls={isVideo}
         loop={isVideo}
       />
+      <RegionOverlay containerRef={containerRef} />
     </div>
   );
 };

--- a/@fanslib/apps/web/src/features/editor/components/RegionOverlay.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/RegionOverlay.tsx
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useEditorStore } from "~/stores/editorStore";
+import {
+  relativeToPixel,
+  getPlayerRect,
+  type CanvasRect,
+} from "../utils/coordinate-mapping";
+
+type SpatialOp = {
+  type: string;
+  x: number;
+  y: number;
+  width: number;
+  height?: number;
+  [key: string]: unknown;
+};
+
+type RegionOverlayProps = {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  compositionWidth?: number;
+  compositionHeight?: number;
+};
+
+type DragState = {
+  type: "move" | "resize";
+  corner?: "nw" | "ne" | "sw" | "se";
+  startMouseX: number;
+  startMouseY: number;
+  startX: number;
+  startY: number;
+  startWidth: number;
+  startHeight: number;
+};
+
+export const RegionOverlay = ({
+  containerRef,
+  compositionWidth = 1920,
+  compositionHeight = 1080,
+}: RegionOverlayProps) => {
+  const operations = useEditorStore((s) => s.operations);
+  const selectedIndex = useEditorStore((s) => s.selectedOperationIndex);
+  const updateOperation = useEditorStore((s) => s.updateOperation);
+  const [dragState, setDragState] = useState<DragState | null>(null);
+  const canvasRectRef = useRef<CanvasRect | null>(null);
+
+  const getCanvasRect = useCallback((): CanvasRect | null => {
+    const container = containerRef.current;
+    if (!container) return null;
+    const rect = getPlayerRect(
+      container.clientWidth,
+      container.clientHeight,
+      compositionWidth,
+      compositionHeight,
+    );
+    canvasRectRef.current = rect;
+    return rect;
+  }, [containerRef, compositionWidth, compositionHeight]);
+
+  // Handle mouse move during drag
+  useEffect(() => {
+    if (!dragState || selectedIndex === null) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const canvas = canvasRectRef.current;
+      if (!canvas) return;
+
+      const dx = e.clientX - dragState.startMouseX;
+      const dy = e.clientY - dragState.startMouseY;
+      const relDx = dx / canvas.canvasWidth;
+      const relDy = dy / canvas.canvasHeight;
+
+      const op = operations[selectedIndex] as SpatialOp;
+      const clamp = (v: number) => Math.max(0, Math.min(1, v));
+
+      if (dragState.type === "move") {
+        updateOperation(selectedIndex, {
+          ...op,
+          x: clamp(dragState.startX + relDx),
+          y: clamp(dragState.startY + relDy),
+        });
+      } else if (dragState.type === "resize") {
+        const newWidth = clamp(dragState.startWidth + relDx);
+        const newHeight = clamp(
+          dragState.startHeight + relDy,
+        );
+        updateOperation(selectedIndex, {
+          ...op,
+          width: newWidth,
+          height: newHeight,
+        });
+      }
+    };
+
+    const handleMouseUp = () => {
+      setDragState(null);
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [dragState, selectedIndex, operations, updateOperation]);
+
+  const canvas = getCanvasRect();
+  if (!canvas) return null;
+
+  return (
+    <>
+      {operations.map((op, index) => {
+        const spatialOp = op as SpatialOp;
+        if (typeof spatialOp.x !== "number" || typeof spatialOp.y !== "number") return null;
+
+        const isSelected = index === selectedIndex;
+        const pos = relativeToPixel(spatialOp.x, spatialOp.y, canvas);
+        const width = (spatialOp.width ?? 0.1) * canvas.canvasWidth;
+        const height = (spatialOp.height ?? spatialOp.width ?? 0.1) * canvas.canvasHeight;
+
+        return (
+          <div
+            key={index}
+            className={`absolute ${
+              isSelected
+                ? "border-2 border-primary cursor-move"
+                : "border border-base-content/20 pointer-events-none"
+            }`}
+            style={{
+              left: pos.px,
+              top: pos.py,
+              width,
+              height,
+            }}
+            onMouseDown={
+              isSelected
+                ? (e) => {
+                    e.preventDefault();
+                    getCanvasRect();
+                    setDragState({
+                      type: "move",
+                      startMouseX: e.clientX,
+                      startMouseY: e.clientY,
+                      startX: spatialOp.x,
+                      startY: spatialOp.y,
+                      startWidth: spatialOp.width ?? 0.1,
+                      startHeight: spatialOp.height ?? spatialOp.width ?? 0.1,
+                    });
+                  }
+                : undefined
+            }
+          >
+            {isSelected && (
+              <>
+                {/* Corner resize handles */}
+                {(["nw", "ne", "sw", "se"] as const).map((corner) => (
+                  <div
+                    key={corner}
+                    className="absolute w-2 h-2 bg-primary border border-base-100 rounded-sm cursor-nwse-resize"
+                    style={{
+                      top: corner.startsWith("n") ? -4 : undefined,
+                      bottom: corner.startsWith("s") ? -4 : undefined,
+                      left: corner.endsWith("w") ? -4 : undefined,
+                      right: corner.endsWith("e") ? -4 : undefined,
+                    }}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      getCanvasRect();
+                      setDragState({
+                        type: "resize",
+                        corner,
+                        startMouseX: e.clientX,
+                        startMouseY: e.clientY,
+                        startX: spatialOp.x,
+                        startY: spatialOp.y,
+                        startWidth: spatialOp.width ?? 0.1,
+                        startHeight: spatialOp.height ?? spatialOp.width ?? 0.1,
+                      });
+                    }}
+                  />
+                ))}
+              </>
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+};

--- a/@fanslib/apps/web/src/features/editor/utils/coordinate-mapping.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/coordinate-mapping.ts
@@ -1,0 +1,65 @@
+export type CanvasRect = {
+  canvasWidth: number;
+  canvasHeight: number;
+  compositionWidth: number;
+  compositionHeight: number;
+};
+
+/**
+ * Given the actual element size and composition aspect ratio,
+ * compute the rendered content area (accounting for letterboxing/pillarboxing).
+ */
+export const getPlayerRect = (
+  elementWidth: number,
+  elementHeight: number,
+  compositionWidth: number,
+  compositionHeight: number,
+): CanvasRect => {
+  const compositionAspect = compositionWidth / compositionHeight;
+  const elementAspect = elementWidth / elementHeight;
+
+  const contentWidth =
+    elementAspect > compositionAspect
+      ? elementHeight * compositionAspect
+      : elementWidth;
+  const contentHeight =
+    elementAspect > compositionAspect
+      ? elementHeight
+      : elementWidth / compositionAspect;
+
+  return {
+    canvasWidth: contentWidth,
+    canvasHeight: contentHeight,
+    compositionWidth,
+    compositionHeight,
+  };
+};
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+/**
+ * Convert pixel coordinates (relative to the rendered Player content area)
+ * to relative 0-1 coordinates.
+ */
+export const pixelToRelative = (
+  px: number,
+  py: number,
+  canvas: CanvasRect,
+): { x: number; y: number } => ({
+  x: clamp(px / canvas.canvasWidth, 0, 1),
+  y: clamp(py / canvas.canvasHeight, 0, 1),
+});
+
+/**
+ * Convert relative 0-1 coordinates to pixel coordinates
+ * within the rendered Player content area.
+ */
+export const relativeToPixel = (
+  x: number,
+  y: number,
+  canvas: CanvasRect,
+): { px: number; py: number } => ({
+  px: x * canvas.canvasWidth,
+  py: y * canvas.canvasHeight,
+});

--- a/@fanslib/apps/web/src/features/editor/utils/coordinate-mapping.vitest.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/coordinate-mapping.vitest.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+import {
+  pixelToRelative,
+  relativeToPixel,
+  getPlayerRect,
+  type CanvasRect,
+} from "./coordinate-mapping";
+
+describe("coordinate-mapping", () => {
+  const canvas: CanvasRect = {
+    canvasWidth: 800,
+    canvasHeight: 450,
+    compositionWidth: 1920,
+    compositionHeight: 1080,
+  };
+
+  describe("pixelToRelative", () => {
+    test("converts pixel coordinates to relative 0-1 coordinates", () => {
+      const result = pixelToRelative(400, 225, canvas);
+      expect(result.x).toBeCloseTo(0.5, 2);
+      expect(result.y).toBeCloseTo(0.5, 2);
+    });
+
+    test("top-left corner maps to 0,0", () => {
+      const result = pixelToRelative(0, 0, canvas);
+      expect(result.x).toBeCloseTo(0, 2);
+      expect(result.y).toBeCloseTo(0, 2);
+    });
+
+    test("bottom-right corner maps to 1,1", () => {
+      const result = pixelToRelative(800, 450, canvas);
+      expect(result.x).toBeCloseTo(1, 2);
+      expect(result.y).toBeCloseTo(1, 2);
+    });
+
+    test("clamps to 0-1 range", () => {
+      const result = pixelToRelative(-50, 500, canvas);
+      expect(result.x).toBe(0);
+      expect(result.y).toBe(1);
+    });
+  });
+
+  describe("relativeToPixel", () => {
+    test("converts relative coordinates to pixel coordinates", () => {
+      const result = relativeToPixel(0.5, 0.5, canvas);
+      expect(result.px).toBeCloseTo(400, 0);
+      expect(result.py).toBeCloseTo(225, 0);
+    });
+
+    test("0,0 maps to top-left", () => {
+      const result = relativeToPixel(0, 0, canvas);
+      expect(result.px).toBe(0);
+      expect(result.py).toBe(0);
+    });
+
+    test("1,1 maps to bottom-right", () => {
+      const result = relativeToPixel(1, 1, canvas);
+      expect(result.px).toBe(800);
+      expect(result.py).toBe(450);
+    });
+  });
+
+  describe("getPlayerRect with letterboxing", () => {
+    test("returns full canvas when aspect ratios match", () => {
+      const rect = getPlayerRect(800, 450, 1920, 1080);
+      expect(rect.canvasWidth).toBe(800);
+      expect(rect.canvasHeight).toBe(450);
+    });
+
+    test("returns letterboxed rect when canvas is wider than composition", () => {
+      // Canvas 1000x450, composition 16:9 = 1920x1080
+      // 16:9 at height 450 = width 800, so letterboxed with bars on sides
+      const rect = getPlayerRect(1000, 450, 1920, 1080);
+      expect(rect.canvasWidth).toBe(800);
+      expect(rect.canvasHeight).toBe(450);
+    });
+
+    test("returns pillarboxed rect when canvas is taller than composition", () => {
+      // Canvas 800x600, composition 16:9
+      // 16:9 at width 800 = height 450
+      const rect = getPlayerRect(800, 600, 1920, 1080);
+      expect(rect.canvasWidth).toBe(800);
+      expect(rect.canvasHeight).toBe(450);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Coordinate mapping utility (`pixelToRelative`, `relativeToPixel`, `getPlayerRect`) with letterboxing/pillarboxing support
- `RegionOverlay` component renders draggable bounding boxes with corner resize handles on the Player canvas
- Drag body to reposition (updates x/y in relative coordinates), drag corners to resize (updates width/height)
- Selected operation shows primary-colored handles, other operations show faint outlines
- All coordinates clamped to 0-1 range
- 10 coordinate mapping tests

**Stacked on:** #270 (Editor route)

Closes #252

## Test plan
- [x] 155 web tests pass (10 new coordinate mapping tests)
- [x] `bun run lint` — 0 errors
- [x] `bun run typecheck` — clean
- [ ] CI (stacked PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)