### PR TITLE
feat(editor): show seek-loading overlay while video buffers new frame

### DIFF
--- a/@fanslib/apps/web/src/features/editor/components/EditorCanvas.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/EditorCanvas.tsx
@@ -405,7 +405,7 @@ export const EditorCanvas = forwardRef<EditorCanvasHandle, EditorCanvasProps>(
       const container = playerAreaRef.current;
       if (!container) return;
 
-      let cleanupFn: (() => void) | undefined;
+      const cleanup = { fn: undefined as (() => void) | undefined };
 
       const attachToVideo = () => {
         const video = container.querySelector("video");
@@ -417,14 +417,14 @@ export const EditorCanvas = forwardRef<EditorCanvasHandle, EditorCanvasProps>(
         video.addEventListener("seeking", onSeeking);
         video.addEventListener("seeked", onSeeked);
 
-        cleanupFn = () => {
+        cleanup.fn = () => {
           video.removeEventListener("seeking", onSeeking);
           video.removeEventListener("seeked", onSeeked);
         };
         return true;
       };
 
-      if (attachToVideo()) return () => cleanupFn?.();
+      if (attachToVideo()) return () => cleanup.fn?.();
 
       // Video element may not be in the DOM yet — wait for it
       const observer = new MutationObserver(() => {
@@ -434,7 +434,7 @@ export const EditorCanvas = forwardRef<EditorCanvasHandle, EditorCanvasProps>(
 
       return () => {
         observer.disconnect();
-        cleanupFn?.();
+        cleanup.fn?.();
       };
     }, [isVideo]);
     const compositionViewport = useRemotionCompositionViewport(


### PR DESCRIPTION
## Summary

- Listens to the native `<video>` element's `seeking` / `seeked` events inside the Remotion Player
- Uses a `MutationObserver` to attach the listeners once the video element is available in the DOM
- While seeking, renders a `bg-black/25` overlay + centered `Loader2` spinner (`z-[5]`, `pointer-events-none`) over the player area — editing handles remain interactive above it
- The browser naturally retains the last decoded frame on the `<video>` element during a seek, so no frame capture is needed; the overlay just dims that frozen frame

## Test plan

- [ ] Open a video in the editor
- [ ] Drag the playhead quickly to a distant position — a dimmed overlay with a spinner should appear briefly until the new frame is decoded
- [ ] Confirm the overlay disappears once the frame is ready
- [ ] Confirm editing overlays (region handles, crop, watermark) remain usable while the overlay is visible
- [ ] Confirm images and non-video media are unaffected (no overlay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)