### PR TITLE
Clip region explicit selection and deselection

### DIFF
--- a/@fanslib/apps/web/src/features/editor/components/ClipTimeline.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/ClipTimeline.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Trash2, Scissors } from "lucide-react";
 import { Button } from "~/components/ui/Button";
 import { useClipStore } from "~/stores/clipStore";
@@ -36,12 +36,25 @@ export const ClipTimeline = ({ totalFrames, fps, onSeek }: ClipTimelineProps) =>
   const [dragStart, setDragStart] = useState<number | null>(null);
   const [dragEnd, setDragEnd] = useState<number | null>(null);
 
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && selectedRangeIndex !== null) {
+        selectRange(null);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [selectedRangeIndex, selectRange]);
+
   const frameFromEvent = useCallback(
     (e: React.MouseEvent): number => {
       const rect = timelineRef.current?.getBoundingClientRect();
       if (!rect) return 0;
       const x = e.clientX - rect.left;
-      return Math.max(0, Math.min(totalFrames - 1, Math.round((x / rect.width) * (totalFrames - 1))));
+      return Math.max(
+        0,
+        Math.min(totalFrames - 1, Math.round((x / rect.width) * (totalFrames - 1))),
+      );
     },
     [totalFrames],
   );
@@ -98,12 +111,18 @@ export const ClipTimeline = ({ totalFrames, fps, onSeek }: ClipTimelineProps) =>
       {/* Timeline bar */}
       <div
         ref={timelineRef}
+        data-testid="clip-timeline-bar"
         className={`relative h-10 bg-base-300 rounded ${clipMode ? "cursor-crosshair" : "cursor-pointer"}`}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
         onMouseLeave={() => {
           if (dragStart !== null) handleMouseUp();
+        }}
+        onClick={(e) => {
+          if (e.target === e.currentTarget) {
+            selectRange(null);
+          }
         }}
       >
         {/* Existing ranges */}
@@ -115,7 +134,7 @@ export const ClipTimeline = ({ totalFrames, fps, onSeek }: ClipTimelineProps) =>
 
           return (
             <div
-              key={index}
+              key={`${range.startFrame}-${range.endFrame}`}
               className={`absolute top-0 bottom-0 border-2 rounded ${colorClass} ${
                 isSelected ? "ring-2 ring-primary ring-offset-1" : ""
               }`}
@@ -153,7 +172,7 @@ export const ClipTimeline = ({ totalFrames, fps, onSeek }: ClipTimelineProps) =>
             const isSelected = selectedRangeIndex === index;
             return (
               <div
-                key={index}
+                key={`${range.startFrame}-${range.endFrame}`}
                 className={`flex items-center gap-2 px-2 py-1 rounded text-xs ${
                   isSelected ? "bg-base-300" : "hover:bg-base-300/50"
                 } cursor-pointer`}

--- a/@fanslib/apps/web/src/features/editor/components/ClipTimeline.vitest.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/ClipTimeline.vitest.tsx
@@ -1,0 +1,84 @@
+/// <reference types="@testing-library/jest-dom" />
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { useClipStore } from "~/stores/clipStore";
+import { ClipTimeline } from "./ClipTimeline";
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  useClipStore.getState().reset();
+});
+
+const defaultProps = {
+  totalFrames: 900,
+  fps: 30,
+  onSeek: vi.fn(),
+};
+
+describe("ClipTimeline — clip region selection", () => {
+  test("clicking a clip region selects it in the store", () => {
+    useClipStore.getState().addRange(0, 100);
+    useClipStore.getState().addRange(200, 400);
+    // addRange auto-selects the last added, so clear selection
+    useClipStore.getState().selectRange(null);
+
+    render(<ClipTimeline {...defaultProps} />);
+
+    // Click the first range item in the range list
+    const rangeItem = screen.getByText("Range 1");
+    fireEvent.click(rangeItem.closest("[class*=cursor-pointer]") as HTMLElement);
+
+    expect(useClipStore.getState().selectedRangeIndex).toBe(0);
+  });
+
+  test("selected clip region has a distinct visual ring", () => {
+    useClipStore.getState().addRange(0, 100);
+    // addRange selects the range automatically
+    expect(useClipStore.getState().selectedRangeIndex).toBe(0);
+
+    const { container } = render(<ClipTimeline {...defaultProps} />);
+
+    // The timeline bar clip region should have ring classes
+    const clipRegion = container.querySelector(".ring-2.ring-primary");
+    expect(clipRegion).toBeTruthy();
+  });
+
+  test("clicking empty space on timeline bar deselects the selected clip region", () => {
+    useClipStore.getState().addRange(100, 200);
+    expect(useClipStore.getState().selectedRangeIndex).toBe(0);
+
+    render(<ClipTimeline {...defaultProps} />);
+
+    // Click the timeline bar background (not on a clip region)
+    const timelineBar = screen.getByTestId("clip-timeline-bar");
+    fireEvent.click(timelineBar);
+
+    expect(useClipStore.getState().selectedRangeIndex).toBeNull();
+  });
+
+  test("pressing Escape deselects the selected clip region", () => {
+    useClipStore.getState().addRange(0, 100);
+    expect(useClipStore.getState().selectedRangeIndex).toBe(0);
+
+    render(<ClipTimeline {...defaultProps} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(useClipStore.getState().selectedRangeIndex).toBeNull();
+  });
+
+  test("only one clip region can be selected at a time", () => {
+    useClipStore.getState().addRange(0, 100);
+    useClipStore.getState().addRange(200, 400);
+    useClipStore.getState().selectRange(0);
+
+    render(<ClipTimeline {...defaultProps} />);
+
+    // Click the second range
+    const rangeItem = screen.getByText("Range 2");
+    fireEvent.click(rangeItem.closest("[class*=cursor-pointer]") as HTMLElement);
+
+    expect(useClipStore.getState().selectedRangeIndex).toBe(1);
+  });
+});

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/Timeline.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/Timeline.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Maximize2, Trash2 } from "lucide-react";
 import { useEditorStore } from "~/stores/editorStore";
