### PR TITLE
Peak marker: P key and timeline visualization

### DIFF
--- a/@fanslib/apps/web/src/features/editor/components/ClipTimeline.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/ClipTimeline.tsx
@@ -41,7 +41,10 @@ export const ClipTimeline = ({ totalFrames, fps, onSeek }: ClipTimelineProps) =>
       const rect = timelineRef.current?.getBoundingClientRect();
       if (!rect) return 0;
       const x = e.clientX - rect.left;
-      return Math.max(0, Math.min(totalFrames - 1, Math.round((x / rect.width) * (totalFrames - 1))));
+      return Math.max(
+        0,
+        Math.min(totalFrames - 1, Math.round((x / rect.width) * (totalFrames - 1))),
+      );
     },
     [totalFrames],
   );
@@ -129,6 +132,23 @@ export const ClipTimeline = ({ totalFrames, fps, onSeek }: ClipTimelineProps) =>
               <span className="absolute top-0.5 left-1 text-[10px] font-mono text-base-content/60">
                 {formatTime(range.startFrame, fps)} – {formatTime(range.endFrame, fps)}
               </span>
+              {range.peakFrame !== undefined &&
+                (() => {
+                  const rangeDuration = range.endFrame - range.startFrame;
+                  const peakOffset =
+                    rangeDuration > 0
+                      ? ((range.peakFrame - range.startFrame) / rangeDuration) * 100
+                      : 0;
+                  return (
+                    <div
+                      data-testid={`peak-marker-${index}`}
+                      className="absolute top-0 bottom-0 w-0.5 bg-error"
+                      style={{ left: `${peakOffset}%` }}
+                    >
+                      <div className="absolute -top-1 left-1/2 -translate-x-1/2 w-2 h-2 bg-error rotate-45" />
+                    </div>
+                  );
+                })()}
             </div>
           );
         })}

--- a/@fanslib/apps/web/src/features/editor/components/EditorLayout.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/EditorLayout.tsx
@@ -160,6 +160,18 @@ export const EditorLayout = ({ mediaId, editId }: EditorLayoutProps) => {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [clipHotkeysActive]);
 
+  // P key: set peak marker inside the clip range containing the playhead
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "p" && e.key !== "P") return;
+      if (isEditableKeyTarget(e.target)) return;
+      e.preventDefault();
+      useClipStore.getState().setPeakAtFrame(currentFrameRef.current);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
   useEffect(() => {
     if (clipHotkeysActive) return;
 

--- a/@fanslib/apps/web/src/stores/clipStore.ts
+++ b/@fanslib/apps/web/src/stores/clipStore.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 export type ClipRange = {
   startFrame: number;
   endFrame: number;
+  peakFrame?: number;
 };
 
 type ClipState = {
@@ -21,6 +22,7 @@ type ClipState = {
   removeRange: (index: number) => void;
   updateRange: (index: number, startFrame: number, endFrame: number) => void;
   selectRange: (index: number | null) => void;
+  setPeakAtFrame: (frame: number) => void;
   undo: () => void;
   redo: () => void;
   reset: () => void;
@@ -112,6 +114,18 @@ export const useClipStore = create<ClipState>((set, get) => {
 
     selectRange: (index) => {
       set({ selectedRangeIndex: index });
+    },
+
+    setPeakAtFrame: (frame) => {
+      const { ranges } = get();
+      const rangeIndex = ranges.findIndex((r) => frame >= r.startFrame && frame <= r.endFrame);
+      if (rangeIndex === -1) return;
+      pushHistory();
+      set((state) => ({
+        ranges: state.ranges.map((r, i) => (i === rangeIndex ? { ...r, peakFrame: frame } : r)),
+        canUndo: true,
+        canRedo: false,
+      }));
     },
 
     undo: () => {

--- a/@fanslib/apps/web/src/stores/clipStore.vitest.ts
+++ b/@fanslib/apps/web/src/stores/clipStore.vitest.ts
@@ -71,4 +71,33 @@ describe("clipStore", () => {
     useClipStore.getState().selectRange(1);
     expect(useClipStore.getState().selectedRangeIndex).toBe(1);
   });
+
+  test("setPeakAtFrame sets peakFrame on the range containing the playhead", () => {
+    useClipStore.getState().addRange(0, 100);
+    useClipStore.getState().addRange(200, 400);
+    useClipStore.getState().setPeakAtFrame(50);
+    expect(useClipStore.getState().ranges[0].peakFrame).toBe(50);
+    expect(useClipStore.getState().ranges[1].peakFrame).toBeUndefined();
+  });
+
+  test("setPeakAtFrame does nothing when playhead is outside all ranges", () => {
+    useClipStore.getState().addRange(0, 100);
+    useClipStore.getState().setPeakAtFrame(150);
+    expect(useClipStore.getState().ranges[0].peakFrame).toBeUndefined();
+  });
+
+  test("setPeakAtFrame updates existing peak on same range", () => {
+    useClipStore.getState().addRange(0, 100);
+    useClipStore.getState().setPeakAtFrame(30);
+    useClipStore.getState().setPeakAtFrame(70);
+    expect(useClipStore.getState().ranges[0].peakFrame).toBe(70);
+  });
+
+  test("setPeakAtFrame is undoable", () => {
+    useClipStore.getState().addRange(0, 100);
+    useClipStore.getState().setPeakAtFrame(50);
+    expect(useClipStore.getState().ranges[0].peakFrame).toBe(50);
+    useClipStore.getState().undo();
+    expect(useClipStore.getState().ranges[0].peakFrame).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- Add optional `peakFrame` field to `ClipRange` type for engagement peak marking
- Pressing P while playhead is inside a clip region sets that region's peak frame
- Peak marker rendered as a vertical error-colored line with diamond in the timeline
- Peak setting is included in the undo history
- P does nothing when playhead is outside all regions

## Test plan

- [x] setPeakAtFrame sets peakFrame on the range containing the playhead
- [x] setPeakAtFrame does nothing when playhead is outside all ranges
- [x] setPeakAtFrame updates existing peak on same range
- [x] setPeakAtFrame is undoable
- [x] All 63 relevant tests pass
- [x] Typecheck, lint, format, and full test suite pass locally

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)