### PR TITLE
feat: zoom/pan operation with keyframes

### DIFF
--- a/@fanslib/apps/web/src/features/editor/components/EditorToolbar.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/EditorToolbar.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Undo2, Redo2 } from "lucide-react";
+import { ArrowLeft, Undo2, Redo2, ZoomIn } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { Button } from "~/components/ui/Button";
 import { useEditorStore } from "~/stores/editorStore";
@@ -12,6 +12,7 @@ export const EditorToolbar = ({ mediaId }: EditorToolbarProps) => {
   const redo = useEditorStore((s) => s.redo);
   const canUndo = useEditorStore((s) => s.canUndo);
   const canRedo = useEditorStore((s) => s.canRedo);
+  const addZoom = useEditorStore((s) => s.addZoom);
 
   return (
     <div className="h-12 border-b border-base-300 bg-base-200/50 flex items-center px-4 gap-2">
@@ -19,6 +20,11 @@ export const EditorToolbar = ({ mediaId }: EditorToolbarProps) => {
         <ArrowLeft className="h-4 w-4" />
         Back to Media
       </Link>
+      <div className="border-l border-base-300 h-6 mx-2" />
+      <Button size="sm" variant="ghost" onPress={addZoom} aria-label="Add zoom effect">
+        <ZoomIn className="h-4 w-4 mr-1" />
+        <span className="text-xs">Zoom</span>
+      </Button>
       <div className="flex-1" />
       <Button
         size="sm"

--- a/@fanslib/apps/web/src/stores/editorStore.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.ts
@@ -21,6 +21,9 @@ type EditorState = {
   removeKeyframe: (opIndex: number, keyframeIndex: number) => void;
   updateKeyframe: (opIndex: number, keyframeIndex: number, keyframe: unknown) => void;
 
+  // Zoom convenience
+  addZoom: () => void;
+
   // Selection
   setSelectedOperationIndex: (index: number | null) => void;
 
@@ -113,6 +116,22 @@ export const useEditorStore = create<EditorState>((set, get) => {
         canUndo: true,
         canRedo: redoStack.length > 0,
       });
+    },
+
+    addZoom: () => {
+      const op = {
+        type: "zoom" as const,
+        scale: 1.0,
+        centerX: 0.5,
+        centerY: 0.5,
+        keyframes: [],
+      };
+      pushHistory();
+      set((state) => ({
+        operations: [...state.operations, op],
+        selectedOperationIndex: state.operations.length,
+        ...updateUndoRedoFlags(),
+      }));
     },
 
     addKeyframe: (opIndex, keyframe) => {

--- a/@fanslib/apps/web/src/stores/editorStore.vitest.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.vitest.ts
@@ -164,4 +164,31 @@ describe("editorStore", () => {
       expect(op.keyframes).toHaveLength(0);
     });
   });
+
+  describe("zoom operations", () => {
+    test("addZoom adds a zoom operation with default values", () => {
+      useEditorStore.getState().addZoom();
+      const ops = useEditorStore.getState().operations;
+      expect(ops).toHaveLength(1);
+      const op = ops[0] as {
+        type: string;
+        scale: number;
+        centerX: number;
+        centerY: number;
+        keyframes: unknown[];
+      };
+      expect(op.type).toBe("zoom");
+      expect(op.scale).toBe(1.0);
+      expect(op.centerX).toBe(0.5);
+      expect(op.centerY).toBe(0.5);
+      expect(op.keyframes).toEqual([]);
+      expect(useEditorStore.getState().selectedOperationIndex).toBe(0);
+    });
+
+    test("addZoom is undoable", () => {
+      useEditorStore.getState().addZoom();
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().operations).toHaveLength(0);
+    });
+  });
 });

--- a/@fanslib/libraries/video/src/compositions/ZoomEffect.tsx
+++ b/@fanslib/libraries/video/src/compositions/ZoomEffect.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { useCurrentFrame } from "remotion";
+import type { ZoomOperation } from "../types";
+import { interpolateKeyframes } from "../keyframes";
+
+type ZoomEffectProps = {
+  zoom: ZoomOperation;
+  children: React.ReactNode;
+};
+
+/**
+ * Wraps child content with a zoom/pan transform.
+ * Uses keyframe interpolation for animated camera movements.
+ */
+export const ZoomEffect: React.FC<ZoomEffectProps> = ({ zoom, children }) => {
+  const frame = useCurrentFrame();
+  const properties = ["scale", "centerX", "centerY"];
+
+  const values =
+    zoom.keyframes.length > 0
+      ? interpolateKeyframes(zoom.keyframes, frame, properties)
+      : { scale: zoom.scale, centerX: zoom.centerX, centerY: zoom.centerY };
+
+  const scale = values.scale;
+  // Translate so the center point stays fixed
+  const translateX = -(values.centerX - 0.5) * 100 * scale;
+  const translateY = -(values.centerY - 0.5) * 100 * scale;
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          transform: `scale(${scale}) translate(${translateX}%, ${translateY}%)`,
+          transformOrigin: `${values.centerX * 100}% ${values.centerY * 100}%`,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/@fanslib/libraries/video/src/compositions/index.ts
+++ b/@fanslib/libraries/video/src/compositions/index.ts
@@ -1,2 +1,3 @@
 export { WatermarkComposition } from "./WatermarkComposition";
+export { ZoomEffect } from "./ZoomEffect";
 export type { WatermarkCompositionProps } from "./WatermarkComposition";

--- a/@fanslib/libraries/video/src/types.ts
+++ b/@fanslib/libraries/video/src/types.ts
@@ -10,5 +10,17 @@ export type WatermarkOperation = {
   opacity: RelativeCoordinate;
 };
 
+export type ZoomOperation = {
+  type: "zoom";
+  scale: number;
+  centerX: RelativeCoordinate;
+  centerY: RelativeCoordinate;
+  keyframes: Array<{
+    frame: number;
+    values: Record<string, number>;
+    easing?: string;
+  }>;
+};
+
 /** Union of all supported edit operations */
-export type Operation = WatermarkOperation;
+export type Operation = WatermarkOperation | ZoomOperation;


### PR DESCRIPTION
## Summary
- `ZoomOperation` type with scale, centerX/Y, and keyframes
- `ZoomEffect` Remotion composition wrapping content with CSS transform scale/translate and keyframe interpolation
- Editor store: `addZoom()` with defaults (scale 1.0, centered)
- Zoom tool button in toolbar

**Stacked on:** #273 (Keyframe system)

Closes #259

## Test plan
- [x] 19 editor store tests pass (2 new zoom)
- [x] `bun run lint` — 0 errors
- [x] `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)