### PR TITLE
Operation-clip intersection utility

### DIFF
--- a/@fanslib/apps/web/src/features/editor/utils/clip-intersection.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/clip-intersection.ts
@@ -1,0 +1,53 @@
+import type { Track, Operation } from "@fanslib/video/types";
+import type { ClipRange } from "~/stores/clipStore";
+
+type KeyframedOp = Operation & {
+  keyframes?: Array<{ frame: number; [key: string]: unknown }>;
+};
+
+export const intersectOperationsWithClip = (tracks: Track[], clip: ClipRange): Track[] => {
+  const clipDuration = clip.endFrame - clip.startFrame;
+
+  return tracks
+    .map((track) => {
+      const remapped = track.operations.flatMap((op) => {
+        const typedOp = op as KeyframedOp & { startFrame?: number; endFrame?: number };
+        const opStart = typedOp.startFrame ?? 0;
+        const opEnd = typedOp.endFrame ?? 0;
+
+        // Check overlap: operation must intersect with clip
+        if (opEnd <= clip.startFrame || opStart >= clip.endFrame) return [];
+
+        // Clamp to clip boundaries and remap
+        const clampedStart = Math.max(opStart, clip.startFrame) - clip.startFrame;
+        const clampedEnd = Math.min(opEnd, clip.endFrame) - clip.startFrame;
+
+        const remappedOp = {
+          ...typedOp,
+          startFrame: clampedStart,
+          endFrame: clampedEnd,
+        };
+
+        // Remap keyframes
+        if (typedOp.keyframes) {
+          remappedOp.keyframes = typedOp.keyframes
+            .map((kf) => ({
+              ...kf,
+              frame: kf.frame - clip.startFrame,
+            }))
+            .filter((kf) => kf.frame >= 0 && kf.frame <= clipDuration);
+        }
+
+        return [remappedOp as Operation];
+      });
+
+      if (remapped.length === 0) return null;
+
+      return {
+        id: track.id,
+        name: track.name,
+        operations: remapped,
+      };
+    })
+    .filter((t): t is Track => t !== null);
+};

