### PR TITLE
feat(editor): ID-based selection + time ranges on all operations

### DIFF
--- a/@fanslib/apps/web/src/features/editor/components/CropOverlay.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/CropOverlay.tsx
@@ -35,18 +35,20 @@ type DragState =
 
 export const CropOverlay = ({ canvasRect, interactive }: CropOverlayProps) => {
   const operations = useEditorStore((s) => s.operations);
-  const cropEditingOperationIndex = useEditorStore((s) => s.cropEditingOperationIndex);
-  const updateOperation = useEditorStore((s) => s.updateOperation);
+  const cropEditingOperationId = useEditorStore((s) => s.cropEditingOperationId);
+  const updateOperationById = useEditorStore((s) => s.updateOperationById);
   const [dragState, setDragState] = useState<DragState | null>(null);
   const canvasRectRef = useRef<CanvasRect | null>(null);
 
   useEffect(() => {
-    if (!dragState || cropEditingOperationIndex === null) return;
+    if (!dragState || cropEditingOperationId === null) return;
 
     const handleMouseMove = (e: MouseEvent) => {
       const canvas = canvasRectRef.current;
       if (!canvas) return;
-      const op = operations[cropEditingOperationIndex];
+      const op = (operations as Array<{ id?: string }>).find(
+        (o) => o.id === cropEditingOperationId,
+      );
       if (!isCropOperation(op)) return;
 
       const dx = e.clientX - dragState.startMouseX;
@@ -59,7 +61,7 @@ export const CropOverlay = ({ canvasRect, interactive }: CropOverlayProps) => {
       if (dragState.kind === "move") {
         const nx = clamp(dragState.startX + relDx, 0, 1 - dragState.startW);
         const ny = clamp(dragState.startY + relDy, 0, 1 - dragState.startH);
-        updateOperation(cropEditingOperationIndex, clampCropRect({ ...op, x: nx, y: ny }));
+        updateOperationById(cropEditingOperationId, clampCropRect({ ...op, x: nx, y: ny }));
         return;
       }
 
@@ -81,8 +83,8 @@ export const CropOverlay = ({ canvasRect, interactive }: CropOverlayProps) => {
         return { w, h: h1 };
       })();
 
-      updateOperation(
-        cropEditingOperationIndex,
+      updateOperationById(
+        cropEditingOperationId,
         clampCropRect({
           ...op,
           x: dragState.startX,
@@ -103,12 +105,12 @@ export const CropOverlay = ({ canvasRect, interactive }: CropOverlayProps) => {
       window.removeEventListener("mousemove", handleMouseMove);
       window.removeEventListener("mouseup", handleMouseUp);
     };
-  }, [dragState, cropEditingOperationIndex, operations, updateOperation]);
+  }, [dragState, cropEditingOperationId, operations, updateOperationById]);
 
   if (!canvasRect || !interactive) return null;
-  if (cropEditingOperationIndex === null) return null;
+  if (cropEditingOperationId === null) return null;
 
-  const op = operations[cropEditingOperationIndex];
+  const op = (operations as Array<{ id?: string }>).find((o) => o.id === cropEditingOperationId);
   if (!isCropOperation(op)) return null;
 
   const canvas = canvasRect;

--- a/@fanslib/apps/web/src/features/editor/components/EditorCanvas.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/EditorCanvas.tsx
@@ -288,9 +288,9 @@ export const EditorCanvas = forwardRef<EditorCanvasHandle, EditorCanvasProps>(
     ref,
   ) => {
     const sourceUrl = useMemo(() => toAbsoluteFileUrl(`/api/media/${mediaId}/file`), [mediaId]);
-    const selectedIndex = useEditorStore((s) => s.selectedOperationIndex);
-    const cropEditingOperationIndex = useEditorStore((s) => s.cropEditingOperationIndex);
-    const updateOperation = useEditorStore((s) => s.updateOperation);
+    const selectedId = useEditorStore((s) => s.selectedOperationId);
+    const cropEditingOperationId = useEditorStore((s) => s.cropEditingOperationId);
+    const updateOperationById = useEditorStore((s) => s.updateOperationById);
 
     // Find watermark operation if any
     const watermarkOp = operations.find(isWatermarkOp);
@@ -346,9 +346,9 @@ export const EditorCanvas = forwardRef<EditorCanvasHandle, EditorCanvasProps>(
     }, [captionFontFamilies]);
 
     const cropsForPreview = useMemo(() => {
-      if (cropEditingOperationIndex !== null) return [];
+      if (cropEditingOperationId !== null) return [];
       return operations.filter(isCropOperation).filter((c) => c.applied);
-    }, [operations, cropEditingOperationIndex]);
+    }, [operations, cropEditingOperationId]);
 
     const isVideo = shouldUseVideoElementForPreview({
       type: mediaType,
@@ -388,8 +388,8 @@ export const EditorCanvas = forwardRef<EditorCanvasHandle, EditorCanvasProps>(
 
     // Find the selected watermark op for the draggable overlay
     const selectedOp =
-      selectedIndex !== null && selectedIndex < operations.length
-        ? operations[selectedIndex]
+      selectedId !== null
+        ? (operations as Array<{ id?: string }>).find((op) => op.id === selectedId) ?? null
         : null;
     const selectedWatermark = selectedOp && isWatermarkOp(selectedOp) ? selectedOp : null;
 
@@ -404,7 +404,7 @@ export const EditorCanvas = forwardRef<EditorCanvasHandle, EditorCanvasProps>(
 
     const handleMouseDown = useCallback(
       (e: React.MouseEvent) => {
-        if (!selectedWatermark || selectedIndex === null || !compositionViewport) return;
+        if (!selectedWatermark || selectedId === null || !compositionViewport) return;
         e.preventDefault();
         dragging.current = true;
         const viewport = compositionViewport;
@@ -416,13 +416,13 @@ export const EditorCanvas = forwardRef<EditorCanvasHandle, EditorCanvasProps>(
         };
 
         const handleMouseMove = (moveEvent: MouseEvent) => {
-          if (!dragging.current || selectedIndex === null) return;
+          if (!dragging.current || selectedId === null) return;
           const dx = (moveEvent.clientX - dragStart.current.x) / viewport.canvasWidth;
           const dy = (moveEvent.clientY - dragStart.current.y) / viewport.canvasHeight;
           const w = selectedWatermark.width;
           const newX = Math.max(0, Math.min(1 - w, dragStart.current.opX + dx));
           const newY = Math.max(0, Math.min(1, dragStart.current.opY + dy));
-          updateOperation(selectedIndex, {
+          updateOperationById(selectedId, {
             ...selectedWatermark,
             x: newX,
             y: newY,
@@ -438,7 +438,7 @@ export const EditorCanvas = forwardRef<EditorCanvasHandle, EditorCanvasProps>(
         document.addEventListener("mousemove", handleMouseMove);
         document.addEventListener("mouseup", handleMouseUp);
       },
-      [selectedWatermark, selectedIndex, updateOperation, compositionViewport],
+      [selectedWatermark, selectedId, updateOperationById, compositionViewport],
     );
 
     return (

--- a/@fanslib/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -37,7 +37,7 @@ export const EditorLayout = ({ mediaId, editId }: EditorLayoutProps) => {
   const clipMode = useClipStore((s) => s.clipMode);
   const clipRanges = useClipStore((s) => s.ranges);
   const resetClips = useClipStore((s) => s.reset);
-  const setSelectedOperationIndex = useEditorStore((s) => s.setSelectedOperationIndex);
+  const setSelectedOperationId = useEditorStore((s) => s.setSelectedOperationId);
 
   const clipHotkeysActive =
     !mediaLoading &&
@@ -133,24 +133,24 @@ export const EditorLayout = ({ mediaId, editId }: EditorLayoutProps) => {
       if (e.key !== "i" && e.key !== "I" && e.key !== "o" && e.key !== "O") return;
       if (isEditableKeyTarget(e.target)) return;
       const {
-        selectedOperationIndex: sel,
+        selectedOperationId: selId,
         operations: ops,
-        updateOperation,
+        updateOperationById,
       } = useEditorStore.getState();
-      if (sel === null || sel >= ops.length) return;
-      const op = ops[sel];
+      if (selId === null) return;
+      const op = (ops as Array<{ id?: string }>).find((o) => o.id === selId);
       if (!isCaptionOperation(op)) return;
       e.preventDefault();
       const frame = currentFrameRef.current;
       if (e.key === "i" || e.key === "I") {
         const start = frame;
         const end = Math.max(op.endFrame, start);
-        updateOperation(sel, { ...op, startFrame: start, endFrame: end });
+        updateOperationById(selId, { ...op, startFrame: start, endFrame: end });
         return;
       }
       const start = Math.min(op.startFrame, frame);
       const end = Math.max(op.startFrame, frame);
-      updateOperation(sel, { ...op, startFrame: start, endFrame: end });
+      updateOperationById(selId, { ...op, startFrame: start, endFrame: end });
     };
 
     window.addEventListener("keydown", onKeyDown);
@@ -159,15 +159,15 @@ export const EditorLayout = ({ mediaId, editId }: EditorLayoutProps) => {
 
   useEffect(() => {
     if (clipRanges.length > 0) {
-      setSelectedOperationIndex(null);
+      setSelectedOperationId(null);
     }
-  }, [clipRanges.length, setSelectedOperationIndex]);
+  }, [clipRanges.length, setSelectedOperationId]);
 
   useEffect(() => {
     if (!clipMode) return;
-    setSelectedOperationIndex(null);
+    setSelectedOperationId(null);
     useClipStore.getState().selectRange(null);
-  }, [clipMode, setSelectedOperationIndex]);
+  }, [clipMode, setSelectedOperationId]);
 
   useEffect(() => {
     if (!isDirty) return;

--- a/@fanslib/apps/web/src/features/editor/components/KeyframeTimeline.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/KeyframeTimeline.tsx
@@ -16,30 +16,36 @@ type KeyframeData = {
 
 export const KeyframeTimeline = ({ totalFrames, currentFrame, onSeek }: KeyframeTimelineProps) => {
   const operations = useEditorStore((s) => s.operations);
-  const selectedIndex = useEditorStore((s) => s.selectedOperationIndex);
-  const addKeyframe = useEditorStore((s) => s.addKeyframe);
-  const removeKeyframe = useEditorStore((s) => s.removeKeyframe);
+  const selectedId = useEditorStore((s) => s.selectedOperationId);
+  const addKeyframeById = useEditorStore((s) => s.addKeyframeById);
+  const removeKeyframeById = useEditorStore((s) => s.removeKeyframeById);
 
-  if (selectedIndex === null || selectedIndex >= operations.length) {
+  const selectedOp =
+    selectedId !== null
+      ? ((operations as Array<{ id?: string }>).find((op) => op.id === selectedId) as
+          | ({ keyframes?: KeyframeData[] } & { id?: string })
+          | undefined)
+      : undefined;
+
+  if (!selectedOp) {
     return null;
   }
 
-  const selectedOp = operations[selectedIndex] as { keyframes?: KeyframeData[] };
   const keyframes = selectedOp.keyframes ?? [];
 
   const isAtKeyframe = keyframes.some((kf) => kf.frame === currentFrame);
 
   const handleAddKeyframe = () => {
-    if (selectedIndex === null) return;
-    addKeyframe(selectedIndex, {
+    if (selectedId === null) return;
+    addKeyframeById(selectedId, {
       frame: currentFrame,
       values: {},
     });
   };
 
   const handleRemoveKeyframe = (kfIndex: number) => {
-    if (selectedIndex === null) return;
-    removeKeyframe(selectedIndex, kfIndex);
+    if (selectedId === null) return;
+    removeKeyframeById(selectedId, kfIndex);
   };
 
   return (

--- a/@fanslib/apps/web/src/features/editor/components/LayerPanel.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/LayerPanel.tsx
@@ -22,12 +22,12 @@ const formatClipRange = (startFrame: number, endFrame: number): string => {
 
 export const LayerPanel = ({ onSeekFrame }: LayerPanelProps) => {
   const operations = useEditorStore((s) => s.operations);
-  const selectedIndex = useEditorStore((s) => s.selectedOperationIndex);
-  const setSelectedIndex = useEditorStore((s) => s.setSelectedOperationIndex);
-  const removeOperation = useEditorStore((s) => s.removeOperation);
+  const selectedId = useEditorStore((s) => s.selectedOperationId);
+  const setSelectedId = useEditorStore((s) => s.setSelectedOperationId);
+  const removeOperationById = useEditorStore((s) => s.removeOperationById);
   const applyCrop = useEditorStore((s) => s.applyCrop);
-  const cropEditingOperationIndex = useEditorStore((s) => s.cropEditingOperationIndex);
-  const setCropEditingOperationIndex = useEditorStore((s) => s.setCropEditingOperationIndex);
+  const cropEditingOperationId = useEditorStore((s) => s.cropEditingOperationId);
+  const setCropEditingOperationId = useEditorStore((s) => s.setCropEditingOperationId);
 
   const clipMode = useClipStore((s) => s.clipMode);
   const ranges = useClipStore((s) => s.ranges);
@@ -60,7 +60,7 @@ export const LayerPanel = ({ onSeekFrame }: LayerPanelProps) => {
                       : "text-base-content/70 hover:bg-base-300/50"
                   }`}
                   onClick={() => {
-                    setSelectedIndex(null);
+                    setSelectedId(null);
                     if (isSelected) {
                       selectRange(null);
                     } else {
@@ -115,16 +115,17 @@ export const LayerPanel = ({ onSeekFrame }: LayerPanelProps) => {
           </p>
         ) : hasOperations ? (
           operations.map((op, index) => {
-            const opObj = op as { type?: string };
+            const opObj = op as { type?: string; id?: string };
+            const opId = opObj.id;
             const label = opObj.type ?? `Operation ${index + 1}`;
-            const isSelected = selectedIndex === index && selectedRangeIndex === null;
+            const isSelected = opId != null && opId === selectedId && selectedRangeIndex === null;
             const crop = isCropOperation(op) ? op : null;
-            const showCropEdit = crop?.applied === true && cropEditingOperationIndex !== index;
-            const showCropApply = crop && (!crop.applied || cropEditingOperationIndex === index);
+            const showCropEdit = crop?.applied === true && cropEditingOperationId !== opId;
+            const showCropApply = crop && (!crop.applied || cropEditingOperationId === opId);
 
             return (
               <div
-                key={`op-${index}`}
+                key={opId ?? `op-${index}`}
                 className={`flex items-center gap-1 px-2 py-1.5 rounded cursor-pointer text-sm ${
                   isSelected
                     ? "bg-base-300 text-base-content"
@@ -132,13 +133,13 @@ export const LayerPanel = ({ onSeekFrame }: LayerPanelProps) => {
                 }`}
                 onClick={() => {
                   selectRange(null);
-                  setSelectedIndex(isSelected ? null : index);
+                  setSelectedId(isSelected ? null : (opId ?? null));
                 }}
               >
                 <GripVertical className="h-3 w-3 text-base-content/30 cursor-grab" />
                 <span className="flex-1 truncate capitalize">{label}</span>
                 <Eye className="h-3 w-3 text-base-content/30" />
-                {showCropEdit && (
+                {showCropEdit && opId && (
                   <div
                     className="inline-flex"
                     onClick={(e) => {
@@ -149,7 +150,7 @@ export const LayerPanel = ({ onSeekFrame }: LayerPanelProps) => {
                       size="sm"
                       variant="ghost"
                       aria-label="Edit crop"
-                      onPress={() => setCropEditingOperationIndex(index)}
+                      onPress={() => setCropEditingOperationId(opId)}
                     >
                       <Pencil className="h-3 w-3" />
                     </Button>
@@ -172,16 +173,18 @@ export const LayerPanel = ({ onSeekFrame }: LayerPanelProps) => {
                     </Button>
                   </div>
                 )}
-                <div
-                  className="inline-flex"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                  }}
-                >
-                  <Button size="sm" variant="ghost" onPress={() => removeOperation(index)}>
-                    <Trash2 className="h-3 w-3 text-error" />
-                  </Button>
-                </div>
+                {opId && (
+                  <div
+                    className="inline-flex"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                    }}
+                  >
+                    <Button size="sm" variant="ghost" onPress={() => removeOperationById(opId)}>
+                      <Trash2 className="h-3 w-3 text-error" />
+                    </Button>
+                  </div>
+                )}
               </div>
             );
           })

--- a/@fanslib/apps/web/src/features/editor/components/PlaybackBar.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/PlaybackBar.tsx
@@ -42,7 +42,7 @@ export const PlaybackBar = ({
   const scrubbing = useRef(false);
   const animFrameRef = useRef<number>(0);
 
-  const setSelectedOperationIndex = useEditorStore((s) => s.setSelectedOperationIndex);
+  const setSelectedOperationId = useEditorStore((s) => s.setSelectedOperationId);
   const ranges = useClipStore((s) => s.ranges);
   const pendingMarkInFrame = useClipStore((s) => s.pendingMarkInFrame);
   const selectedRangeIndex = useClipStore((s) => s.selectedRangeIndex);
@@ -167,7 +167,7 @@ export const PlaybackBar = ({
               style={{ left: `${left}%`, width: `${width}%` }}
               onPointerDown={(e) => {
                 e.stopPropagation();
-                setSelectedOperationIndex(null);
+                setSelectedOperationId(null);
                 selectRange(i);
               }}
             />

--- a/@fanslib/apps/web/src/features/editor/components/PropertiesPanel.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/PropertiesPanel.tsx
@@ -133,15 +133,15 @@ const CAPTION_ANIMATIONS: CaptionOperation["animation"][] = [
   "typewriter",
 ];
 
-const CaptionProperties = ({ op, index }: { op: CaptionOperation; index: number }) => {
+const CaptionProperties = ({ op, opId }: { op: CaptionOperation; opId: string }) => {
   const presetNameRef = useRef<HTMLInputElement>(null);
-  const updateOperation = useEditorStore((s) => s.updateOperation);
+  const updateOperationById = useEditorStore((s) => s.updateOperationById);
   const { data: settings } = useSettingsQuery();
   const saveSettings = useSaveSettingsMutation();
   const presets = settings?.captionStylePresets ?? [];
 
   const update = (patch: Partial<CaptionOperation>) => {
-    updateOperation(index, { ...op, ...patch });
+    updateOperationById(opId, { ...op, ...patch });
   };
 
   const applyPresetById = (id: string) => {
@@ -369,21 +369,21 @@ const CaptionProperties = ({ op, index }: { op: CaptionOperation; index: number 
   );
 };
 
-const CropProperties = ({ op, index }: { op: CropOperation; index: number }) => {
-  const updateOperation = useEditorStore((s) => s.updateOperation);
+const CropProperties = ({ op, opId, index }: { op: CropOperation; opId: string; index: number }) => {
+  const updateOperationById = useEditorStore((s) => s.updateOperationById);
   const applyCrop = useEditorStore((s) => s.applyCrop);
-  const cropEditingOperationIndex = useEditorStore((s) => s.cropEditingOperationIndex);
+  const cropEditingOperationId = useEditorStore((s) => s.cropEditingOperationId);
 
-  const canEdit = !op.applied || cropEditingOperationIndex === index;
-  const showApply = !op.applied || cropEditingOperationIndex === index;
+  const canEdit = !op.applied || cropEditingOperationId === opId;
+  const showApply = !op.applied || cropEditingOperationId === opId;
 
   const update = (patch: Partial<CropOperation>) => {
     const next = clampCropRect({ ...op, ...patch });
-    updateOperation(index, next);
+    updateOperationById(opId, next);
   };
 
   const updateFromPixels = (pixel: Partial<Record<"xPx" | "yPx" | "wPx" | "hPx", number>>) => {
-    updateOperation(index, cropOperationWithPixelRect(op, pixel));
+    updateOperationById(opId, cropOperationWithPixelRect(op, pixel));
   };
 
   const setAspectPreset = (preset: CropAspectPreset) => {
@@ -397,8 +397,8 @@ const CropProperties = ({ op, index }: { op: CropOperation; index: number }) => 
       yPx + hFromRatio > CROP_COMPOSITION_HEIGHT ? CROP_COMPOSITION_HEIGHT - yPx : hFromRatio;
     const xPx2 =
       xPx + wPx > CROP_COMPOSITION_WIDTH ? Math.max(0, CROP_COMPOSITION_WIDTH - wPx) : xPx;
-    updateOperation(
-      index,
+    updateOperationById(
+      opId,
       cropOperationWithPixelRect({ ...op, aspectPreset: preset }, { xPx: xPx2, yPx, wPx, hPx }),
     );
   };
@@ -519,12 +519,12 @@ const CropProperties = ({ op, index }: { op: CropOperation; index: number }) => 
   );
 };
 
-const WatermarkProperties = ({ op, index }: { op: WatermarkOp; index: number }) => {
-  const updateOperation = useEditorStore((s) => s.updateOperation);
+const WatermarkProperties = ({ op, opId }: { op: WatermarkOp; opId: string }) => {
+  const updateOperationById = useEditorStore((s) => s.updateOperationById);
   const { data: assets } = useAssetsQuery("image");
 
   const update = (patch: Partial<WatermarkOp>) => {
-    updateOperation(index, { ...op, ...patch });
+    updateOperationById(opId, { ...op, ...patch });
   };
 
   return (
@@ -665,9 +665,9 @@ const SliderField = ({
   </div>
 );
 
-const BlurProperties = ({ op, index }: { op: BlurOperation; index: number }) => {
-  const updateOperation = useEditorStore((s) => s.updateOperation);
-  const update = (patch: Partial<BlurOperation>) => updateOperation(index, { ...op, ...patch });
+const BlurProperties = ({ op, opId }: { op: BlurOperation; opId: string }) => {
+  const updateOperationById = useEditorStore((s) => s.updateOperationById);
+  const update = (patch: Partial<BlurOperation>) => updateOperationById(opId, { ...op, ...patch });
 
   return (
     <div className="space-y-4">
@@ -691,9 +691,9 @@ const BlurProperties = ({ op, index }: { op: BlurOperation; index: number }) => 
   );
 };
 
-const PixelateProperties = ({ op, index }: { op: PixelateOperation; index: number }) => {
-  const updateOperation = useEditorStore((s) => s.updateOperation);
-  const update = (patch: Partial<PixelateOperation>) => updateOperation(index, { ...op, ...patch });
+const PixelateProperties = ({ op, opId }: { op: PixelateOperation; opId: string }) => {
+  const updateOperationById = useEditorStore((s) => s.updateOperationById);
+  const update = (patch: Partial<PixelateOperation>) => updateOperationById(opId, { ...op, ...patch });
 
   return (
     <div className="space-y-4">
@@ -717,9 +717,9 @@ const PixelateProperties = ({ op, index }: { op: PixelateOperation; index: numbe
   );
 };
 
-const EmojiProperties = ({ op, index }: { op: EmojiOperation; index: number }) => {
-  const updateOperation = useEditorStore((s) => s.updateOperation);
-  const update = (patch: Partial<EmojiOperation>) => updateOperation(index, { ...op, ...patch });
+const EmojiProperties = ({ op, opId }: { op: EmojiOperation; opId: string }) => {
+  const updateOperationById = useEditorStore((s) => s.updateOperationById);
+  const update = (patch: Partial<EmojiOperation>) => updateOperationById(opId, { ...op, ...patch });
 
   return (
     <div className="space-y-4">
@@ -740,9 +740,9 @@ const EmojiProperties = ({ op, index }: { op: EmojiOperation; index: number }) =
   );
 };
 
-const ZoomProperties = ({ op, index }: { op: ZoomOperation; index: number }) => {
-  const updateOperation = useEditorStore((s) => s.updateOperation);
-  const update = (patch: Partial<ZoomOperation>) => updateOperation(index, { ...op, ...patch });
+const ZoomProperties = ({ op, opId }: { op: ZoomOperation; opId: string }) => {
+  const updateOperationById = useEditorStore((s) => s.updateOperationById);
+  const update = (patch: Partial<ZoomOperation>) => updateOperationById(opId, { ...op, ...patch });
 
   return (
     <div className="space-y-4">
@@ -766,9 +766,14 @@ const ZoomProperties = ({ op, index }: { op: ZoomOperation; index: number }) => 
 
 export const PropertiesPanel = () => {
   const operations = useEditorStore((s) => s.operations);
-  const selectedIndex = useEditorStore((s) => s.selectedOperationIndex);
+  const selectedId = useEditorStore((s) => s.selectedOperationId);
 
-  if (selectedIndex === null || selectedIndex >= operations.length) {
+  const selectedOp =
+    selectedId !== null
+      ? (operations as Array<{ id?: string }>).find((o) => o.id === selectedId)
+      : undefined;
+
+  if (!selectedOp || selectedId === null) {
     return (
       <div className="w-72 border-l border-base-300 bg-base-200/30 p-4 flex flex-col items-center justify-center text-base-content/40">
         <Settings2 className="h-8 w-8 mb-2" />
@@ -777,7 +782,10 @@ export const PropertiesPanel = () => {
     );
   }
 
-  const op = operations[selectedIndex];
+  const op = selectedOp;
+  const selectedIndex = (operations as Array<{ id?: string }>).findIndex(
+    (o) => o.id === selectedId,
+  );
 
   return (
     <div className="w-72 border-l border-base-300 bg-base-200/30 p-4 overflow-y-auto">
@@ -786,19 +794,19 @@ export const PropertiesPanel = () => {
       </h3>
 
       {isWatermarkOp(op) ? (
-        <WatermarkProperties op={op} index={selectedIndex} />
+        <WatermarkProperties op={op} opId={selectedId} />
       ) : isCropOperation(op) ? (
-        <CropProperties op={op} index={selectedIndex} />
+        <CropProperties op={op} opId={selectedId} index={selectedIndex} />
       ) : isCaptionOperation(op) ? (
-        <CaptionProperties op={op} index={selectedIndex} />
+        <CaptionProperties op={op} opId={selectedId} />
       ) : isBlurOp(op) ? (
-        <BlurProperties op={op} index={selectedIndex} />
+        <BlurProperties op={op} opId={selectedId} />
       ) : isPixelateOp(op) ? (
-        <PixelateProperties op={op} index={selectedIndex} />
+        <PixelateProperties op={op} opId={selectedId} />
       ) : isEmojiOp(op) ? (
-        <EmojiProperties op={op} index={selectedIndex} />
+        <EmojiProperties op={op} opId={selectedId} />
       ) : isZoomOp(op) ? (
-        <ZoomProperties op={op} index={selectedIndex} />
+        <ZoomProperties op={op} opId={selectedId} />
       ) : (
         <div className="space-y-3 text-sm">
           {Object.entries(op as Record<string, unknown>)

--- a/@fanslib/apps/web/src/features/editor/components/RegionOverlay.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/RegionOverlay.tsx
@@ -56,33 +56,36 @@ export const RegionOverlay = ({
   previewDurationInFrames = 1,
 }: RegionOverlayProps) => {
   const operations = useEditorStore((s) => s.operations);
-  const selectedIndex = useEditorStore((s) => s.selectedOperationIndex);
-  const updateOperation = useEditorStore((s) => s.updateOperation);
+  const selectedId = useEditorStore((s) => s.selectedOperationId);
+  const updateOperationById = useEditorStore((s) => s.updateOperationById);
   const [dragState, setDragState] = useState<DragState | null>(null);
   const canvasRectRef = useRef<CanvasRect | null>(null);
 
   useEffect(() => {
-    if (!dragState || selectedIndex === null) return;
+    if (!dragState || selectedId === null) return;
 
     const handleMouseMove = (e: MouseEvent) => {
       const canvas = canvasRectRef.current;
       if (!canvas) return;
+
+      const raw = (operations as Array<{ id?: string }>).find((op) => op.id === selectedId) as
+        | unknown
+        | undefined;
+      if (!raw) return;
+      const op = raw as SpatialOp;
+      const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
 
       const dx = e.clientX - dragState.startMouseX;
       const dy = e.clientY - dragState.startMouseY;
       const relDx = dx / canvas.canvasWidth;
       const relDy = dy / canvas.canvasHeight;
 
-      const raw = operations[selectedIndex];
-      const op = raw as SpatialOp;
-      const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
-
       if (dragState.kind === "caption-move") {
         if (!isCaptionOperation(raw)) return;
         const cap = raw;
         const nx = clamp(dragState.startX + relDx, dragState.halfWNorm, 1 - dragState.halfWNorm);
         const ny = clamp(dragState.startY + relDy, dragState.halfHNorm, 1 - dragState.halfHNorm);
-        updateOperation(selectedIndex, { ...cap, x: nx, y: ny });
+        updateOperationById(selectedId, { ...cap, x: nx, y: ny });
         return;
       }
 
@@ -94,7 +97,7 @@ export const RegionOverlay = ({
       if (dragState.type === "move") {
         const nx = dragState.startX + relDx;
         const ny = dragState.startY + relDy;
-        updateOperation(selectedIndex, {
+        updateOperationById(selectedId, {
           ...op,
           x: isEmoji ? Math.max(opW / 2, Math.min(1 - opW / 2, nx)) : clamp01(nx, 1 - opW),
           y: isEmoji ? Math.max(opH / 2, Math.min(1 - opH / 2, ny)) : clamp01(ny, 1 - opH),
@@ -106,7 +109,7 @@ export const RegionOverlay = ({
       const maxH = 1 - dragState.startY;
       const newWidth = clamp01(dragState.startWidth + relDx, maxW);
       const newHeight = clamp01(dragState.startHeight + relDy, maxH);
-      updateOperation(selectedIndex, {
+      updateOperationById(selectedId, {
         ...op,
         width: newWidth,
         height: newHeight,
@@ -123,7 +126,7 @@ export const RegionOverlay = ({
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("mouseup", handleMouseUp);
     };
-  }, [dragState, selectedIndex, operations, updateOperation]);
+  }, [dragState, selectedId, operations, updateOperationById]);
 
   if (!canvasRect) return null;
   if (!interactive) return null;
@@ -137,7 +140,8 @@ export const RegionOverlay = ({
         if (spatialOp.type === "crop") return null;
         if (typeof spatialOp.x !== "number" || typeof spatialOp.y !== "number") return null;
 
-        const isSelected = index === selectedIndex;
+        const opId = (op as { id?: string }).id;
+        const isSelected = opId != null && opId === selectedId;
 
         if (isCaptionOperation(op)) {
           const caption = op;

--- a/@fanslib/apps/web/src/features/editor/utils/caption-layout.vitest.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/caption-layout.vitest.ts
@@ -15,6 +15,7 @@ import {
 describe("caption-layout", () => {
   const base: CaptionOperation = {
     type: "caption",
+    id: "test-caption-1",
     text: "Hi",
     x: 0.5,
     y: 0.5,

--- a/@fanslib/apps/web/src/stores/editorStore.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.ts
@@ -4,8 +4,10 @@ import { type CropOperation, normalizeCropOperation } from "~/features/editor/ut
 type EditorState = {
   operations: unknown[];
   selectedOperationIndex: number | null;
+  selectedOperationId: string | null;
   /** When set, player shows full source and crop overlay for this operation index. */
   cropEditingOperationIndex: number | null;
+  cropEditingOperationId: string | null;
   canUndo: boolean;
   canRedo: boolean;
   isDirty: boolean;
@@ -17,6 +19,13 @@ type EditorState = {
   removeOperation: (index: number) => void;
   updateOperation: (index: number, op: unknown) => void;
   reorderOperations: (fromIndex: number, toIndex: number) => void;
+
+  // ID-based mutation actions
+  removeOperationById: (id: string) => void;
+  updateOperationById: (id: string, op: unknown) => void;
+  addKeyframeById: (opId: string, keyframe: unknown) => void;
+  removeKeyframeById: (opId: string, keyframeIndex: number) => void;
+  updateKeyframeById: (opId: string, keyframeIndex: number, keyframe: unknown) => void;
 
   // Undo/redo
   undo: () => void;
@@ -31,6 +40,7 @@ type EditorState = {
   addCrop: () => void;
   applyCrop: (index: number) => void;
   setCropEditingOperationIndex: (index: number | null) => void;
+  setCropEditingOperationId: (id: string | null) => void;
 
   // Caption convenience
   addCaption: () => void;
@@ -49,6 +59,7 @@ type EditorState = {
 
   // Selection
   setSelectedOperationIndex: (index: number | null) => void;
+  setSelectedOperationId: (id: string | null) => void;
 
   // Watermark convenience
   addWatermark: (assetId: string) => void;
@@ -87,7 +98,9 @@ export const useEditorStore = create<EditorState>((set, get) => {
   return {
     operations: [],
     selectedOperationIndex: null,
+    selectedOperationId: null,
     cropEditingOperationIndex: null,
+    cropEditingOperationId: null,
     canUndo: false,
     isDirty: false,
     sourceMediaId: null,
@@ -96,8 +109,9 @@ export const useEditorStore = create<EditorState>((set, get) => {
 
     addOperation: (op) => {
       pushHistory();
+      const stamped = { ...(op as object), id: crypto.randomUUID() };
       set((state) => ({
-        operations: [...state.operations, op],
+        operations: [...state.operations, stamped],
         ...updateUndoRedoFlags(),
       }));
     },
@@ -136,6 +150,74 @@ export const useEditorStore = create<EditorState>((set, get) => {
       });
     },
 
+    removeOperationById: (id) => {
+      pushHistory();
+      set((state) => {
+        const nextSelId = state.selectedOperationId === id ? null : state.selectedOperationId;
+        const nextCeId = state.cropEditingOperationId === id ? null : state.cropEditingOperationId;
+        return {
+          operations: state.operations.filter((op) => (op as { id?: string }).id !== id),
+          selectedOperationId: nextSelId,
+          cropEditingOperationId: nextCeId,
+          ...updateUndoRedoFlags(),
+        };
+      });
+    },
+
+    updateOperationById: (id, patch) => {
+      pushHistory();
+      set((state) => ({
+        operations: state.operations.map((op) =>
+          (op as { id?: string }).id === id ? { ...(patch as object), id } : op,
+        ),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    addKeyframeById: (opId, keyframe) => {
+      pushHistory();
+      set((state) => ({
+        operations: state.operations.map((op) => {
+          if ((op as { id?: string }).id !== opId) return op;
+          const opObj = op as { keyframes?: unknown[] };
+          return { ...opObj, keyframes: [...(opObj.keyframes ?? []), keyframe] };
+        }),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    removeKeyframeById: (opId, keyframeIndex) => {
+      pushHistory();
+      set((state) => ({
+        operations: state.operations.map((op) => {
+          if ((op as { id?: string }).id !== opId) return op;
+          const opObj = op as { keyframes?: unknown[] };
+          return {
+            ...opObj,
+            keyframes: (opObj.keyframes ?? []).filter((_, ki) => ki !== keyframeIndex),
+          };
+        }),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    updateKeyframeById: (opId, keyframeIndex, keyframe) => {
+      pushHistory();
+      set((state) => ({
+        operations: state.operations.map((op) => {
+          if ((op as { id?: string }).id !== opId) return op;
+          const opObj = op as { keyframes?: unknown[] };
+          return {
+            ...opObj,
+            keyframes: (opObj.keyframes ?? []).map((kf, ki) =>
+              ki === keyframeIndex ? keyframe : kf,
+            ),
+          };
+        }),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
     undo: () => {
       const previous = undoStack.pop();
       if (previous === undefined) return;
@@ -146,6 +228,7 @@ export const useEditorStore = create<EditorState>((set, get) => {
         canUndo: undoStack.length > 0,
         canRedo: true,
         cropEditingOperationIndex: null,
+        cropEditingOperationId: null,
       });
     },
 
@@ -159,12 +242,15 @@ export const useEditorStore = create<EditorState>((set, get) => {
         canUndo: true,
         canRedo: redoStack.length > 0,
         cropEditingOperationIndex: null,
+        cropEditingOperationId: null,
       });
     },
 
     addCrop: () => {
-      const op: CropOperation = {
+      const id = crypto.randomUUID();
+      const op: CropOperation & { id: string } = {
         type: "crop",
+        id,
         x: 0.05,
         y: 0.05,
         width: 0.9,
@@ -176,7 +262,9 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set((state) => ({
         operations: [...state.operations, op],
         selectedOperationIndex: state.operations.length,
+        selectedOperationId: id,
         cropEditingOperationIndex: state.operations.length,
+        cropEditingOperationId: id,
         ...updateUndoRedoFlags(),
       }));
     },
@@ -190,6 +278,7 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set({
         operations: state.operations.map((o, i) => (i === index ? { ...c, applied: true } : o)),
         cropEditingOperationIndex: null,
+        cropEditingOperationId: null,
         ...updateUndoRedoFlags(),
       });
     },
@@ -201,9 +290,18 @@ export const useEditorStore = create<EditorState>((set, get) => {
       });
     },
 
+    setCropEditingOperationId: (id) => {
+      set({
+        cropEditingOperationId: id,
+        selectedOperationId: id,
+      });
+    },
+
     addCaption: () => {
+      const id = crypto.randomUUID();
       const op = {
         type: "caption" as const,
+        id,
         text: "Caption",
         x: 0.5,
         y: 0.8,
@@ -217,13 +315,16 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set((state) => ({
         operations: [...state.operations, op],
         selectedOperationIndex: state.operations.length,
+        selectedOperationId: id,
         ...updateUndoRedoFlags(),
       }));
     },
 
     addWatermark: (assetId) => {
+      const id = crypto.randomUUID();
       const op = {
         type: "watermark" as const,
+        id,
         assetId,
         x: 0.5,
         y: 0.5,
@@ -234,13 +335,16 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set((state) => ({
         operations: [...state.operations, op],
         selectedOperationIndex: state.operations.length,
+        selectedOperationId: id,
         ...updateUndoRedoFlags(),
       }));
     },
 
     addBlur: () => {
+      const id = crypto.randomUUID();
       const op = {
         type: "blur" as const,
+        id,
         x: 0.4,
         y: 0.4,
         width: 0.15,
@@ -252,13 +356,16 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set((state) => ({
         operations: [...state.operations, op],
         selectedOperationIndex: state.operations.length,
+        selectedOperationId: id,
         ...updateUndoRedoFlags(),
       }));
     },
 
     addEmoji: (emoji = "⭐") => {
+      const id = crypto.randomUUID();
       const op = {
         type: "emoji" as const,
+        id,
         emoji,
         x: 0.5,
         y: 0.5,
@@ -269,13 +376,16 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set((state) => ({
         operations: [...state.operations, op],
         selectedOperationIndex: state.operations.length,
+        selectedOperationId: id,
         ...updateUndoRedoFlags(),
       }));
     },
 
     addPixelate: () => {
+      const id = crypto.randomUUID();
       const op = {
         type: "pixelate" as const,
+        id,
         x: 0.4,
         y: 0.4,
         width: 0.15,
@@ -287,13 +397,16 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set((state) => ({
         operations: [...state.operations, op],
         selectedOperationIndex: state.operations.length,
+        selectedOperationId: id,
         ...updateUndoRedoFlags(),
       }));
     },
 
     addZoom: () => {
+      const id = crypto.randomUUID();
       const op = {
         type: "zoom" as const,
+        id,
         scale: 1.0,
         centerX: 0.5,
         centerY: 0.5,
@@ -303,6 +416,7 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set((state) => ({
         operations: [...state.operations, op],
         selectedOperationIndex: state.operations.length,
+        selectedOperationId: id,
         ...updateUndoRedoFlags(),
       }));
     },
@@ -355,6 +469,10 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set({ selectedOperationIndex: index });
     },
 
+    setSelectedOperationId: (id) => {
+      set({ selectedOperationId: id });
+    },
+
     setSourceMediaId: (id) => {
       set({ sourceMediaId: id });
     },
@@ -370,10 +488,25 @@ export const useEditorStore = create<EditorState>((set, get) => {
     hydrate: (operations) => {
       undoStack = [];
       redoStack = [];
+      const hydratedOps = operations.map((op) => {
+        const normalized = normalizeCropOperation(op);
+        const obj = normalized as Record<string, unknown>;
+        // Assign id if missing
+        if (!obj.id) {
+          obj.id = crypto.randomUUID();
+        }
+        // Assign default startFrame if missing (skip clip/caption which already have it)
+        if (obj.startFrame === undefined && obj.type !== "clip") {
+          obj.startFrame = 0;
+        }
+        return normalized;
+      });
       set({
-        operations: operations.map((op) => normalizeCropOperation(op)),
+        operations: hydratedOps,
         selectedOperationIndex: null,
+        selectedOperationId: null,
         cropEditingOperationIndex: null,
+        cropEditingOperationId: null,
         canUndo: false,
         canRedo: false,
         isDirty: false,
@@ -386,7 +519,9 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set({
         operations: [],
         selectedOperationIndex: null,
+        selectedOperationId: null,
         cropEditingOperationIndex: null,
+        cropEditingOperationId: null,
         canUndo: false,
         canRedo: false,
         isDirty: false,

--- a/@fanslib/apps/web/src/stores/editorStore.vitest.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.vitest.ts
@@ -10,11 +10,21 @@ describe("editorStore", () => {
     expect(useEditorStore.getState().operations).toEqual([]);
   });
 
-  test("addOperation appends an operation", () => {
+  test("addOperation appends an operation and stamps an id", () => {
     const op = { type: "watermark", assetId: "a1", x: 0.5, y: 0.5, width: 0.1, opacity: 1 };
     useEditorStore.getState().addOperation(op);
     expect(useEditorStore.getState().operations).toHaveLength(1);
-    expect(useEditorStore.getState().operations[0]).toEqual(op);
+    const stored = useEditorStore.getState().operations[0] as { type: string; id: string };
+    expect(stored.type).toBe("watermark");
+    expect(typeof stored.id).toBe("string");
+    expect(stored.id.length).toBeGreaterThan(0);
+  });
+
+  test("addOperation generates unique ids for each operation", () => {
+    useEditorStore.getState().addOperation({ type: "blur" });
+    useEditorStore.getState().addOperation({ type: "emoji" });
+    const ops = useEditorStore.getState().operations as Array<{ id: string }>;
+    expect(ops[0].id).not.toBe(ops[1].id);
   });
 
   test("removeOperation removes by index", () => {
@@ -24,28 +34,65 @@ describe("editorStore", () => {
     useEditorStore.getState().addOperation(op2);
     useEditorStore.getState().removeOperation(0);
     expect(useEditorStore.getState().operations).toHaveLength(1);
-    expect(useEditorStore.getState().operations[0]).toEqual(op2);
+    expect(useEditorStore.getState().operations[0]).toMatchObject(op2);
   });
 
   test("updateOperation updates at index", () => {
     const op = { type: "watermark", assetId: "a1", x: 0.5, y: 0.5, width: 0.1, opacity: 1 };
     useEditorStore.getState().addOperation(op);
-    useEditorStore.getState().updateOperation(0, { ...op, opacity: 0.3 });
-    expect(useEditorStore.getState().operations[0]).toEqual({ ...op, opacity: 0.3 });
+    const stored = useEditorStore.getState().operations[0] as { id: string };
+    useEditorStore.getState().updateOperation(0, { ...op, id: stored.id, opacity: 0.3 });
+    expect(useEditorStore.getState().operations[0]).toMatchObject({ ...op, opacity: 0.3 });
+  });
+
+  test("removeOperationById removes by id and clears selection if matched", () => {
+    useEditorStore.getState().addOperation({ type: "blur" });
+    useEditorStore.getState().addOperation({ type: "emoji" });
+    const ops = useEditorStore.getState().operations as Array<{ id: string }>;
+    const blurId = ops[0].id;
+    const emojiId = ops[1].id;
+    useEditorStore.getState().setSelectedOperationId(blurId);
+    useEditorStore.getState().removeOperationById(blurId);
+    expect(useEditorStore.getState().operations).toHaveLength(1);
+    expect((useEditorStore.getState().operations[0] as { id: string }).id).toBe(emojiId);
+    expect(useEditorStore.getState().selectedOperationId).toBeNull();
+  });
+
+  test("removeOperationById preserves selection if different op removed", () => {
+    useEditorStore.getState().addOperation({ type: "blur" });
+    useEditorStore.getState().addOperation({ type: "emoji" });
+    const ops = useEditorStore.getState().operations as Array<{ id: string }>;
+    useEditorStore.getState().setSelectedOperationId(ops[1].id);
+    useEditorStore.getState().removeOperationById(ops[0].id);
+    expect(useEditorStore.getState().selectedOperationId).toBe(ops[1].id);
+  });
+
+  test("updateOperationById updates by id preserving the id", () => {
+    useEditorStore.getState().addOperation({ type: "blur", radius: 20 });
+    const op = useEditorStore.getState().operations[0] as { id: string; radius: number };
+    useEditorStore.getState().updateOperationById(op.id, { type: "blur", radius: 50 });
+    const updated = useEditorStore.getState().operations[0] as { id: string; radius: number };
+    expect(updated.radius).toBe(50);
+    expect(updated.id).toBe(op.id);
+  });
+
+  test("addKeyframeById adds a keyframe to an operation found by id", () => {
+    useEditorStore.getState().addOperation({ type: "blur", keyframes: [] });
+    const op = useEditorStore.getState().operations[0] as { id: string };
+    useEditorStore.getState().addKeyframeById(op.id, { frame: 0, values: { x: 10 } });
+    const updated = useEditorStore.getState().operations[0] as { keyframes: unknown[] };
+    expect(updated.keyframes).toHaveLength(1);
   });
 
   test("reorderOperations moves operation from one index to another", () => {
-    const ops = [
-      { type: "a", id: 1 },
-      { type: "b", id: 2 },
-      { type: "c", id: 3 },
-    ];
-    ops.forEach((op) => useEditorStore.getState().addOperation(op));
+    useEditorStore.getState().addOperation({ type: "a" });
+    useEditorStore.getState().addOperation({ type: "b" });
+    useEditorStore.getState().addOperation({ type: "c" });
     useEditorStore.getState().reorderOperations(0, 2);
-    const result = useEditorStore.getState().operations;
-    expect(result[0]).toEqual({ type: "b", id: 2 });
-    expect(result[1]).toEqual({ type: "c", id: 3 });
-    expect(result[2]).toEqual({ type: "a", id: 1 });
+    const result = useEditorStore.getState().operations as Array<{ type: string }>;
+    expect(result[0].type).toBe("b");
+    expect(result[1].type).toBe("c");
+    expect(result[2].type).toBe("a");
   });
 
   test("undo reverts the last operation", () => {
@@ -65,7 +112,7 @@ describe("editorStore", () => {
 
     useEditorStore.getState().redo();
     expect(useEditorStore.getState().operations).toHaveLength(1);
-    expect(useEditorStore.getState().operations[0]).toEqual(op);
+    expect(useEditorStore.getState().operations[0]).toMatchObject(op);
   });
 
   test("new mutation after undo clears the redo stack", () => {
@@ -78,7 +125,7 @@ describe("editorStore", () => {
 
     useEditorStore.getState().redo(); // should do nothing — redo stack cleared
     expect(useEditorStore.getState().operations).toHaveLength(2);
-    expect(useEditorStore.getState().operations[1]).toEqual({ type: "c" });
+    expect(useEditorStore.getState().operations[1]).toMatchObject({ type: "c" });
   });
 
   test("undo on empty history does nothing", () => {
@@ -104,19 +151,45 @@ describe("editorStore", () => {
     expect(useEditorStore.getState().canRedo).toBe(true);
   });
 
-  test("setSelectedOperationIndex tracks selection", () => {
+  test("setSelectedOperationId tracks selection by ID", () => {
     useEditorStore.getState().addOperation({ type: "a" });
-    useEditorStore.getState().setSelectedOperationIndex(0);
-    expect(useEditorStore.getState().selectedOperationIndex).toBe(0);
+    const op = useEditorStore.getState().operations[0] as { id: string };
+    useEditorStore.getState().setSelectedOperationId(op.id);
+    expect(useEditorStore.getState().selectedOperationId).toBe(op.id);
   });
 
-  test("addWatermark adds a watermark operation with default values and selects it", () => {
+  test("setCropEditingOperationId sets both crop editing and selection by ID", () => {
+    useEditorStore.getState().addOperation({ type: "crop" });
+    const op = useEditorStore.getState().operations[0] as { id: string };
+    useEditorStore.getState().setCropEditingOperationId(op.id);
+    expect(useEditorStore.getState().cropEditingOperationId).toBe(op.id);
+    expect(useEditorStore.getState().selectedOperationId).toBe(op.id);
+  });
+
+  test("setCropEditingOperationId(null) clears crop editing", () => {
+    useEditorStore.getState().addOperation({ type: "crop" });
+    const op = useEditorStore.getState().operations[0] as { id: string };
+    useEditorStore.getState().setCropEditingOperationId(op.id);
+    useEditorStore.getState().setCropEditingOperationId(null);
+    expect(useEditorStore.getState().cropEditingOperationId).toBeNull();
+  });
+
+  test("setSelectedOperationId(null) clears selection", () => {
+    useEditorStore.getState().addOperation({ type: "a" });
+    const op = useEditorStore.getState().operations[0] as { id: string };
+    useEditorStore.getState().setSelectedOperationId(op.id);
+    useEditorStore.getState().setSelectedOperationId(null);
+    expect(useEditorStore.getState().selectedOperationId).toBeNull();
+  });
+
+  test("addWatermark adds a watermark operation with default values and selects it by ID", () => {
     useEditorStore.getState().addWatermark("asset-123");
 
     const ops = useEditorStore.getState().operations;
     expect(ops).toHaveLength(1);
     const op = ops[0] as {
       type: string;
+      id: string;
       assetId: string;
       x: number;
       y: number;
@@ -129,7 +202,8 @@ describe("editorStore", () => {
     expect(op.y).toBe(0.5);
     expect(op.width).toBe(0.1);
     expect(op.opacity).toBe(0.7);
-    expect(useEditorStore.getState().selectedOperationIndex).toBe(0);
+    expect(typeof op.id).toBe("string");
+    expect(useEditorStore.getState().selectedOperationId).toBe(op.id);
   });
 
   test("addWatermark is undoable", () => {
@@ -142,11 +216,46 @@ describe("editorStore", () => {
   });
 
   test("hydrate loads operations from existing data", () => {
-    const ops = [{ type: "a" }, { type: "b" }];
+    const ops = [{ type: "blur" }, { type: "emoji" }];
     useEditorStore.getState().hydrate(ops);
-    expect(useEditorStore.getState().operations).toEqual(ops);
+    expect(useEditorStore.getState().operations).toHaveLength(2);
     // History should be clean after hydration
     expect(useEditorStore.getState().canUndo).toBe(false);
+  });
+
+  test("hydrate assigns ids to legacy operations that lack them", () => {
+    const legacyOps = [
+      { type: "blur", x: 0.4, y: 0.4, width: 0.15, height: 0.15, radius: 20, keyframes: [] },
+      { type: "watermark", assetId: "a1", x: 0.5, y: 0.5, width: 0.1, opacity: 0.7 },
+    ];
+    useEditorStore.getState().hydrate(legacyOps);
+    const ops = useEditorStore.getState().operations as Array<{ id: string; type: string }>;
+    expect(typeof ops[0].id).toBe("string");
+    expect(ops[0].id.length).toBeGreaterThan(0);
+    expect(typeof ops[1].id).toBe("string");
+    expect(ops[0].id).not.toBe(ops[1].id);
+  });
+
+  test("hydrate preserves existing ids", () => {
+    const existingId = "pre-existing-id-123";
+    const ops = [{ type: "blur", id: existingId, keyframes: [] }];
+    useEditorStore.getState().hydrate(ops);
+    const stored = useEditorStore.getState().operations[0] as { id: string };
+    expect(stored.id).toBe(existingId);
+  });
+
+  test("hydrate assigns default time ranges to operations that lack them", () => {
+    const legacyOps = [
+      { type: "blur", x: 0.4, y: 0.4, width: 0.15, height: 0.15, radius: 20, keyframes: [] },
+      { type: "caption", text: "hello", x: 0.5, y: 0.8, fontSize: 0.05, color: "#fff", animation: "fade-in", startFrame: 10, endFrame: 50 },
+    ];
+    useEditorStore.getState().hydrate(legacyOps);
+    const ops = useEditorStore.getState().operations as Array<{ startFrame?: number; endFrame?: number }>;
+    // blur had no time range — should get defaults (0, undefined)
+    expect(ops[0].startFrame).toBe(0);
+    // caption already had time range — should be preserved
+    expect(ops[1].startFrame).toBe(10);
+    expect(ops[1].endFrame).toBe(50);
   });
 
   test("setEditId and setSourceMediaId track metadata", () => {
@@ -218,13 +327,14 @@ describe("editorStore", () => {
   });
 
   describe("crop operations", () => {
-    test("addCrop adds a crop operation with draft rect and enters crop edit mode", () => {
+    test("addCrop adds a crop operation with draft rect and enters crop edit mode by ID", () => {
       useEditorStore.getState().addCrop();
 
       const ops = useEditorStore.getState().operations;
       expect(ops).toHaveLength(1);
       const op = ops[0] as {
         type: string;
+        id: string;
         x: number;
         y: number;
         width: number;
@@ -235,8 +345,9 @@ describe("editorStore", () => {
       expect(op.applied).toBe(false);
       expect(op.width).toBe(0.9);
       expect(op.height).toBe(0.9);
-      expect(useEditorStore.getState().selectedOperationIndex).toBe(0);
-      expect(useEditorStore.getState().cropEditingOperationIndex).toBe(0);
+      expect(typeof op.id).toBe("string");
+      expect(useEditorStore.getState().selectedOperationId).toBe(op.id);
+      expect(useEditorStore.getState().cropEditingOperationId).toBe(op.id);
     });
 
     test("addCrop is undoable", () => {
@@ -272,7 +383,8 @@ describe("editorStore", () => {
       expect(op.animation).toBe("fade-in");
       expect(op.startFrame).toBe(0);
       expect(op.endFrame).toBe(90);
-      expect(useEditorStore.getState().selectedOperationIndex).toBe(0);
+      const opWithId = ops[0] as { id: string };
+      expect(useEditorStore.getState().selectedOperationId).toBe(opWithId.id);
     });
 
     test("addCaption is undoable", () => {
@@ -304,7 +416,7 @@ describe("editorStore", () => {
       expect(op.height).toBe(0.15);
       expect(op.radius).toBe(20);
       expect(op.keyframes).toEqual([]);
-      expect(useEditorStore.getState().selectedOperationIndex).toBe(0);
+      expect(useEditorStore.getState().selectedOperationId).toBe((useEditorStore.getState().operations[0] as { id: string }).id);
     });
 
     test("addBlur is undoable", () => {
@@ -335,7 +447,7 @@ describe("editorStore", () => {
       expect(op.y).toBe(0.5);
       expect(op.size).toBe(0.08);
       expect(op.keyframes).toEqual([]);
-      expect(useEditorStore.getState().selectedOperationIndex).toBe(0);
+      expect(useEditorStore.getState().selectedOperationId).toBe((useEditorStore.getState().operations[0] as { id: string }).id);
     });
 
     test("addEmoji is undoable", () => {
@@ -367,7 +479,7 @@ describe("editorStore", () => {
       expect(op.height).toBe(0.15);
       expect(op.pixelSize).toBe(10);
       expect(op.keyframes).toEqual([]);
-      expect(useEditorStore.getState().selectedOperationIndex).toBe(0);
+      expect(useEditorStore.getState().selectedOperationId).toBe((useEditorStore.getState().operations[0] as { id: string }).id);
     });
 
     test("addPixelate is undoable", () => {
@@ -396,7 +508,7 @@ describe("editorStore", () => {
       expect(op.centerX).toBe(0.5);
       expect(op.centerY).toBe(0.5);
       expect(op.keyframes).toEqual([]);
-      expect(useEditorStore.getState().selectedOperationIndex).toBe(0);
+      expect(useEditorStore.getState().selectedOperationId).toBe((useEditorStore.getState().operations[0] as { id: string }).id);
     });
 
     test("addZoom is undoable", () => {

--- a/@fanslib/libraries/video/src/Root.tsx
+++ b/@fanslib/libraries/video/src/Root.tsx
@@ -13,6 +13,7 @@ export const RemotionRoot: React.FC = () => (
       sourceUrl: "",
       watermark: {
         type: "watermark" as const,
+        id: "default",
         assetId: "",
         x: 0,
         y: 0,

--- a/@fanslib/libraries/video/src/compositions/WatermarkComposition.test.tsx
+++ b/@fanslib/libraries/video/src/compositions/WatermarkComposition.test.tsx
@@ -9,6 +9,7 @@ describe("WatermarkComposition", () => {
         sourceUrl="https://example.com/source.jpg"
         watermark={{
           type: "watermark",
+          id: "test-wm-1",
           assetId: "asset-1",
           x: 0.85,
           y: 0.9,
@@ -29,6 +30,7 @@ describe("WatermarkComposition", () => {
         sourceUrl="https://example.com/source.jpg"
         watermark={{
           type: "watermark",
+          id: "test-wm-2",
           assetId: "asset-1",
           x: 0.5,
           y: 0.25,

--- a/@fanslib/libraries/video/src/types.test.ts
+++ b/@fanslib/libraries/video/src/types.test.ts
@@ -5,6 +5,7 @@ describe("Operation types", () => {
   test("watermark operation has required fields with relative coordinates", () => {
     const op: WatermarkOperation = {
       type: "watermark",
+      id: "test-id-1",
       assetId: "asset-123",
       x: 0.85,
       y: 0.9,
@@ -25,7 +26,7 @@ describe("Operation types", () => {
 
   test("Operation union includes watermark type", () => {
     const ops: Operation[] = [
-      { type: "watermark", assetId: "a1", x: 0.5, y: 0.5, width: 0.2, opacity: 1 },
+      { type: "watermark", id: "test-id-2", assetId: "a1", x: 0.5, y: 0.5, width: 0.2, opacity: 1 },
     ];
 
     expect(ops).toHaveLength(1);

--- a/@fanslib/libraries/video/src/types.ts
+++ b/@fanslib/libraries/video/src/types.ts
@@ -5,15 +5,19 @@ export type RelativeCoordinate = number;
 
 export type WatermarkOperation = {
   type: "watermark";
+  id: string;
   assetId: string;
   x: RelativeCoordinate;
   y: RelativeCoordinate;
   width: RelativeCoordinate;
   opacity: RelativeCoordinate;
+  startFrame?: number;
+  endFrame?: number;
 };
 
 export type ClipOperation = {
   type: "clip";
+  id: string;
   startFrame: number;
   endFrame: number;
 };
@@ -23,18 +27,22 @@ export type CropAspectPreset = "16:9" | "9:16" | "1:1" | "4:5" | "free";
 /** Normalized rect in composition space; optional UI-only fields may be stripped before render. */
 export type CropOperation = {
   type: "crop";
+  id: string;
   x: RelativeCoordinate;
   y: RelativeCoordinate;
   width: RelativeCoordinate;
   height: RelativeCoordinate;
   applied?: boolean;
   aspectPreset?: CropAspectPreset;
+  startFrame?: number;
+  endFrame?: number;
 };
 
 export type CaptionAnimation = "typewriter" | "fade-in" | "scale-in" | "slide-up";
 
 export type CaptionOperation = {
   type: "caption";
+  id: string;
   text: string;
   x: RelativeCoordinate;
   y: RelativeCoordinate;
@@ -50,11 +58,14 @@ export type CaptionOperation = {
 
 export type BlurOperation = {
   type: "blur";
+  id: string;
   x: RelativeCoordinate;
   y: RelativeCoordinate;
   width: RelativeCoordinate;
   height: RelativeCoordinate;
   radius: number;
+  startFrame?: number;
+  endFrame?: number;
   keyframes: Array<{
     frame: number;
     values: Record<string, number>;
@@ -64,11 +75,14 @@ export type BlurOperation = {
 
 export type PixelateOperation = {
   type: "pixelate";
+  id: string;
   x: RelativeCoordinate;
   y: RelativeCoordinate;
   width: RelativeCoordinate;
   height: RelativeCoordinate;
   pixelSize: number;
+  startFrame?: number;
+  endFrame?: number;
   keyframes: Array<{
     frame: number;
     values: Record<string, number>;
@@ -78,10 +92,13 @@ export type PixelateOperation = {
 
 export type EmojiOperation = {
   type: "emoji";
+  id: string;
   emoji: string;
   x: RelativeCoordinate;
   y: RelativeCoordinate;
   size: RelativeCoordinate;
+  startFrame?: number;
+  endFrame?: number;
   keyframes: Array<{
     frame: number;
     values: Record<string, number>;
@@ -91,9 +108,12 @@ export type EmojiOperation = {
 
 export type ZoomOperation = {
   type: "zoom";
+  id: string;
   scale: number;
   centerX: RelativeCoordinate;
   centerY: RelativeCoordinate;
+  startFrame?: number;
+  endFrame?: number;
   keyframes: Array<{
     frame: number;
     values: Record<string, number>;


### PR DESCRIPTION
## Summary
- Shifts editor selection from `selectedOperationIndex: number | null` to `selectedOperationId: string | null`, with all operations receiving a unique `id` via `crypto.randomUUID()`
- Adds `startFrame?` / `endFrame?` fields to all operation types for future timeline support
- Adds ID-based mutation helpers (`removeOperationById`, `updateOperationById`, `addKeyframeById`, etc.) alongside existing index-based ones
- Updates `hydrate()` to assign IDs and default time ranges to legacy saved edits
- Migrates all 8 editor components (EditorCanvas, CropOverlay, RegionOverlay, LayerPanel, PropertiesPanel, KeyframeTimeline, PlaybackBar, EditorLayout) to use ID-based selection

## Test plan
- [x] `editorStore.vitest.ts` extended with 45 tests covering ID generation, ID-based selection, ID-based mutations, hydration of legacy data, and time range defaults
- [x] All 207 web tests pass
- [x] All 373 server tests pass
- [x] All 14 video library tests pass
- [x] `bun run typecheck` passes across all 6 packages
- [x] `bun run lint` passes with 0 errors
- [x] Format check passes on all changed files

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)