+import { useClipStore } from "~/stores/clipStore";
+import { ClipTimeline } from "../ClipTimeline";
 import { Playhead } from "./Playhead";
 import { SourceMediaBar } from "./SourceMediaBar";
 import { TimeRuler } from "./TimeRuler";
@@ -39,6 +41,9 @@ export const Timeline = ({
   onSkipBack,
   onSkipForward,
 }: TimelineProps) => {
+  const clipMode = useClipStore((s) => s.clipMode);
+  const clipRanges = useClipStore((s) => s.ranges);
+  const showClipTimeline = clipMode || clipRanges.length > 0;
   const tracks = useEditorStore((s) => s.tracks);
   const selectedOperationId = useEditorStore((s) => s.selectedOperationId);
   const setSelectedOperationId = useEditorStore((s) => s.setSelectedOperationId);
@@ -211,11 +216,7 @@ export const Timeline = ({
           </div>
 
           {/* Track rows with playhead */}
-          <div
-            ref={scrollRef}
-            className="flex-1 overflow-x-auto relative"
-            onScroll={handleScroll}
-          >
+          <div ref={scrollRef} className="flex-1 overflow-x-auto relative" onScroll={handleScroll}>
             <Playhead
               currentFrame={currentFrame}
               pixelsPerFrame={pixelsPerFrame}
@@ -259,6 +260,8 @@ export const Timeline = ({
           </div>
         </div>
       </div>
+
+      {showClipTimeline && <ClipTimeline totalFrames={totalFrames} fps={fps} onSeek={onSeek} />}
 
       {/* Context menu */}
       {contextMenu && (


### PR DESCRIPTION
## Summary

- Integrate ClipTimeline into the editor Timeline, visible when clip mode is active or clip ranges exist
- Clicking a clip region selects it with a distinct ring highlight
- Pressing Escape deselects the selected clip region
- Clicking empty timeline space deselects the selected clip region
- Only one clip region can be selected at a time (store-level guarantee)

## Test plan

- [x] Clicking a clip region in the range list selects it in the store
- [x] Selected clip region renders with ring-2 ring-primary visual highlight
- [x] Clicking empty timeline bar space deselects the selected clip region
- [x] Pressing Escape deselects the selected clip region
- [x] Only one clip region selected at a time (clicking second deselects first)
- [x] All existing editor tests pass (121 tests across 8 files)
- [x] Typecheck, lint, format, and full test suite pass locally

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)