### PR TITLE
feat(editor): nested track data model

### DIFF
--- a/@fanslib/apps/server/src/features/media-edits/entity.ts
+++ b/@fanslib/apps/server/src/features/media-edits/entity.ts
@@ -39,6 +39,9 @@ export class MediaEdit {
   @Column({ type: "simple-json", name: "operations" })
   operations!: unknown[];
 
+  @Column({ type: "simple-json", nullable: true, name: "tracks" })
+  tracks: unknown[] | null = null;
+
   @Column({ type: "varchar", default: "draft", name: "status" })
   status: MediaEditStatus = "draft";
 
@@ -61,12 +64,19 @@ export const MediaEditStatusSchema = z.enum([
   "failed",
 ]);
 
+export const TrackSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  operations: z.array(z.unknown()),
+});
+
 export const MediaEditSchema = z.object({
   id: z.string(),
   sourceMediaId: z.string(),
   outputMediaId: z.string().nullable(),
   type: MediaEditTypeSchema,
   operations: z.array(z.unknown()),
+  tracks: z.array(TrackSchema).nullable(),
   status: MediaEditStatusSchema,
   error: z.string().nullable(),
   createdAt: z.coerce.date(),

--- a/@fanslib/apps/server/src/features/media-edits/flatten-tracks.test.ts
+++ b/@fanslib/apps/server/src/features/media-edits/flatten-tracks.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { flattenTracks } from "./flatten-tracks";
+
+describe("flattenTracks", () => {
+  it("flattens operations from tracks when tracks are provided", () => {
+    const tracks = [
+      { id: "t1", name: "Track 1", operations: [{ type: "blur", id: "op1" }] },
+      {
+        id: "t2",
+        name: "Track 2",
+        operations: [
+          { type: "crop", id: "op2" },
+          { type: "watermark", id: "op3" },
+        ],
+      },
+    ];
+    const legacyOps = [{ type: "old", id: "legacy" }];
+
+    const result = flattenTracks(tracks, legacyOps);
+
+    expect(result).toEqual([
+      { type: "blur", id: "op1" },
+      { type: "crop", id: "op2" },
+      { type: "watermark", id: "op3" },
+    ]);
+  });
+
+  it("falls back to operations when tracks is null", () => {
+    const legacyOps = [{ type: "watermark", id: "op1" }];
+
+    const result = flattenTracks(null, legacyOps);
+
+    expect(result).toEqual(legacyOps);
+  });
+
+  it("falls back to operations when tracks is undefined", () => {
+    const legacyOps = [{ type: "blur", id: "op1" }];
+
+    const result = flattenTracks(undefined, legacyOps);
+
+    expect(result).toEqual(legacyOps);
+  });
+
+  it("falls back to operations when tracks is an empty array", () => {
+    const legacyOps = [{ type: "crop", id: "op1" }];
+
+    const result = flattenTracks([], legacyOps);
+
+    expect(result).toEqual(legacyOps);
+  });
+
+  it("falls back to operations when tracks contains non-track objects", () => {
+    const notTracks = [{ foo: "bar" }];
+    const legacyOps = [{ type: "watermark", id: "op1" }];
+
+    const result = flattenTracks(notTracks, legacyOps);
+
+    expect(result).toEqual(legacyOps);
+  });
+
+  it("returns empty array when both tracks and operations are empty", () => {
+    const result = flattenTracks([], []);
+
+    expect(result).toEqual([]);
+  });
+
+  it("handles tracks with empty operations arrays", () => {
+    const tracks = [
+      { id: "t1", name: "Track 1", operations: [] },
+      { id: "t2", name: "Track 2", operations: [{ type: "blur", id: "op1" }] },
+    ];
+
+    const result = flattenTracks(tracks, []);
+
+    expect(result).toEqual([{ type: "blur", id: "op1" }]);
+  });
+});

--- a/@fanslib/apps/server/src/features/media-edits/flatten-tracks.ts
+++ b/@fanslib/apps/server/src/features/media-edits/flatten-tracks.ts
@@ -1,0 +1,38 @@
+/**
+ * Server-side utility to flatten tracks into a flat array of operations.
+ * Handles both the new track format and the legacy flat array format.
+ */
+
+type Track = {
+  id: string;
+  name: string;
+  operations: unknown[];
+};
+
+/**
+ * Given either a tracks array (new format) or a flat operations array (legacy),
+ * returns a flat array of operations suitable for rendering.
+ *
+ * - If `tracks` is a non-empty array of track objects, flatten their operations.
+ * - Otherwise fall back to the `operations` array (legacy format).
+ */
+export const flattenTracks = (
+  tracks: unknown[] | null | undefined,
+  operations: unknown[],
+): unknown[] => {
+  if (Array.isArray(tracks) && tracks.length > 0 && isTrackArray(tracks)) {
+    return tracks.flatMap((t) => t.operations);
+  }
+  return operations;
+};
+
+const isTrackArray = (arr: unknown[]): arr is Track[] =>
+  arr.every(
+    (item) =>
+      typeof item === "object" &&
+      item !== null &&
+      "id" in item &&
+      "name" in item &&
+      "operations" in item &&
+      Array.isArray((item as Track).operations),
+  );

--- a/@fanslib/apps/server/src/features/media-edits/operations/media-edit/create.ts
+++ b/@fanslib/apps/server/src/features/media-edits/operations/media-edit/create.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
 import { db } from "../../../../lib/db";
-import { MediaEdit, MediaEditTypeSchema } from "../../entity";
+import { MediaEdit, MediaEditTypeSchema, TrackSchema } from "../../entity";
+import { flattenTracks } from "../../flatten-tracks";
 
 export const CreateMediaEditRequestBodySchema = z.object({
   sourceMediaId: z.string(),
   type: MediaEditTypeSchema,
   operations: z.array(z.unknown()).default([]),
+  tracks: z.array(TrackSchema).nullable().optional(),
 });
 
 export const createMediaEdit = async (
@@ -14,10 +16,14 @@ export const createMediaEdit = async (
   const database = await db();
   const repo = database.getRepository(MediaEdit);
 
+  const tracks = payload.tracks ?? null;
+  const operations = flattenTracks(tracks, payload.operations);
+
   const mediaEdit = repo.create({
     sourceMediaId: payload.sourceMediaId,
     type: payload.type,
-    operations: payload.operations,
+    operations,
+    tracks,
     status: "draft",
   });
 

--- a/@fanslib/apps/server/src/features/media-edits/operations/media-edit/update.ts
+++ b/@fanslib/apps/server/src/features/media-edits/operations/media-edit/update.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
 import { db } from "../../../../lib/db";
-import { MediaEdit, MediaEditStatusSchema } from "../../entity";
+import { MediaEdit, MediaEditStatusSchema, TrackSchema } from "../../entity";
+import { flattenTracks } from "../../flatten-tracks";
 
 export const UpdateMediaEditRequestBodySchema = z.object({
   operations: z.array(z.unknown()).optional(),
+  tracks: z.array(TrackSchema).nullable().optional(),
   status: MediaEditStatusSchema.optional(),
   outputMediaId: z.string().nullable().optional(),
   error: z.string().nullable().optional(),
@@ -21,7 +23,13 @@ export const updateMediaEdit = async (
     return null;
   }
 
-  if (payload.operations !== undefined) mediaEdit.operations = payload.operations;
+  if (payload.tracks !== undefined) {
+    mediaEdit.tracks = payload.tracks;
+    // When tracks are provided, derive the flat operations from them
+    mediaEdit.operations = flattenTracks(payload.tracks, mediaEdit.operations);
+  } else if (payload.operations !== undefined) {
+    mediaEdit.operations = payload.operations;
+  }
   if (payload.status !== undefined) mediaEdit.status = payload.status;
   if (payload.outputMediaId !== undefined) mediaEdit.outputMediaId = payload.outputMediaId;
   if (payload.error !== undefined) mediaEdit.error = payload.error;

--- a/@fanslib/apps/server/src/features/media-edits/remotion-render.ts
+++ b/@fanslib/apps/server/src/features/media-edits/remotion-render.ts
@@ -3,6 +3,7 @@ import { bundle } from "@remotion/bundler";
 import { renderStill, renderMedia, selectComposition } from "@remotion/renderer";
 import type { RenderFn } from "./render-pipeline";
 import { appdataPath } from "../../lib/env";
+import { flattenTracks } from "./flatten-tracks";
 
 type WatermarkOperation = {
   type: "watermark";
@@ -43,7 +44,7 @@ const getServeUrl = async (): Promise<string> => {
  * Uses the WatermarkComposition from @fanslib/video.
  */
 export const remotionRenderFn: RenderFn = async ({ edit, sourceMedia, outputPath, onProgress }) => {
-  const operations = edit.operations as Operation[];
+  const operations = flattenTracks(edit.tracks, edit.operations) as Operation[];
 
   // Resolve asset URLs for watermark operations
   const watermarkOp = operations.find((op) => op.type === "watermark");

--- a/@fanslib/apps/web/src/features/editor/components/EditorToolbar.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/EditorToolbar.tsx
@@ -38,6 +38,7 @@ export const EditorToolbar = ({ mediaId }: EditorToolbarProps) => {
   const editId = useEditorStore((s) => s.editId);
   const sourceMediaId = useEditorStore((s) => s.sourceMediaId);
   const operations = useEditorStore((s) => s.operations);
+  const tracks = useEditorStore((s) => s.tracks);
   const addWatermark = useEditorStore((s) => s.addWatermark);
   const addBlur = useEditorStore((s) => s.addBlur);
   const addEmoji = useEditorStore((s) => s.addEmoji);
@@ -89,7 +90,7 @@ export const EditorToolbar = ({ mediaId }: EditorToolbarProps) => {
         const res = await fetch(`/api/media-edits/${editId}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ operations }),
+          body: JSON.stringify({ tracks }),
         });
         if (!res.ok) throw new Error("Failed to save edit");
         markClean();
@@ -100,7 +101,7 @@ export const EditorToolbar = ({ mediaId }: EditorToolbarProps) => {
           body: JSON.stringify({
             sourceMediaId: currentSourceMediaId,
             type: "transform",
-            operations,
+            tracks,
           }),
         });
         if (!res.ok) throw new Error("Failed to create edit");
@@ -113,7 +114,7 @@ export const EditorToolbar = ({ mediaId }: EditorToolbarProps) => {
     } finally {
       setSaving(false);
     }
-  }, [editId, sourceMediaId, mediaId, operations, setEditId, markClean]);
+  }, [editId, sourceMediaId, mediaId, tracks, setEditId, markClean]);
 
   const canExport = operations.length > 0 || clipRanges.length > 0;
 

--- a/@fanslib/apps/web/src/stores/editorStore.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.ts
@@ -1,7 +1,14 @@
 import { create } from "zustand";
 import { type CropOperation, normalizeCropOperation } from "~/features/editor/utils/crop-operation";
 
+type Track = {
+  id: string;
+  name: string;
+  operations: unknown[];
+};
+
 type EditorState = {
+  tracks: Track[];
   operations: unknown[];
   selectedOperationIndex: number | null;
   selectedOperationId: string | null;
@@ -64,19 +71,58 @@ type EditorState = {
   // Watermark convenience
   addWatermark: (assetId: string) => void;
 
+  // Track management
+  addTrack: () => void;
+  removeTrack: (trackId: string) => void;
+  renameTrack: (trackId: string, name: string) => void;
+  moveOperation: (opId: string, targetTrackId: string) => void;
+
+  // Derived
+  flattenOperations: () => unknown[];
+
   // Metadata
   setSourceMediaId: (id: string) => void;
   setEditId: (id: string | null) => void;
   markClean: () => void;
 
   // Hydrate from existing MediaEdit
-  hydrate: (operations: unknown[]) => void;
+  hydrate: (data: unknown[] | { tracks: Track[] }) => void;
 
   // Reset
   reset: () => void;
 };
 
-type HistoryEntry = unknown[];
+type HistoryEntry = Track[];
+
+const makeDefaultTrack = (): Track => ({
+  id: crypto.randomUUID(),
+  name: "Track 1",
+  operations: [],
+});
+
+/** Flatten all operations from all tracks into a single ordered array */
+const flattenTracks = (tracks: Track[]): unknown[] =>
+  tracks.flatMap((t) => t.operations);
+
+/**
+ * Map a function over operations across all tracks, returning new tracks.
+ * Useful for keyframe mutations and operation updates by index or id.
+ */
+const mapOperationsAcrossTracks = (
+  tracks: Track[],
+  fn: (op: unknown, flatIndex: number) => unknown,
+): Track[] => {
+  // eslint-disable-next-line functional/no-let
+  let flatIdx = 0;
+  return tracks.map((t) => ({
+    ...t,
+    operations: t.operations.map((op) => {
+      const result = fn(op, flatIdx);
+      flatIdx++;
+      return result;
+    }),
+  }));
+};
 
 export const useEditorStore = create<EditorState>((set, get) => {
   // eslint-disable-next-line functional/no-let
@@ -84,8 +130,11 @@ export const useEditorStore = create<EditorState>((set, get) => {
   // eslint-disable-next-line functional/no-let
   let redoStack: HistoryEntry[] = [];
 
+  const cloneTracks = (tracks: Track[]): Track[] =>
+    tracks.map((t) => ({ ...t, operations: [...t.operations] }));
+
   const pushHistory = () => {
-    undoStack.push([...get().operations]);
+    undoStack.push(cloneTracks(get().tracks));
     redoStack = []; // Clear redo on new mutation
   };
 
@@ -95,7 +144,10 @@ export const useEditorStore = create<EditorState>((set, get) => {
     isDirty: true,
   });
 
+  const initialTrack = makeDefaultTrack();
+
   return {
+    tracks: [initialTrack],
     operations: [],
     selectedOperationIndex: null,
     selectedOperationId: null,
@@ -110,10 +162,15 @@ export const useEditorStore = create<EditorState>((set, get) => {
     addOperation: (op) => {
       pushHistory();
       const stamped = { ...(op as object), id: crypto.randomUUID() };
-      set((state) => ({
-        operations: [...state.operations, stamped],
-        ...updateUndoRedoFlags(),
-      }));
+      set((state) => {
+        const tracks = cloneTracks(state.tracks);
+        tracks[0].operations.push(stamped);
+        return {
+          tracks,
+          operations: flattenTracks(tracks),
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     removeOperation: (index) => {
@@ -123,8 +180,23 @@ export const useEditorStore = create<EditorState>((set, get) => {
         const nextSel = sel === null ? null : sel === index ? null : sel > index ? sel - 1 : sel;
         const ce = state.cropEditingOperationIndex;
         const nextCe = ce === null ? null : ce === index ? null : ce > index ? ce - 1 : ce;
+        // Remove by flat index: find which track owns the index and splice it
+        const tracks = state.tracks.reduce<{ result: Track[]; offset: number; removed: boolean }>(
+          (acc, t) => {
+            if (!acc.removed && index < acc.offset + t.operations.length) {
+              acc.result.push({ ...t, operations: t.operations.filter((_, i) => i !== index - acc.offset) });
+              acc.removed = true;
+            } else {
+              acc.result.push({ ...t, operations: [...t.operations] });
+            }
+            acc.offset += t.operations.length;
+            return acc;
+          },
+          { result: [], offset: 0, removed: false },
+        ).result;
         return {
-          operations: state.operations.filter((_, i) => i !== index),
+          tracks,
+          operations: flattenTracks(tracks),
           selectedOperationIndex: nextSel,
           cropEditingOperationIndex: nextCe,
           ...updateUndoRedoFlags(),
@@ -134,19 +206,35 @@ export const useEditorStore = create<EditorState>((set, get) => {
 
     updateOperation: (index, op) => {
       pushHistory();
-      set((state) => ({
-        operations: state.operations.map((existing, i) => (i === index ? op : existing)),
-        ...updateUndoRedoFlags(),
-      }));
+      set((state) => {
+        const tracks = mapOperationsAcrossTracks(state.tracks, (existing, flatIdx) =>
+          flatIdx === index ? op : existing,
+        );
+        return {
+          tracks,
+          operations: flattenTracks(tracks),
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     reorderOperations: (fromIndex, toIndex) => {
       pushHistory();
       set((state) => {
-        const ops = [...state.operations];
-        const [moved] = ops.splice(fromIndex, 1);
-        ops.splice(toIndex, 0, moved);
-        return { operations: ops, ...updateUndoRedoFlags() };
+        const ops = flattenTracks(state.tracks);
+        const flat = [...ops];
+        const [moved] = flat.splice(fromIndex, 1);
+        flat.splice(toIndex, 0, moved);
+        // Redistribute reordered ops back into tracks preserving per-track counts
+        const tracks = state.tracks.reduce<{ result: Track[]; offset: number }>(
+          (acc, t) => {
+            acc.result.push({ ...t, operations: flat.slice(acc.offset, acc.offset + t.operations.length) });
+            acc.offset += t.operations.length;
+            return acc;
+          },
+          { result: [], offset: 0 },
+        ).result;
+        return { tracks, operations: flat, ...updateUndoRedoFlags() };
       });
     },
 
@@ -155,8 +243,13 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set((state) => {
         const nextSelId = state.selectedOperationId === id ? null : state.selectedOperationId;
         const nextCeId = state.cropEditingOperationId === id ? null : state.cropEditingOperationId;
+        const tracks = state.tracks.map((t) => ({
+          ...t,
+          operations: t.operations.filter((op) => (op as { id?: string }).id !== id),
+        }));
         return {
-          operations: state.operations.filter((op) => (op as { id?: string }).id !== id),
+          tracks,
+          operations: flattenTracks(tracks),
           selectedOperationId: nextSelId,
           cropEditingOperationId: nextCeId,
           ...updateUndoRedoFlags(),
@@ -166,65 +259,93 @@ export const useEditorStore = create<EditorState>((set, get) => {
 
     updateOperationById: (id, patch) => {
       pushHistory();
-      set((state) => ({
-        operations: state.operations.map((op) =>
-          (op as { id?: string }).id === id ? { ...(patch as object), id } : op,
-        ),
-        ...updateUndoRedoFlags(),
-      }));
+      set((state) => {
+        const tracks = state.tracks.map((t) => ({
+          ...t,
+          operations: t.operations.map((op) =>
+            (op as { id?: string }).id === id ? { ...(patch as object), id } : op,
+          ),
+        }));
+        return {
+          tracks,
+          operations: flattenTracks(tracks),
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     addKeyframeById: (opId, keyframe) => {
       pushHistory();
-      set((state) => ({
-        operations: state.operations.map((op) => {
-          if ((op as { id?: string }).id !== opId) return op;
-          const opObj = op as { keyframes?: unknown[] };
-          return { ...opObj, keyframes: [...(opObj.keyframes ?? []), keyframe] };
-        }),
-        ...updateUndoRedoFlags(),
-      }));
+      set((state) => {
+        const tracks = state.tracks.map((t) => ({
+          ...t,
+          operations: t.operations.map((op) => {
+            if ((op as { id?: string }).id !== opId) return op;
+            const opObj = op as { keyframes?: unknown[] };
+            return { ...opObj, keyframes: [...(opObj.keyframes ?? []), keyframe] };
+          }),
+        }));
+        return {
+          tracks,
+          operations: flattenTracks(tracks),
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     removeKeyframeById: (opId, keyframeIndex) => {
       pushHistory();
-      set((state) => ({
-        operations: state.operations.map((op) => {
-          if ((op as { id?: string }).id !== opId) return op;
-          const opObj = op as { keyframes?: unknown[] };
-          return {
-            ...opObj,
-            keyframes: (opObj.keyframes ?? []).filter((_, ki) => ki !== keyframeIndex),
-          };
-        }),
-        ...updateUndoRedoFlags(),
-      }));
+      set((state) => {
+        const tracks = state.tracks.map((t) => ({
+          ...t,
+          operations: t.operations.map((op) => {
+            if ((op as { id?: string }).id !== opId) return op;
+            const opObj = op as { keyframes?: unknown[] };
+            return {
+              ...opObj,
+              keyframes: (opObj.keyframes ?? []).filter((_, ki) => ki !== keyframeIndex),
+            };
+          }),
+        }));
+        return {
+          tracks,
+          operations: flattenTracks(tracks),
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     updateKeyframeById: (opId, keyframeIndex, keyframe) => {
       pushHistory();
-      set((state) => ({
-        operations: state.operations.map((op) => {
-          if ((op as { id?: string }).id !== opId) return op;
-          const opObj = op as { keyframes?: unknown[] };
-          return {
-            ...opObj,
-            keyframes: (opObj.keyframes ?? []).map((kf, ki) =>
-              ki === keyframeIndex ? keyframe : kf,
-            ),
-          };
-        }),
-        ...updateUndoRedoFlags(),
-      }));
+      set((state) => {
+        const tracks = state.tracks.map((t) => ({
+          ...t,
+          operations: t.operations.map((op) => {
+            if ((op as { id?: string }).id !== opId) return op;
+            const opObj = op as { keyframes?: unknown[] };
+            return {
+              ...opObj,
+              keyframes: (opObj.keyframes ?? []).map((kf, ki) =>
+                ki === keyframeIndex ? keyframe : kf,
+              ),
+            };
+          }),
+        }));
+        return {
+          tracks,
+          operations: flattenTracks(tracks),
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     undo: () => {
       const previous = undoStack.pop();
       if (previous === undefined) return;
-      const current = [...get().operations];
-      redoStack.push(current);
+      redoStack.push(cloneTracks(get().tracks));
       set({
-        operations: previous,
+        tracks: previous,
+        operations: flattenTracks(previous),
         canUndo: undoStack.length > 0,
         canRedo: true,
         cropEditingOperationIndex: null,
@@ -235,10 +356,10 @@ export const useEditorStore = create<EditorState>((set, get) => {
     redo: () => {
       const next = redoStack.pop();
       if (next === undefined) return;
-      const current = [...get().operations];
-      undoStack.push(current);
+      undoStack.push(cloneTracks(get().tracks));
       set({
-        operations: next,
+        tracks: next,
+        operations: flattenTracks(next),
         canUndo: true,
         canRedo: redoStack.length > 0,
         cropEditingOperationIndex: null,
@@ -259,27 +380,39 @@ export const useEditorStore = create<EditorState>((set, get) => {
         aspectPreset: "free",
       };
       pushHistory();
-      set((state) => ({
-        operations: [...state.operations, op],
-        selectedOperationIndex: state.operations.length,
-        selectedOperationId: id,
-        cropEditingOperationIndex: state.operations.length,
-        cropEditingOperationId: id,
-        ...updateUndoRedoFlags(),
-      }));
+      set((state) => {
+        const tracks = cloneTracks(state.tracks);
+        tracks[0].operations.push(op);
+        return {
+          tracks,
+          operations: flattenTracks(tracks),
+          selectedOperationIndex: flattenTracks(tracks).length - 1,
+          selectedOperationId: id,
+          cropEditingOperationIndex: flattenTracks(tracks).length - 1,
+          cropEditingOperationId: id,
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     applyCrop: (index) => {
       const state = get();
-      const raw = state.operations[index];
+      const ops = flattenTracks(state.tracks);
+      const raw = ops[index];
       if (!raw || (raw as { type?: string }).type !== "crop") return;
       const c = raw as CropOperation;
       pushHistory();
-      set({
-        operations: state.operations.map((o, i) => (i === index ? { ...c, applied: true } : o)),
-        cropEditingOperationIndex: null,
-        cropEditingOperationId: null,
-        ...updateUndoRedoFlags(),
+      set((prev) => {
+        const tracks = mapOperationsAcrossTracks(prev.tracks, (o, flatIdx) =>
+          flatIdx === index ? { ...c, applied: true } : o,
+        );
+        return {
+          tracks,
+          operations: flattenTracks(tracks),
+          cropEditingOperationIndex: null,
+          cropEditingOperationId: null,
+          ...updateUndoRedoFlags(),
+        };
       });
     },
 
@@ -312,12 +445,18 @@ export const useEditorStore = create<EditorState>((set, get) => {
         endFrame: 90,
       };
       pushHistory();
-      set((state) => ({
-        operations: [...state.operations, op],
-        selectedOperationIndex: state.operations.length,
-        selectedOperationId: id,
-        ...updateUndoRedoFlags(),
-      }));
+      set((state) => {
+        const tracks = cloneTracks(state.tracks);
+        tracks[0].operations.push(op);
+        const flat = flattenTracks(tracks);
+        return {
+          tracks,
+          operations: flat,
+          selectedOperationIndex: flat.length - 1,
+          selectedOperationId: id,
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     addWatermark: (assetId) => {
@@ -332,12 +471,18 @@ export const useEditorStore = create<EditorState>((set, get) => {
         opacity: 0.7,
       };
       pushHistory();
-      set((state) => ({
-        operations: [...state.operations, op],
-        selectedOperationIndex: state.operations.length,
-        selectedOperationId: id,
-        ...updateUndoRedoFlags(),
-      }));
+      set((state) => {
+        const tracks = cloneTracks(state.tracks);
+        tracks[0].operations.push(op);
+        const flat = flattenTracks(tracks);
+        return {
+          tracks,
+          operations: flat,
+          selectedOperationIndex: flat.length - 1,
+          selectedOperationId: id,
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     addBlur: () => {
@@ -353,12 +498,18 @@ export const useEditorStore = create<EditorState>((set, get) => {
         keyframes: [],
       };
       pushHistory();
-      set((state) => ({
-        operations: [...state.operations, op],
-        selectedOperationIndex: state.operations.length,
-        selectedOperationId: id,
-        ...updateUndoRedoFlags(),
-      }));
+      set((state) => {
+        const tracks = cloneTracks(state.tracks);
+        tracks[0].operations.push(op);
+        const flat = flattenTracks(tracks);
+        return {
+          tracks,
+          operations: flat,
+          selectedOperationIndex: flat.length - 1,
+          selectedOperationId: id,
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     addEmoji: (emoji = "⭐") => {
@@ -373,12 +524,18 @@ export const useEditorStore = create<EditorState>((set, get) => {
         keyframes: [],
       };
       pushHistory();
-      set((state) => ({
-        operations: [...state.operations, op],
-        selectedOperationIndex: state.operations.length,
-        selectedOperationId: id,
-        ...updateUndoRedoFlags(),
-      }));
+      set((state) => {
+        const tracks = cloneTracks(state.tracks);
+        tracks[0].operations.push(op);
+        const flat = flattenTracks(tracks);
+        return {
+          tracks,
+          operations: flat,
+          selectedOperationIndex: flat.length - 1,
+          selectedOperationId: id,
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     addPixelate: () => {
@@ -394,12 +551,18 @@ export const useEditorStore = create<EditorState>((set, get) => {
         keyframes: [],
       };
       pushHistory();
-      set((state) => ({
-        operations: [...state.operations, op],
-        selectedOperationIndex: state.operations.length,
-        selectedOperationId: id,
-        ...updateUndoRedoFlags(),
-      }));
+      set((state) => {
+        const tracks = cloneTracks(state.tracks);
+        tracks[0].operations.push(op);
+        const flat = flattenTracks(tracks);
+        return {
+          tracks,
+          operations: flat,
+          selectedOperationIndex: flat.length - 1,
+          selectedOperationId: id,
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     addZoom: () => {
@@ -413,46 +576,60 @@ export const useEditorStore = create<EditorState>((set, get) => {
         keyframes: [],
       };
       pushHistory();
-      set((state) => ({
-        operations: [...state.operations, op],
-        selectedOperationIndex: state.operations.length,
-        selectedOperationId: id,
-        ...updateUndoRedoFlags(),
-      }));
+      set((state) => {
+        const tracks = cloneTracks(state.tracks);
+        tracks[0].operations.push(op);
+        const flat = flattenTracks(tracks);
+        return {
+          tracks,
+          operations: flat,
+          selectedOperationIndex: flat.length - 1,
+          selectedOperationId: id,
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     addKeyframe: (opIndex, keyframe) => {
       pushHistory();
-      set((state) => ({
-        operations: state.operations.map((op, i) => {
-          if (i !== opIndex) return op;
+      set((state) => {
+        const tracks = mapOperationsAcrossTracks(state.tracks, (op, flatIdx) => {
+          if (flatIdx !== opIndex) return op;
           const opObj = op as { keyframes?: unknown[] };
           return { ...opObj, keyframes: [...(opObj.keyframes ?? []), keyframe] };
-        }),
-        ...updateUndoRedoFlags(),
-      }));
+        });
+        return {
+          tracks,
+          operations: flattenTracks(tracks),
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     removeKeyframe: (opIndex, keyframeIndex) => {
       pushHistory();
-      set((state) => ({
-        operations: state.operations.map((op, i) => {
-          if (i !== opIndex) return op;
+      set((state) => {
+        const tracks = mapOperationsAcrossTracks(state.tracks, (op, flatIdx) => {
+          if (flatIdx !== opIndex) return op;
           const opObj = op as { keyframes?: unknown[] };
           return {
             ...opObj,
             keyframes: (opObj.keyframes ?? []).filter((_, ki) => ki !== keyframeIndex),
           };
-        }),
-        ...updateUndoRedoFlags(),
-      }));
+        });
+        return {
+          tracks,
+          operations: flattenTracks(tracks),
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     updateKeyframe: (opIndex, keyframeIndex, keyframe) => {
       pushHistory();
-      set((state) => ({
-        operations: state.operations.map((op, i) => {
-          if (i !== opIndex) return op;
+      set((state) => {
+        const tracks = mapOperationsAcrossTracks(state.tracks, (op, flatIdx) => {
+          if (flatIdx !== opIndex) return op;
           const opObj = op as { keyframes?: unknown[] };
           return {
             ...opObj,
@@ -460,9 +637,13 @@ export const useEditorStore = create<EditorState>((set, get) => {
               ki === keyframeIndex ? keyframe : kf,
             ),
           };
-        }),
-        ...updateUndoRedoFlags(),
-      }));
+        });
+        return {
+          tracks,
+          operations: flattenTracks(tracks),
+          ...updateUndoRedoFlags(),
+        };
+      });
     },
 
     setSelectedOperationIndex: (index) => {
@@ -472,6 +653,55 @@ export const useEditorStore = create<EditorState>((set, get) => {
     setSelectedOperationId: (id) => {
       set({ selectedOperationId: id });
     },
+
+    addTrack: () => {
+      pushHistory();
+      set((state) => {
+        const tracks = cloneTracks(state.tracks);
+        tracks.push({
+          id: crypto.randomUUID(),
+          name: `Track ${tracks.length + 1}`,
+          operations: [],
+        });
+        return { tracks, ...updateUndoRedoFlags() };
+      });
+    },
+
+    removeTrack: (trackId) => {
+      pushHistory();
+      set((state) => {
+        const tracks = state.tracks.filter((t) => t.id !== trackId);
+        return { tracks, operations: flattenTracks(tracks), ...updateUndoRedoFlags() };
+      });
+    },
+
+    renameTrack: (trackId, name) => {
+      pushHistory();
+      set((state) => ({
+        tracks: state.tracks.map((t) => (t.id === trackId ? { ...t, name } : t)),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    moveOperation: (opId, targetTrackId) => {
+      pushHistory();
+      set((state) => {
+        // Find the operation to move
+        const movedOp = flattenTracks(state.tracks).find(
+          (op) => (op as { id?: string }).id === opId,
+        );
+        if (!movedOp) return { ...updateUndoRedoFlags() };
+        // Remove from source, add to target
+        const tracks = state.tracks.map((t) => {
+          const filtered = t.operations.filter((op) => (op as { id?: string }).id !== opId);
+          const ops = t.id === targetTrackId ? [...filtered, movedOp] : filtered;
+          return { ...t, operations: ops };
+        });
+        return { tracks, operations: flattenTracks(tracks), ...updateUndoRedoFlags() };
+      });
+    },
+
+    flattenOperations: () => flattenTracks(get().tracks),
 
     setSourceMediaId: (id) => {
       set({ sourceMediaId: id });
@@ -485,24 +715,28 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set({ isDirty: false });
     },
 
-    hydrate: (operations) => {
+    hydrate: (data) => {
       undoStack = [];
       redoStack = [];
-      const hydratedOps = operations.map((op) => {
-        const normalized = normalizeCropOperation(op);
-        const obj = normalized as Record<string, unknown>;
-        // Assign id if missing
-        if (!obj.id) {
-          obj.id = crypto.randomUUID();
-        }
-        // Assign default startFrame if missing (skip clip/caption which already have it)
-        if (obj.startFrame === undefined && obj.type !== "clip") {
-          obj.startFrame = 0;
-        }
-        return normalized;
-      });
+
+      // Detect format: array = legacy flat operations, object with tracks = new format
+      const tracks: Track[] = Array.isArray(data)
+        ? [{
+            id: crypto.randomUUID(),
+            name: "Track 1",
+            operations: data.map((op) => {
+              const normalized = normalizeCropOperation(op);
+              const obj = normalized as Record<string, unknown>;
+              if (!obj.id) obj.id = crypto.randomUUID();
+              if (obj.startFrame === undefined && obj.type !== "clip") obj.startFrame = 0;
+              return normalized;
+            }),
+          }]
+        : (data as { tracks: Track[] }).tracks;
+
       set({
-        operations: hydratedOps,
+        tracks,
+        operations: flattenTracks(tracks),
         selectedOperationIndex: null,
         selectedOperationId: null,
         cropEditingOperationIndex: null,
@@ -517,6 +751,7 @@ export const useEditorStore = create<EditorState>((set, get) => {
       undoStack = [];
       redoStack = [];
       set({
+        tracks: [makeDefaultTrack()],
         operations: [],
         selectedOperationIndex: null,
         selectedOperationId: null,

--- a/@fanslib/apps/web/src/stores/editorStore.vitest.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.vitest.ts
@@ -490,6 +490,128 @@ describe("editorStore", () => {
     });
   });
 
+  describe("track operations", () => {
+    test("starts with one default track", () => {
+      const tracks = useEditorStore.getState().tracks;
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0].name).toBe("Track 1");
+      expect(typeof tracks[0].id).toBe("string");
+      expect(tracks[0].operations).toEqual([]);
+    });
+
+    test("addTrack adds a new track", () => {
+      useEditorStore.getState().addTrack();
+      const tracks = useEditorStore.getState().tracks;
+      expect(tracks).toHaveLength(2);
+      expect(tracks[1].name).toBe("Track 2");
+    });
+
+    test("removeTrack removes an empty track", () => {
+      useEditorStore.getState().addTrack();
+      const trackId = useEditorStore.getState().tracks[1].id;
+      useEditorStore.getState().removeTrack(trackId);
+      expect(useEditorStore.getState().tracks).toHaveLength(1);
+    });
+
+    test("renameTrack renames a track", () => {
+      const trackId = useEditorStore.getState().tracks[0].id;
+      useEditorStore.getState().renameTrack(trackId, "My Track");
+      expect(useEditorStore.getState().tracks[0].name).toBe("My Track");
+    });
+
+    test("moveOperation moves an operation between tracks", () => {
+      useEditorStore.getState().addBlur();
+      useEditorStore.getState().addTrack();
+      const opId = (useEditorStore.getState().tracks[0].operations[0] as { id: string }).id;
+      const targetTrackId = useEditorStore.getState().tracks[1].id;
+      useEditorStore.getState().moveOperation(opId, targetTrackId);
+      expect(useEditorStore.getState().tracks[0].operations).toHaveLength(0);
+      expect(useEditorStore.getState().tracks[1].operations).toHaveLength(1);
+      expect((useEditorStore.getState().tracks[1].operations[0] as { id: string }).id).toBe(opId);
+    });
+
+    test("moveOperation is undoable", () => {
+      useEditorStore.getState().addBlur();
+      useEditorStore.getState().addTrack();
+      const opId = (useEditorStore.getState().tracks[0].operations[0] as { id: string }).id;
+      const targetTrackId = useEditorStore.getState().tracks[1].id;
+      useEditorStore.getState().moveOperation(opId, targetTrackId);
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().tracks[0].operations).toHaveLength(1);
+      expect(useEditorStore.getState().tracks[1].operations).toHaveLength(0);
+    });
+
+    test("flattenOperations returns all operations across tracks in order", () => {
+      useEditorStore.getState().addBlur();
+      useEditorStore.getState().addTrack();
+      useEditorStore.getState().addCaption();
+      // Caption goes to track[0], move it to track[1]
+      const captionId = (useEditorStore.getState().operations[1] as { id: string }).id;
+      const track2Id = useEditorStore.getState().tracks[1].id;
+      useEditorStore.getState().moveOperation(captionId, track2Id);
+      const flat = useEditorStore.getState().flattenOperations();
+      expect(flat).toHaveLength(2);
+      expect((flat[0] as { type: string }).type).toBe("blur");
+      expect((flat[1] as { type: string }).type).toBe("caption");
+    });
+
+    test("addOperation adds to first track by default", () => {
+      useEditorStore.getState().addTrack();
+      useEditorStore.getState().addOperation({ type: "blur" });
+      expect(useEditorStore.getState().tracks[0].operations).toHaveLength(1);
+      expect(useEditorStore.getState().tracks[1].operations).toHaveLength(0);
+    });
+
+    test("removeOperationById removes across tracks", () => {
+      useEditorStore.getState().addBlur();
+      useEditorStore.getState().addTrack();
+      const opId = (useEditorStore.getState().tracks[0].operations[0] as { id: string }).id;
+      const track2Id = useEditorStore.getState().tracks[1].id;
+      useEditorStore.getState().moveOperation(opId, track2Id);
+      useEditorStore.getState().removeOperationById(opId);
+      expect(useEditorStore.getState().tracks[1].operations).toHaveLength(0);
+      expect(useEditorStore.getState().operations).toHaveLength(0);
+    });
+
+    test("undo/redo restores full track state", () => {
+      useEditorStore.getState().addBlur();
+      useEditorStore.getState().addTrack();
+      expect(useEditorStore.getState().tracks).toHaveLength(2);
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().tracks).toHaveLength(1);
+      useEditorStore.getState().redo();
+      expect(useEditorStore.getState().tracks).toHaveLength(2);
+    });
+
+    test("hydrate with legacy flat array wraps in single track", () => {
+      const legacyOps = [
+        { type: "blur", x: 0.4, y: 0.4, width: 0.15, height: 0.15, radius: 20, keyframes: [] },
+      ];
+      useEditorStore.getState().hydrate(legacyOps);
+      const tracks = useEditorStore.getState().tracks;
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0].name).toBe("Track 1");
+      expect(tracks[0].operations).toHaveLength(1);
+      expect(useEditorStore.getState().operations).toHaveLength(1);
+    });
+
+    test("hydrate with track format loads directly", () => {
+      const trackData = {
+        tracks: [
+          { id: "t1", name: "Video", operations: [{ type: "blur", id: "op1", keyframes: [] }] },
+          { id: "t2", name: "Audio", operations: [] },
+        ],
+      };
+      useEditorStore.getState().hydrate(trackData);
+      const tracks = useEditorStore.getState().tracks;
+      expect(tracks).toHaveLength(2);
+      expect(tracks[0].name).toBe("Video");
+      expect(tracks[0].id).toBe("t1");
+      expect(tracks[1].name).toBe("Audio");
+      expect(useEditorStore.getState().operations).toHaveLength(1);
+    });
+  });
+
   describe("zoom operations", () => {
     test("addZoom adds a zoom operation with default values", () => {
       useEditorStore.getState().addZoom();

--- a/@fanslib/libraries/video/src/types.ts
+++ b/@fanslib/libraries/video/src/types.ts
@@ -123,3 +123,10 @@ export type ZoomOperation = {
 
 /** Union of all supported edit operations */
 export type Operation = WatermarkOperation | ClipOperation | CropOperation | CaptionOperation | BlurOperation | PixelateOperation | EmojiOperation | ZoomOperation;
+
+/** A named track containing an ordered list of operations */
+export type Track = {
+  id: string;
+  name: string;
+  operations: Operation[];
+};


### PR DESCRIPTION
## Summary
- Restructures editor store from flat `operations: unknown[]` to `tracks: Track[]` where each track contains an ordered list of operations
- Adds track management actions: `addTrack`, `removeTrack`, `renameTrack`, `moveOperation(opId, targetTrackId)`
- Adds `flattenOperations()` selector and derived `operations` field for backward compatibility
- Updates `hydrate()` to detect legacy flat-array format vs new track format
- Undo/redo now snapshots the full tracks array
- Server-side: adds `flattenTracks()` utility, `tracks` column on MediaEdit entity, and updated render pipeline
- EditorToolbar now saves tracks structure to the server

## Test plan
- [x] 57 editorStore tests covering track CRUD, moveOperation, flattenOperations, hydration (old + new format), undo/redo with tracks
- [x] 7 server-side flattenTracks tests covering valid tracks, null/empty/invalid fallbacks
- [x] All 214 web tests pass
- [x] All 380 server tests pass (including 7 new)
- [x] All 14 video library tests pass
- [x] `bun run typecheck` passes (6/6 packages)
- [x] `bun run lint` passes (0 errors)

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)