### PR TITLE
feat(editor): read-only NLE timeline with playhead and transport

### DIFF
--- a/@fanslib/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { shouldUseVideoElementForPreview } from "~/lib/editor-media-preview";
 import { useMediaQuery } from "~/lib/queries/library";
 import { useEditorStore } from "~/stores/editorStore";
@@ -7,9 +8,8 @@ import { useMediaEditByIdQuery } from "~/lib/queries/media-edits";
 import { isCaptionOperation } from "~/features/editor/utils/caption-layout";
 import { EditorToolbar } from "./EditorToolbar";
 import { EditorCanvas, type EditorCanvasHandle } from "./EditorCanvas";
-import { LayerPanel } from "./LayerPanel";
 import { PropertiesPanel } from "./PropertiesPanel";
-import { PlaybackBar } from "./PlaybackBar";
+import { Timeline } from "./Timeline";
 
 type EditorLayoutProps = {
   mediaId: string;
@@ -57,11 +57,44 @@ export const EditorLayout = ({ mediaId, editId }: EditorLayoutProps) => {
   const canvasRef = useRef<EditorCanvasHandle>(null);
   const getPlayer = () => canvasRef.current?.getPlayerRef() ?? null;
 
+  const [playing, setPlaying] = useState(false);
+
   const seekToFrame = useCallback((frame: number) => {
     const player = canvasRef.current?.getPlayerRef();
     if (player) player.seekTo(frame);
     setCurrentFrame(frame);
   }, []);
+
+  const handlePlay = useCallback(() => {
+    const player = getPlayer();
+    if (player) player.play();
+    setPlaying(true);
+  }, []);
+
+  const handlePause = useCallback(() => {
+    const player = getPlayer();
+    if (player) player.pause();
+    setPlaying(false);
+  }, []);
+
+  const handleSkipBack = useCallback(() => {
+    seekToFrame(0);
+  }, [seekToFrame]);
+
+  const totalFramesRef = useRef(1);
+
+  const handleSkipForward = useCallback(() => {
+    seekToFrame(Math.max(0, totalFramesRef.current - 1));
+  }, [seekToFrame]);
+
+  const handleCanvasBackgroundClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        setSelectedOperationId(null);
+      }
+    },
+    [setSelectedOperationId],
+  );
 
   useEffect(() => {
     setSourceMediaId(mediaId);
@@ -97,8 +130,10 @@ export const EditorLayout = ({ mediaId, editId }: EditorLayoutProps) => {
         if (!player) return;
         if (player.isPlaying()) {
           player.pause();
+          setPlaying(false);
         } else {
           player.play();
+          setPlaying(true);
         }
       }
     };
@@ -199,35 +234,43 @@ export const EditorLayout = ({ mediaId, editId }: EditorLayoutProps) => {
     relativePath: media.relativePath,
   });
   const totalFrames = isVideo ? Math.max(1, Math.round((media.duration ?? 30) * 30)) : 1;
