### PR TITLE
feat: add delete button for draft media edits

### DIFF
--- a/@fanslib/apps/web/src/features/editor/components/MediaEditsSection.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/MediaEditsSection.tsx
@@ -1,7 +1,9 @@
+import { useState } from "react";
 import { Link } from "@tanstack/react-router";
-import { Edit3, Plus, Clock, CheckCircle2, XCircle, Loader2 } from "lucide-react";
+import { Edit3, Plus, Clock, CheckCircle2, XCircle, Loader2, Trash2 } from "lucide-react";
 import { Button } from "~/components/ui/Button";
-import { useMediaEditsBySourceQuery } from "~/lib/queries/media-edits";
+import { DeleteConfirmDialog } from "~/components/ui/DeleteConfirmDialog";
+import { useMediaEditsBySourceQuery, useDeleteMediaEditMutation } from "~/lib/queries/media-edits";
 
 const statusConfig = {
   draft: { icon: Edit3, label: "Draft", color: "text-base-content/50" },
@@ -17,6 +19,8 @@ type MediaEditsSectionProps = {
 
 export const MediaEditsSection = ({ mediaId }: MediaEditsSectionProps) => {
   const { data: edits = [] } = useMediaEditsBySourceQuery(mediaId);
+  const deleteEdit = useDeleteMediaEditMutation();
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
   return (
     <div>
@@ -35,6 +39,7 @@ export const MediaEditsSection = ({ mediaId }: MediaEditsSectionProps) => {
           {edits.map((edit) => {
             const config = statusConfig[edit.status];
             const StatusIcon = config.icon;
+            const isDraft = edit.status === "draft";
             return (
               <Link
                 key={edit.id}
@@ -53,11 +58,37 @@ export const MediaEditsSection = ({ mediaId }: MediaEditsSectionProps) => {
                 <span className="text-xs text-base-content/40">
                   {new Date(edit.createdAt).toLocaleDateString()}
                 </span>
+                {isDraft && (
+                  <button
+                    type="button"
+                    className="p-1 rounded hover:bg-error/20 text-base-content/40 hover:text-error transition-colors"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setDeleteTarget(edit.id);
+                    }}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                )}
               </Link>
             );
           })}
         </div>
       )}
+      <DeleteConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+        itemType="edit"
+        onConfirm={async () => {
+          if (deleteTarget) {
+            await deleteEdit.mutateAsync({ id: deleteTarget });
+            setDeleteTarget(null);
+          }
+        }}
+        isLoading={deleteEdit.isPending}
+      />
     </div>
   );
 };

--- a/@fanslib/apps/web/src/lib/queries/media-edits.ts
+++ b/@fanslib/apps/web/src/lib/queries/media-edits.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { QUERY_KEYS } from "./query-keys";
 
 type MediaEdit = {
@@ -37,6 +37,21 @@ export const useMediaEditByIdQuery = (editId: string) =>
 
 export type QueuedMediaEdit = MediaEdit & {
   progress?: number;
+};
+
+export const useDeleteMediaEditMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id }: { id: string }) => {
+      const res = await fetch(`/api/media-edits/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed to delete media edit");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["media-edits"] });
+    },
+  });
 };
 
 export const useMediaEditQueueQuery = () =>


### PR DESCRIPTION
## Summary
- Add a trash icon button on draft edits in the media detail page's Edits section
- Clicking the button opens a `DeleteConfirmDialog` for confirmation before calling the existing `DELETE /api/media-edits/:id` endpoint
- Only edits with `status === "draft"` show the delete button

## Test plan
- [ ] Open a media detail page that has draft edits
- [ ] Verify draft edits show a trash icon on the right
- [ ] Verify non-draft edits (queued, rendering, completed, failed) do not show the icon
- [ ] Click the trash icon and confirm the deletion dialog appears
- [ ] Confirm deletion removes the edit from the list
- [ ] Verify clicking the trash icon does not navigate to the edit page

🤖 Generated with [Claude Code](https://claude.com/claude-code)