### PR TITLE
Pending clip region visualization with duration flag

### DIFF
--- a/@fanslib/apps/web/src/features/editor/components/ClipTimeline.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/ClipTimeline.tsx
@@ -6,6 +6,7 @@ import { useClipStore } from "~/stores/clipStore";
 type ClipTimelineProps = {
   totalFrames: number;
   fps: number;
+  currentFrame?: number;
   onSeek: (frame: number) => void;
 };
 
@@ -24,7 +25,12 @@ const RANGE_COLORS = [
   "bg-success/30 border-success",
 ];
 
-export const ClipTimeline = ({ totalFrames, fps, onSeek }: ClipTimelineProps) => {
+const formatDuration = (frames: number, fps: number): string => {
+  const seconds = Math.abs(frames) / fps;
+  return `${seconds.toFixed(1)}s`;
+};
+
+export const ClipTimeline = ({ totalFrames, fps, currentFrame = 0, onSeek }: ClipTimelineProps) => {
   const ranges = useClipStore((s) => s.ranges);
   const clipMode = useClipStore((s) => s.clipMode);
   const pendingMarkInFrame = useClipStore((s) => s.pendingMarkInFrame);
@@ -162,6 +168,30 @@ export const ClipTimeline = ({ totalFrames, fps, onSeek }: ClipTimelineProps) =>
             }}
           />
         )}
+
+        {/* Pending clip region (mark-in set, waiting for mark-out) */}
+        {pendingMarkInFrame !== null &&
+          (() => {
+            const start = Math.min(pendingMarkInFrame, currentFrame);
+            const end = Math.max(pendingMarkInFrame, currentFrame);
+            const left = (start / totalFrames) * 100;
+            const width = ((end - start) / totalFrames) * 100;
+            const durationFrames = end - start;
+            return (
+              <div
+                data-testid="pending-clip-region"
+                className="absolute top-0 bottom-0 bg-warning/15 border border-warning/40 border-dashed rounded"
+                style={{ left: `${left}%`, width: `${width}%` }}
+              >
+                <span
+                  data-testid="pending-duration-flag"
+                  className="absolute -top-5 right-0 text-[10px] font-mono bg-warning/80 text-warning-content px-1 rounded"
+                >
+                  {formatDuration(durationFrames, fps)}
+                </span>
+              </div>
+            );
+          })()}
       </div>
 
       {/* Range list */}

--- a/@fanslib/apps/web/src/features/editor/components/ClipTimeline.vitest.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/ClipTimeline.vitest.tsx
@@ -82,3 +82,49 @@ describe("ClipTimeline — clip region selection", () => {
     expect(useClipStore.getState().selectedRangeIndex).toBe(1);
   });
 });
+
+describe("ClipTimeline — pending clip region visualization", () => {
+  test("renders pending region from mark-in to current playhead", () => {
+    useClipStore.getState().toggleClipMode();
+    useClipStore.getState().setMarkInAtFrame(100);
+
+    const { container } = render(<ClipTimeline {...defaultProps} currentFrame={400} />);
+
+    const pendingRegion = container.querySelector("[data-testid='pending-clip-region']");
+    expect(pendingRegion).toBeTruthy();
+  });
+
+  test("pending region is not visible when no mark-in is set", () => {
+    useClipStore.getState().toggleClipMode();
+
+    const { container } = render(<ClipTimeline {...defaultProps} currentFrame={400} />);
+
+    const pendingRegion = container.querySelector("[data-testid='pending-clip-region']");
+    expect(pendingRegion).toBeNull();
+  });
+
+  test("duration flag shows running length in seconds", () => {
+    useClipStore.getState().toggleClipMode();
+    useClipStore.getState().setMarkInAtFrame(0);
+
+    // At frame 210 with 30fps, that's 7.0 seconds
+    render(<ClipTimeline {...defaultProps} currentFrame={210} />);
+
+    expect(screen.getByTestId("pending-duration-flag").textContent).toBe("7.0s");
+  });
+
+  test("pending region disappears when clip is committed", () => {
+    useClipStore.getState().toggleClipMode();
+    useClipStore.getState().setMarkInAtFrame(100);
+
+    const { container, rerender } = render(<ClipTimeline {...defaultProps} currentFrame={400} />);
+
+    // Commit the clip
+    useClipStore.getState().commitMarkOutAtFrame(400);
+
+    rerender(<ClipTimeline {...defaultProps} currentFrame={400} />);
+
+    const pendingRegion = container.querySelector("[data-testid='pending-clip-region']");
+    expect(pendingRegion).toBeNull();
+  });
+});

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/Timeline.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/Timeline.tsx
@@ -261,7 +261,14 @@ export const Timeline = ({
         </div>
       </div>
 
-      {showClipTimeline && <ClipTimeline totalFrames={totalFrames} fps={fps} onSeek={onSeek} />}
+      {showClipTimeline && (
+        <ClipTimeline
+          totalFrames={totalFrames}
+          fps={fps}
+          currentFrame={currentFrame}
+          onSeek={onSeek}
+        />
+      )}
 
       {/* Context menu */}
       {contextMenu && (


### PR DESCRIPTION
## Summary

- Show a live preview of the pending clip region (mark-in set, waiting for mark-out) as a dim warning-colored bar from mark-in frame to current playhead
- Display a duration flag (e.g. "7.0s") showing the running length of the pending region
- Pending region updates in real-time as playhead moves and disappears when clip is committed

## Test plan

- [x] Pending region renders from mark-in to current playhead when mark-in is set
- [x] Pending region not visible when no mark-in is set
- [x] Duration flag shows correct running length in seconds (e.g. 7.0s for 210 frames at 30fps)
- [x] Pending region disappears when clip is committed
- [x] All 9 ClipTimeline tests pass
- [x] Typecheck, lint, format, and full test suite pass locally

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)