### PR TITLE
feat(editor): source media bar with clip range overlays

### DIFF
--- a/@fanslib/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -263,6 +263,7 @@ export const EditorLayout = ({ mediaId, editId }: EditorLayoutProps) => {
             totalFrames={totalFrames}
             fps={30}
             playing={playing}
+            filename={media?.relativePath.split("/").pop() ?? undefined}
             onSeek={seekToFrame}
             onPlay={handlePlay}
             onPause={handlePause}

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/SourceMediaBar.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/SourceMediaBar.tsx
@@ -1,0 +1,67 @@
+import { useClipStore } from "~/stores/clipStore";
+
+const RANGE_COLORS = [
+  "bg-primary/30 border-primary",
+  "bg-secondary/30 border-secondary",
+  "bg-accent/30 border-accent",
+  "bg-info/30 border-info",
+  "bg-success/30 border-success",
+];
+
+type SourceMediaBarProps = {
+  filename: string;
+  totalFrames: number;
+  pixelsPerFrame: number;
+};
+
+export const SourceMediaBar = ({ filename, totalFrames, pixelsPerFrame }: SourceMediaBarProps) => {
+  const ranges = useClipStore((s) => s.ranges);
+  const selectedRangeIndex = useClipStore((s) => s.selectedRangeIndex);
+  const pendingMarkInFrame = useClipStore((s) => s.pendingMarkInFrame);
+  const selectRange = useClipStore((s) => s.selectRange);
+
+  const barWidth = totalFrames * pixelsPerFrame;
+
+  return (
+    <div data-testid="source-media-bar" className="relative h-8 shrink-0" style={{ width: barWidth }}>
+      {/* Source file bar */}
+      <div className="absolute inset-0 rounded bg-base-300/80 border border-base-content/10 flex items-center px-2 overflow-hidden">
+        <span className="text-[10px] font-mono text-base-content/40 truncate select-none">
+          {filename}
+        </span>
+      </div>
+
+      {/* Clip range overlays */}
+      {ranges.map((range, i) => {
+        const left = range.startFrame * pixelsPerFrame;
+        const width = (range.endFrame - range.startFrame) * pixelsPerFrame;
+        const colorClass = RANGE_COLORS[i % RANGE_COLORS.length];
+        const isSelected = selectedRangeIndex === i;
+
+        return (
+          <div
+            key={i}
+            data-testid={`source-range-${i}`}
+            className={`absolute top-0 bottom-0 border rounded cursor-pointer ${colorClass} ${
+              isSelected ? "ring-2 ring-primary ring-offset-1" : ""
+            }`}
+            style={{ left, width }}
+            onClick={(e) => {
+              e.stopPropagation();
+              selectRange(i);
+            }}
+          />
+        );
+      })}
+
+      {/* Pending mark-in indicator */}
+      {pendingMarkInFrame !== null && (
+        <div
+          data-testid="pending-mark-in"
+          className="absolute top-0 bottom-0 w-px bg-warning"
+          style={{ left: pendingMarkInFrame * pixelsPerFrame }}
+        />
+      )}
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/Timeline.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/Timeline.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import { useEditorStore } from "~/stores/editorStore";
 import { Playhead } from "./Playhead";
+import { SourceMediaBar } from "./SourceMediaBar";
 import { TimeRuler } from "./TimeRuler";
 import { TrackHeader } from "./TrackHeader";
 import { TrackRow } from "./TrackRow";
@@ -11,6 +12,7 @@ type TimelineProps = {
   totalFrames: number;
   fps: number;
   playing: boolean;
+  filename?: string;
   onSeek: (frame: number) => void;
   onPlay: () => void;
   onPause: () => void;
@@ -23,6 +25,7 @@ export const Timeline = ({
   totalFrames,
   fps,
   playing,
+  filename,
   onSeek,
   onPlay,
   onPause,
@@ -133,6 +136,13 @@ export const Timeline = ({
                 totalFrames={totalFrames}
               />
             ))}
+            {filename && (
+              <SourceMediaBar
+                filename={filename}
+                totalFrames={totalFrames}
+                pixelsPerFrame={pixelsPerFrame}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/Timeline.vitest.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/Timeline.vitest.tsx
@@ -1,6 +1,8 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "vitest";
+import { useClipStore } from "~/stores/clipStore";
 import { OperationBlock } from "./OperationBlock";
+import { SourceMediaBar } from "./SourceMediaBar";
 import { TrackHeader } from "./TrackHeader";
 import { TimeRuler } from "./TimeRuler";
 import { TransportControls } from "./TransportControls";
@@ -159,5 +161,32 @@ describe("TimeRuler", () => {
   test("renders without crashing", () => {
     render(<TimeRuler pixelsPerFrame={2} totalFrames={900} fps={30} scrollLeft={0} />);
     expect(screen.getByTestId("time-ruler")).toBeDefined();
+  });
+});
+
+describe("SourceMediaBar", () => {
+  afterEach(() => {
+    useClipStore.getState().reset();
+  });
+
+  test("renders with filename and data-testid", () => {
+    render(<SourceMediaBar filename="clip.mp4" totalFrames={900} pixelsPerFrame={2} />);
+    const bar = screen.getByTestId("source-media-bar");
+    expect(bar).toBeDefined();
+    expect(bar.textContent).toContain("clip.mp4");
+  });
+
+  test("renders clip range overlays from clipStore", () => {
+    useClipStore.getState().addRange(10, 100);
+    useClipStore.getState().addRange(200, 400);
+    render(<SourceMediaBar filename="video.mp4" totalFrames={900} pixelsPerFrame={2} />);
+    expect(screen.getByTestId("source-range-0")).toBeDefined();
+    expect(screen.getByTestId("source-range-1")).toBeDefined();
+  });
+
+  test("shows pending mark-in indicator", () => {
+    useClipStore.getState().setMarkInAtFrame(50);
+    render(<SourceMediaBar filename="video.mp4" totalFrames={900} pixelsPerFrame={2} />);
+    expect(screen.getByTestId("pending-mark-in")).toBeDefined();
   });
 });

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/index.ts
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/index.ts
@@ -1,5 +1,6 @@
 export { Timeline } from "./Timeline";
 export { OperationBlock } from "./OperationBlock";
+export { SourceMediaBar } from "./SourceMediaBar";
 export { TrackRow } from "./TrackRow";
 export { TrackHeader } from "./TrackHeader";
 export { TimeRuler } from "./TimeRuler";


### PR DESCRIPTION
## Summary
- Adds `SourceMediaBar.tsx` component below timeline track rows
- Shows source filename as a muted bar spanning full video duration
- Clip ranges from `clipStore` rendered as colored overlays using `RANGE_COLORS`
- Click clip range to select, selected range highlighted with ring
- Pending mark-in frame shown as vertical warning-colored indicator
- Bar scrolls and zooms with the rest of the timeline

## Test plan
- [x] 3 component tests (rendering, clip ranges, mark-in indicator)
- [x] All 232 web tests pass
- [x] Typecheck passes (6/6 packages)
- [x] Lint passes (0 errors)

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)