+  totalFramesRef.current = totalFrames;
 
   return (
     <div className="flex flex-col h-screen">
       <EditorToolbar mediaId={mediaId} />
-      <div className="flex flex-1 overflow-hidden">
-        <LayerPanel onSeekFrame={seekToFrame} />
-        <div className="flex-1 flex flex-col overflow-hidden">
-          <EditorCanvas
-            ref={canvasRef}
-            mediaId={mediaId}
-            mediaType={media.type}
-            relativePath={media.relativePath}
-            operations={operations}
-            totalFrames={totalFrames}
+      <PanelGroup direction="vertical">
+        <Panel defaultSize={70} minSize={30}>
+          <div className="flex flex-1 h-full overflow-hidden" onClick={handleCanvasBackgroundClick}>
+            <EditorCanvas
+              ref={canvasRef}
+              mediaId={mediaId}
+              mediaType={media.type}
+              relativePath={media.relativePath}
+              operations={operations}
+              totalFrames={totalFrames}
+              currentFrame={currentFrame}
+              onPlayerFrameChange={setCurrentFrame}
+              transformEditingLocked={clipRanges.length > 0 || clipMode}
+            />
+            <PropertiesPanel />
+          </div>
+        </Panel>
+        <PanelResizeHandle className="h-1.5 bg-base-300 hover:bg-primary/30 cursor-row-resize" />
+        <Panel defaultSize={30} minSize={15}>
+          <Timeline
             currentFrame={currentFrame}
-            onPlayerFrameChange={setCurrentFrame}
-            transformEditingLocked={clipRanges.length > 0 || clipMode}
+            totalFrames={totalFrames}
+            fps={30}
+            playing={playing}
+            onSeek={seekToFrame}
+            onPlay={handlePlay}
+            onPause={handlePause}
+            onSkipBack={handleSkipBack}
+            onSkipForward={handleSkipForward}
           />
-        </div>
-        <PropertiesPanel />
-      </div>
-      <PlaybackBar
-        getPlayer={getPlayer}
-        totalFrames={totalFrames}
-        fps={30}
-        isVideo={isVideo}
-        currentFrame={currentFrame}
-        onFrameChange={setCurrentFrame}
-      />
+        </Panel>
+      </PanelGroup>
     </div>
   );
 };

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/OperationBlock.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/OperationBlock.tsx
@@ -1,0 +1,67 @@
+import {
+  Crop,
+  Droplets,
+  Grid3x3,
+  Image as ImageIcon,
+  Smile,
+  Type,
+  ZoomIn,
+} from "lucide-react";
+
+type OperationBlockProps = {
+  id: string;
+  type: string;
+  label?: string;
+  startFrame: number;
+  endFrame: number;
+  pixelsPerFrame: number;
+  selected: boolean;
+  onClick: () => void;
+};
+
+const typeConfig: Record<
+  string,
+  { bg: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  caption: { bg: "bg-primary/30 border-primary", icon: Type },
+  blur: { bg: "bg-secondary/30 border-secondary", icon: Droplets },
+  crop: { bg: "bg-accent/30 border-accent", icon: Crop },
+  watermark: { bg: "bg-info/30 border-info", icon: ImageIcon },
+  emoji: { bg: "bg-success/30 border-success", icon: Smile },
+  pixelate: { bg: "bg-warning/30 border-warning", icon: Grid3x3 },
+  zoom: { bg: "bg-neutral/30 border-neutral", icon: ZoomIn },
+};
+
+export const OperationBlock = ({
+  id,
+  type,
+  label,
+  startFrame,
+  endFrame,
+  pixelsPerFrame,
+  selected,
+  onClick,
+}: OperationBlockProps) => {
+  const config = typeConfig[type] ?? {
+    bg: "bg-base-300 border-base-content",
+    icon: Type,
+  };
+  const Icon = config.icon;
+  const width = (endFrame - startFrame) * pixelsPerFrame;
+  const left = startFrame * pixelsPerFrame;
+
+  return (
+    <div
+      data-testid={`operation-block-${id}`}
+      className={`absolute h-8 rounded-sm border cursor-pointer overflow-hidden whitespace-nowrap text-xs flex items-center gap-1 px-1 ${config.bg}${selected ? " ring-2 ring-base-content" : ""}`}
+      style={{ width: `${width}px`, left: `${left}px` }}
+      onClick={onClick}
+    >
+      <Icon className="w-3 h-3 shrink-0" />
+      <span className="shrink-0">{type}</span>
+      {type === "caption" && label && (
+        <span className="truncate opacity-70">{label}</span>
+      )}
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/Playhead.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/Playhead.tsx
@@ -1,0 +1,69 @@
+import { useCallback, useRef } from "react";
+
+type PlayheadProps = {
+  currentFrame: number;
+  pixelsPerFrame: number;
+  totalFrames: number;
+  onSeek: (frame: number) => void;
+};
+
+export const Playhead = ({
+  currentFrame,
+  pixelsPerFrame,
+  totalFrames,
+  onSeek,
+}: PlayheadProps) => {
+  const draggingRef = useRef(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const xToFrame = useCallback(
+    (clientX: number) => {
+      const rect = containerRef.current?.parentElement?.getBoundingClientRect();
+      if (!rect) return 0;
+      const x = clientX - rect.left;
+      const frame = Math.round(x / pixelsPerFrame);
+      return Math.max(0, Math.min(totalFrames, frame));
+    },
+    [pixelsPerFrame, totalFrames],
+  );
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      draggingRef.current = true;
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      onSeek(xToFrame(e.clientX));
+    },
+    [onSeek, xToFrame],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!draggingRef.current) return;
+      onSeek(xToFrame(e.clientX));
+    },
+    [onSeek, xToFrame],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    draggingRef.current = false;
+  }, []);
+
+  const left = currentFrame * pixelsPerFrame;
+
+  return (
+    <div
+      ref={containerRef}
+      className="absolute inset-0 pointer-events-none z-10"
+    >
+      <div
+        className="absolute top-0 h-full w-0.5 bg-error pointer-events-auto cursor-col-resize"
+        style={{ left: `${left}px` }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+      >
+        <div className="absolute -top-1 -left-1.5 w-3.5 h-3 bg-error rounded-b-sm" />
+      </div>
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/TimeRuler.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/TimeRuler.tsx
@@ -1,0 +1,54 @@
+type TimeRulerProps = {
+  pixelsPerFrame: number;
+  totalFrames: number;
+  fps: number;
+  scrollLeft: number;
+};
+
+export const TimeRuler = ({
+  pixelsPerFrame,
+  totalFrames,
+  fps,
+  scrollLeft: _scrollLeft,
+}: TimeRulerProps) => {
+  const totalWidth = totalFrames * pixelsPerFrame;
+
+  // Determine tick interval based on zoom level
+  const pixelsPerSecond = pixelsPerFrame * fps;
+  const tickIntervalSec =
+    pixelsPerSecond > 200 ? 1 : pixelsPerSecond > 50 ? 5 : pixelsPerSecond > 20 ? 10 : 30;
+
+  const totalSeconds = totalFrames / fps;
+  const tickCount = Math.floor(totalSeconds / tickIntervalSec) + 1;
+  const ticks = Array.from({ length: tickCount }, (_, i) => {
+    const sec = i * tickIntervalSec;
+    return { sec, x: sec * fps * pixelsPerFrame };
+  });
+
+  const formatTime = (sec: number) => {
+    const m = Math.floor(sec / 60);
+    const s = sec % 60;
+    return `${m}:${s.toString().padStart(2, "0")}`;
+  };
+
+  return (
+    <div
+      data-testid="time-ruler"
+      className="h-6 relative border-b border-base-300 overflow-hidden"
+      style={{ width: `${totalWidth}px` }}
+    >
+      {ticks.map((tick) => (
+        <div
+          key={tick.sec}
+          className="absolute top-0 h-full flex flex-col items-start"
+          style={{ left: `${tick.x}px` }}
+        >
+          <div className="w-px h-3 bg-base-content/40" />
+          <span className="text-[10px] text-base-content/60 pl-0.5 leading-none">
+            {formatTime(tick.sec)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/Timeline.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/Timeline.tsx
@@ -1,0 +1,141 @@
+import { useCallback, useRef, useState } from "react";
+import { useEditorStore } from "~/stores/editorStore";
+import { Playhead } from "./Playhead";
+import { TimeRuler } from "./TimeRuler";
+import { TrackHeader } from "./TrackHeader";
+import { TrackRow } from "./TrackRow";
+import { TransportControls } from "./TransportControls";
+
+type TimelineProps = {
+  currentFrame: number;
+  totalFrames: number;
+  fps: number;
+  playing: boolean;
+  onSeek: (frame: number) => void;
+  onPlay: () => void;
+  onPause: () => void;
+  onSkipBack: () => void;
+  onSkipForward: () => void;
+};
+
+export const Timeline = ({
+  currentFrame,
+  totalFrames,
+  fps,
+  playing,
+  onSeek,
+  onPlay,
+  onPause,
+  onSkipBack,
+  onSkipForward,
+}: TimelineProps) => {
+  const tracks = useEditorStore((s) => s.tracks);
+  const selectedOperationId = useEditorStore((s) => s.selectedOperationId);
+  const setSelectedOperationId = useEditorStore((s) => s.setSelectedOperationId);
+  const addTrack = useEditorStore((s) => s.addTrack);
+
+  const [pixelsPerFrame, setPixelsPerFrame] = useState(2);
+  const [scrollLeft, setScrollLeft] = useState(0);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const handleWheel = useCallback(
+    (e: React.WheelEvent) => {
+      if (e.ctrlKey || e.metaKey) {
+        e.preventDefault();
+        setPixelsPerFrame((prev) =>
+          Math.max(0.5, Math.min(20, prev + (e.deltaY > 0 ? -0.25 : 0.25))),
+        );
+      }
+    },
+    [],
+  );
+
+  const handleScroll = useCallback(() => {
+    if (scrollRef.current) {
+      setScrollLeft(scrollRef.current.scrollLeft);
+    }
+  }, []);
+
+  return (
+    <div data-testid="timeline" className="flex flex-col border-t border-base-300 bg-base-200">
+      {/* Transport bar */}
+      <div className="flex items-center px-2 py-1 border-b border-base-300 bg-base-100">
+        <TransportControls
+          playing={playing}
+          currentFrame={currentFrame}
+          totalFrames={totalFrames}
+          fps={fps}
+          onPlay={onPlay}
+          onPause={onPause}
+          onSkipBack={onSkipBack}
+          onSkipForward={onSkipForward}
+        />
+      </div>
+
+      {/* Ruler + tracks area */}
+      <div className="flex flex-col overflow-hidden" onWheel={handleWheel}>
+        {/* Ruler row */}
+        <div className="flex">
+          <div className="w-32 shrink-0 border-r border-base-300" />
+          <div className="overflow-hidden flex-1">
+            <div style={{ marginLeft: `${-scrollLeft}px` }}>
+              <TimeRuler
+                pixelsPerFrame={pixelsPerFrame}
+                totalFrames={totalFrames}
+                fps={fps}
+                scrollLeft={scrollLeft}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Tracks */}
+        <div className="flex flex-1 overflow-hidden">
+          {/* Track headers */}
+          <div className="shrink-0">
+            {tracks.map((track) => (
+              <TrackHeader
+                key={track.id}
+                name={track.name}
+                trackId={track.id}
+                onAddTrack={addTrack}
+              />
+            ))}
+          </div>
+
+          {/* Track rows with playhead */}
+          <div
+            ref={scrollRef}
+            className="flex-1 overflow-x-auto relative"
+            onScroll={handleScroll}
+          >
+            <Playhead
+              currentFrame={currentFrame}
+              pixelsPerFrame={pixelsPerFrame}
+              totalFrames={totalFrames}
+              onSeek={onSeek}
+            />
+            {tracks.map((track) => (
+              <TrackRow
+                key={track.id}
+                operations={
+                  track.operations as Array<{
+                    id: string;
+                    type: string;
+                    label?: string;
+                    startFrame: number;
+                    endFrame: number;
+                  }>
+                }
+                pixelsPerFrame={pixelsPerFrame}
+                selectedOperationId={selectedOperationId}
+                onSelectOperation={setSelectedOperationId}
+                totalFrames={totalFrames}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/Timeline.vitest.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/Timeline.vitest.tsx
@@ -1,0 +1,163 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+import { OperationBlock } from "./OperationBlock";
+import { TrackHeader } from "./TrackHeader";
+import { TimeRuler } from "./TimeRuler";
+import { TransportControls } from "./TransportControls";
+
+afterEach(cleanup);
+
+describe("OperationBlock", () => {
+  test("renders with type name and correct color class for caption", () => {
+    render(
+      <OperationBlock
+        id="op-1"
+        type="caption"
+        label="Hello world"
+        startFrame={0}
+        endFrame={90}
+        pixelsPerFrame={2}
+        selected={false}
+        onClick={() => {}}
+      />,
+    );
+    const block = screen.getByTestId("operation-block-op-1");
+    expect(block).toBeDefined();
+    expect(block.textContent).toContain("caption");
+    expect(block.className).toContain("primary");
+  });
+
+  test("renders with correct color class for blur", () => {
+    render(
+      <OperationBlock
+        id="op-2"
+        type="blur"
+        startFrame={0}
+        endFrame={60}
+        pixelsPerFrame={2}
+        selected={false}
+        onClick={() => {}}
+      />,
+    );
+    const block = screen.getByTestId("operation-block-op-2");
+    expect(block.className).toContain("secondary");
+  });
+
+  test("shows ring highlight when selected", () => {
+    render(
+      <OperationBlock
+        id="op-3"
+        type="emoji"
+        startFrame={0}
+        endFrame={30}
+        pixelsPerFrame={2}
+        selected={true}
+        onClick={() => {}}
+      />,
+    );
+    const block = screen.getByTestId("operation-block-op-3");
+    expect(block.className).toContain("ring");
+  });
+
+  test("caption block shows truncated text preview", () => {
+    render(
+      <OperationBlock
+        id="op-4"
+        type="caption"
+        label="This is a very long caption text that should be truncated"
+        startFrame={0}
+        endFrame={90}
+        pixelsPerFrame={2}
+        selected={false}
+        onClick={() => {}}
+      />,
+    );
+    const block = screen.getByTestId("operation-block-op-4");
+    expect(block.textContent).toContain("This is a very long");
+  });
+
+  test("block width is computed from frame range and pixelsPerFrame", () => {
+    render(
+      <OperationBlock
+        id="op-5"
+        type="blur"
+        startFrame={10}
+        endFrame={60}
+        pixelsPerFrame={3}
+        selected={false}
+        onClick={() => {}}
+      />,
+    );
+    const block = screen.getByTestId("operation-block-op-5");
+    // width = (60 - 10) * 3 = 150px
+    expect(block.style.width).toBe("150px");
+    // left = 10 * 3 = 30px
+    expect(block.style.left).toBe("30px");
+  });
+});
+
+describe("TrackHeader", () => {
+  test("renders track name", () => {
+    render(<TrackHeader name="Track 1" trackId="t1" onAddTrack={() => {}} />);
+    expect(screen.getByText("Track 1")).toBeDefined();
+  });
+});
+
+describe("TransportControls", () => {
+  test("renders play button and timecode", () => {
+    render(
+      <TransportControls
+        playing={false}
+        currentFrame={0}
+        totalFrames={900}
+        fps={30}
+        onPlay={() => {}}
+        onPause={() => {}}
+        onSkipBack={() => {}}
+        onSkipForward={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("transport-play")).toBeDefined();
+    expect(screen.getByTestId("transport-timecode")).toBeDefined();
+  });
+
+  test("shows pause button when playing", () => {
+    render(
+      <TransportControls
+        playing={true}
+        currentFrame={0}
+        totalFrames={900}
+        fps={30}
+        onPlay={() => {}}
+        onPause={() => {}}
+        onSkipBack={() => {}}
+        onSkipForward={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("transport-pause")).toBeDefined();
+  });
+
+  test("formats timecode as MM:SS:FF", () => {
+    // Frame 90 at 30fps = 00:03:00
+    render(
+      <TransportControls
+        playing={false}
+        currentFrame={90}
+        totalFrames={900}
+        fps={30}
+        onPlay={() => {}}
+        onPause={() => {}}
+        onSkipBack={() => {}}
+        onSkipForward={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("transport-timecode").textContent).toBe("00:03:00");
+  });
+});
+
+describe("TimeRuler", () => {
+  test("renders without crashing", () => {
+    render(<TimeRuler pixelsPerFrame={2} totalFrames={900} fps={30} scrollLeft={0} />);
+    expect(screen.getByTestId("time-ruler")).toBeDefined();
+  });
+});

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/TrackHeader.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/TrackHeader.tsx
@@ -1,0 +1,19 @@
+import { Plus } from "lucide-react";
+
+type TrackHeaderProps = {
+  name: string;
+  trackId: string;
+  onAddTrack: () => void;
+};
+
+export const TrackHeader = ({ name, trackId: _trackId, onAddTrack }: TrackHeaderProps) => <div className="w-32 h-10 flex items-center justify-between px-2 border-r border-base-300 shrink-0">
+      <span className="text-xs truncate">{name}</span>
+      <button
+        type="button"
+        className="btn btn-ghost btn-xs btn-square"
+        onClick={onAddTrack}
+        aria-label={`Add track after ${name}`}
+      >
+        <Plus className="w-3 h-3" />
+      </button>
+    </div>;

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/TrackRow.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/TrackRow.tsx
@@ -1,0 +1,45 @@
+import { OperationBlock } from "./OperationBlock";
+
+type TrackRowProps = {
+  operations: Array<{
+    id: string;
+    type: string;
+    label?: string;
+    startFrame: number;
+    endFrame: number;
+  }>;
+  pixelsPerFrame: number;
+  selectedOperationId: string | null;
+  onSelectOperation: (id: string | null) => void;
+  totalFrames: number;
+};
+
+export const TrackRow = ({
+  operations,
+  pixelsPerFrame,
+  selectedOperationId,
+  onSelectOperation,
+  totalFrames,
+}: TrackRowProps) => <div
+      className="relative h-10 flex items-center"
+      style={{ width: `${totalFrames * pixelsPerFrame}px` }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          onSelectOperation(null);
+        }
+      }}
+    >
+      {operations.map((op) => (
+        <OperationBlock
+          key={op.id}
+          id={op.id}
+          type={op.type}
+          label={op.label}
+          startFrame={op.startFrame}
+          endFrame={op.endFrame}
+          pixelsPerFrame={pixelsPerFrame}
+          selected={selectedOperationId === op.id}
+          onClick={() => onSelectOperation(op.id)}
+        />
+      ))}
+    </div>;

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/TransportControls.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/TransportControls.tsx
@@ -1,0 +1,75 @@
+import { Pause, Play, SkipBack, SkipForward } from "lucide-react";
+
+type TransportControlsProps = {
+  playing: boolean;
+  currentFrame: number;
+  totalFrames: number;
+  fps: number;
+  onPlay: () => void;
+  onPause: () => void;
+  onSkipBack: () => void;
+  onSkipForward: () => void;
+};
+
+const formatTimecode = (frame: number, fps: number): string => {
+  const totalSeconds = Math.floor(frame / fps);
+  const remainingFrames = frame % fps;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}:${remainingFrames.toString().padStart(2, "0")}`;
+};
+
+export const TransportControls = ({
+  playing,
+  currentFrame,
+  totalFrames: _totalFrames,
+  fps,
+  onPlay,
+  onPause,
+  onSkipBack,
+  onSkipForward,
+}: TransportControlsProps) => <div className="flex items-center gap-1">
+      <button
+        type="button"
+        className="btn btn-ghost btn-xs btn-square"
+        onClick={onSkipBack}
+        aria-label="Skip back"
+      >
+        <SkipBack className="w-4 h-4" />
+      </button>
+      {playing ? (
+        <button
+          type="button"
+          data-testid="transport-pause"
+          className="btn btn-ghost btn-xs btn-square"
+          onClick={onPause}
+          aria-label="Pause"
+        >
+          <Pause className="w-4 h-4" />
+        </button>
+      ) : (
+        <button
+          type="button"
+          data-testid="transport-play"
+          className="btn btn-ghost btn-xs btn-square"
+          onClick={onPlay}
+          aria-label="Play"
+        >
+          <Play className="w-4 h-4" />
+        </button>
+      )}
+      <button
+        type="button"
+        className="btn btn-ghost btn-xs btn-square"
+        onClick={onSkipForward}
+        aria-label="Skip forward"
+      >
+        <SkipForward className="w-4 h-4" />
+      </button>
+      <span
+        data-testid="transport-timecode"
+        className="font-mono text-xs tabular-nums px-2"
+      >
+        {formatTimecode(currentFrame, fps)}
+      </span>
+    </div>;

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/index.ts
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/index.ts
@@ -1,0 +1,7 @@
+export { Timeline } from "./Timeline";
+export { OperationBlock } from "./OperationBlock";
+export { TrackRow } from "./TrackRow";
+export { TrackHeader } from "./TrackHeader";
+export { TimeRuler } from "./TimeRuler";
+export { Playhead } from "./Playhead";
+export { TransportControls } from "./TransportControls";


### PR DESCRIPTION
## Summary
- Creates new `Timeline/` component directory with 8 files: Timeline, OperationBlock, TrackRow, TrackHeader, TimeRuler, Playhead, TransportControls, index
- EditorLayout uses `react-resizable-panels` for vertical split (canvas+properties on top, timeline on bottom)
- Removes LayerPanel and PlaybackBar from editor layout
- Operation blocks colored by type using daisyUI semantic colors (caption=primary, blur=secondary, crop=accent, watermark=info, emoji=success, pixelate=warning, zoom=neutral)
- Blocks show lucide-react icon + type name; caption blocks show truncated text
- Draggable playhead, adaptive time ruler, transport controls with MM:SS:FF timecode
- Zoom via ctrl+scroll wheel, horizontal scroll for panning
- Click block to select, click empty area to deselect

## Test plan
- [x] 10 component rendering tests (OperationBlock coloring, selection, sizing; TrackHeader; TransportControls timecode; TimeRuler)
- [x] All 229 web tests pass
- [x] `bun run typecheck` passes (6/6 packages)
- [x] `bun run lint` passes (0 errors)

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)