--- a/@fanslib/apps/web/src/features/editor/utils/clip-intersection.vitest.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/clip-intersection.vitest.ts
@@ -1,0 +1,290 @@
+import { describe, expect, test } from "vitest";
+import { intersectOperationsWithClip } from "./clip-intersection";
+import type { Track } from "@fanslib/video/types";
+import type { ClipRange } from "~/stores/clipStore";
+
+const makeTrack = (name: string, operations: Track["operations"]): Track => ({
+  id: `track-${name}`,
+  name,
+  operations,
+});
+
+const clip: ClipRange = { startFrame: 100, endFrame: 400 };
+
+describe("intersectOperationsWithClip", () => {
+  test("includes operation fully inside clip with remapped frames", () => {
+    const tracks = [
+      makeTrack("T1", [
+        {
+          type: "caption",
+          id: "op1",
+          text: "Hello",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 150,
+          endFrame: 300,
+        },
+      ]),
+    ];
+
+    const result = intersectOperationsWithClip(tracks, clip);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].operations).toHaveLength(1);
+    const op = result[0].operations[0] as { startFrame: number; endFrame: number };
+    expect(op.startFrame).toBe(50); // 150 - 100
+    expect(op.endFrame).toBe(200); // 300 - 100
+  });
+
+  test("excludes operation fully outside clip", () => {
+    const tracks = [
+      makeTrack("T1", [
+        {
+          type: "caption",
+          id: "op1",
+          text: "Hello",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 500,
+          endFrame: 600,
+        },
+      ]),
+    ];
+
+    const result = intersectOperationsWithClip(tracks, clip);
+
+    expect(result).toHaveLength(0); // empty track excluded
+  });
+
+  test("clamps partially overlapping operation to clip boundaries", () => {
+    const tracks = [
+      makeTrack("T1", [
+        {
+          type: "caption",
+          id: "op1",
+          text: "Hello",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 50,
+          endFrame: 250,
+        },
+      ]),
+    ];
+
+    const result = intersectOperationsWithClip(tracks, clip);
+
+    expect(result).toHaveLength(1);
+    const op = result[0].operations[0] as { startFrame: number; endFrame: number };
+    expect(op.startFrame).toBe(0); // clamped to clip start
+    expect(op.endFrame).toBe(150); // 250 - 100
+  });
+
+  test("remaps keyframes by clip start offset", () => {
+    const tracks = [
+      makeTrack("T1", [
+        {
+          type: "zoom",
+          id: "op1",
+          scale: 1.5,
+          centerX: 0.5,
+          centerY: 0.5,
+          startFrame: 100,
+          endFrame: 400,
+          keyframes: [
+            { frame: 150, values: { scale: 1 } },
+            { frame: 300, values: { scale: 2 } },
+          ],
+        },
+      ]),
+    ];
+
+    const result = intersectOperationsWithClip(tracks, clip);
+
+    expect(result).toHaveLength(1);
+    const op = result[0].operations[0] as { keyframes: Array<{ frame: number }> };
+    expect(op.keyframes[0].frame).toBe(50); // 150 - 100
+    expect(op.keyframes[1].frame).toBe(200); // 300 - 100
+  });
+
+  test("preserves track structure with id and name", () => {
+    const tracks = [
+      makeTrack("My Track", [
+        {
+          type: "caption",
+          id: "op1",
+          text: "Hello",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 150,
+          endFrame: 300,
+        },
+      ]),
+    ];
+
+    const result = intersectOperationsWithClip(tracks, clip);
+
+    expect(result[0].id).toBe("track-My Track");
+    expect(result[0].name).toBe("My Track");
+  });
+
+  test("excludes empty tracks from output", () => {
+    const tracks = [
+      makeTrack("Empty", [
+        {
+          type: "caption",
+          id: "op1",
+          text: "Hello",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 500,
+          endFrame: 600,
+        },
+      ]),
+      makeTrack("HasOps", [
+        {
+          type: "caption",
+          id: "op2",
+          text: "World",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 150,
+          endFrame: 300,
+        },
+      ]),
+    ];
+
+    const result = intersectOperationsWithClip(tracks, clip);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("HasOps");
+  });
+
+  test("handles empty tracks input", () => {
+    const result = intersectOperationsWithClip([], clip);
+    expect(result).toHaveLength(0);
+  });
+
+  test("handles multiple tracks with mixed overlap", () => {
+    const tracks = [
+      makeTrack("T1", [
+        {
+          type: "caption",
+          id: "op1",
+          text: "Inside",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 200,
+          endFrame: 300,
+        },
+        {
+          type: "caption",
+          id: "op2",
+          text: "Outside",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 500,
+          endFrame: 600,
+        },
+      ]),
+      makeTrack("T2", [
+        {
+          type: "caption",
+          id: "op3",
+          text: "Overlap",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 350,
+          endFrame: 500,
+        },
+      ]),
+    ];
+
+    const result = intersectOperationsWithClip(tracks, clip);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].operations).toHaveLength(1); // only op1
+    expect(result[1].operations).toHaveLength(1); // op3 clamped
+    const op3 = result[1].operations[0] as { startFrame: number; endFrame: number };
+    expect(op3.startFrame).toBe(250); // 350 - 100
+    expect(op3.endFrame).toBe(300); // clamped to 400 - 100 = 300
+  });
+
+  test("handles boundary: operation starts exactly at clip start", () => {
+    const tracks = [
+      makeTrack("T1", [
+        {
+          type: "caption",
+          id: "op1",
+          text: "Boundary",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 100,
+          endFrame: 200,
+        },
+      ]),
+    ];
+
+    const result = intersectOperationsWithClip(tracks, clip);
+
+    expect(result).toHaveLength(1);
+    const op = result[0].operations[0] as { startFrame: number; endFrame: number };
+    expect(op.startFrame).toBe(0);
+    expect(op.endFrame).toBe(100);
+  });
+
+  test("handles boundary: operation ends exactly at clip end", () => {
+    const tracks = [
+      makeTrack("T1", [
+        {
+          type: "caption",
+          id: "op1",
+          text: "Boundary",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 300,
+          endFrame: 400,
+        },
+      ]),
+    ];
+
+    const result = intersectOperationsWithClip(tracks, clip);
+
+    expect(result).toHaveLength(1);
+    const op = result[0].operations[0] as { startFrame: number; endFrame: number };
+    expect(op.startFrame).toBe(200);
+    expect(op.endFrame).toBe(300);
+  });
+});


### PR DESCRIPTION
## Summary

- Pure utility function `intersectOperationsWithClip(tracks, clipRange)` that returns operations overlapping a clip window with frames remapped relative to clip start
- Operations fully inside clip: included with remapped frames
- Operations fully outside: excluded
- Partially overlapping: clamped to clip boundaries
- Keyframes remapped by same offset, out-of-range keyframes filtered
- Empty tracks excluded; track structure preserved

## Test plan

- [x] 10 tests covering: fully inside, fully outside, partial overlap, keyframe remapping, track preservation, empty tracks, empty input, multiple tracks, boundary edges
- [x] Typecheck, lint, format pass

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)