### PR TITLE
feat(editor): add source mode with I/O marking and segment push

### DIFF
--- a/@fanslib/apps/server/src/features/compositions/entity.ts
+++ b/@fanslib/apps/server/src/features/compositions/entity.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import type { Relation } from "typeorm";
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { Shoot } from "../shoots/entity";
+
+@Entity("composition")
+export class Composition {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ type: "varchar", name: "shootId" })
+  shootId!: string;
+
+  @ManyToOne(() => Shoot, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "shootId" })
+  shoot!: Relation<Shoot>;
+
+  @Column({ type: "varchar", name: "name" })
+  name!: string;
+
+  @Column({ type: "simple-json", name: "segments", default: "[]" })
+  segments: unknown[] = [];
+
+  @Column({ type: "simple-json", name: "tracks", default: "[]" })
+  tracks: unknown[] = [];
+
+  @Column({ type: "simple-json", name: "exportRegions", default: "[]" })
+  exportRegions: unknown[] = [];
+
+  @CreateDateColumn({ type: "datetime", name: "createdAt" })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: "datetime", name: "updatedAt" })
+  updatedAt!: Date;
+}
+
+const SegmentTransitionSchema = z.object({
+  type: z.literal("crossfade"),
+  durationFrames: z.number(),
+  easing: z.string().optional(),
+});
+
+export const SegmentSchema = z.object({
+  id: z.string(),
+  sourceMediaId: z.string(),
+  sourceStartFrame: z.number(),
+  sourceEndFrame: z.number(),
+  transition: SegmentTransitionSchema.optional(),
+});
+
+export const TrackSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  operations: z.array(z.unknown()),
+});
+
+export const ExportRegionSchema = z.object({
+  id: z.string(),
+  startFrame: z.number(),
+  endFrame: z.number(),
+  package: z.string().nullable().optional(),
+  role: z.string().nullable().optional(),
+  contentRating: z.string().nullable().optional(),
+  quality: z.string().nullable().optional(),
+});
+
+export const CompositionSchema = z.object({
+  id: z.string(),
+  shootId: z.string(),
+  name: z.string(),
+  segments: z.array(SegmentSchema),
+  tracks: z.array(TrackSchema),
+  exportRegions: z.array(ExportRegionSchema),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/create.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/create.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const CreateCompositionRequestBodySchema = z.object({
+  shootId: z.string(),
+  name: z.string(),
+});
+
+export const createComposition = async (
+  payload: z.infer<typeof CreateCompositionRequestBodySchema>,
+): Promise<Composition> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+
+  const composition = repo.create({
+    shootId: payload.shootId,
+    name: payload.name,
+    segments: [],
+    tracks: [],
+    exportRegions: [],
+  });
+
+  await repo.save(composition);
+  const created = await repo.findOne({ where: { id: composition.id } });
+  if (!created) throw new Error(`Failed to fetch created composition ${composition.id}`);
+  return created;
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/delete.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/delete.ts
@@ -1,0 +1,11 @@
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const deleteComposition = async (id: string): Promise<boolean> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+  const composition = await repo.findOne({ where: { id } });
+  if (!composition) return false;
+  await repo.delete(id);
+  return true;
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-id.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-id.ts
@@ -1,0 +1,8 @@
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const fetchCompositionById = async (id: string): Promise<Composition | null> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+  return repo.findOne({ where: { id } });
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-shoot.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-shoot.ts
@@ -1,0 +1,11 @@
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const fetchCompositionsByShoot = async (shootId: string): Promise<Composition[]> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+  return repo.find({
+    where: { shootId },
+    order: { createdAt: "DESC" },
+  });
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/update.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/update.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { db } from "../../../../lib/db";
+import { Composition, SegmentSchema, TrackSchema, ExportRegionSchema } from "../../entity";
+
+export const UpdateCompositionRequestBodySchema = z.object({
+  name: z.string().optional(),
+  segments: z.array(SegmentSchema).optional(),
+  tracks: z.array(TrackSchema).optional(),
+  exportRegions: z.array(ExportRegionSchema).optional(),
+});
+
+export const updateComposition = async (
+  id: string,
+  payload: z.infer<typeof UpdateCompositionRequestBodySchema>,
+): Promise<Composition | null> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+
+  const composition = await repo.findOne({ where: { id } });
+  if (!composition) return null;
+
+  if (payload.name !== undefined) composition.name = payload.name;
+  if (payload.segments !== undefined) composition.segments = payload.segments;
+  if (payload.tracks !== undefined) composition.tracks = payload.tracks;
+  if (payload.exportRegions !== undefined) composition.exportRegions = payload.exportRegions;
+
+  await repo.save(composition);
+  return composition;
+};

--- a/@fanslib/apps/server/src/features/compositions/routes.test.ts
+++ b/@fanslib/apps/server/src/features/compositions/routes.test.ts
@@ -1,0 +1,257 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import "reflect-metadata";
+import { getTestDataSource, setupTestDatabase, teardownTestDatabase } from "../../lib/test-db";
+import { resetAllFixtures } from "../../lib/test-fixtures";
+import { devalueMiddleware } from "../../lib/devalue-middleware";
+import { parseResponse } from "../../test-utils/setup";
+import { Shoot } from "../shoots/entity";
+import { compositionsRoutes } from "./routes";
+
+describe("Compositions Routes", () => {
+  // eslint-disable-next-line functional/no-let
+  let app: Hono;
+  // eslint-disable-next-line functional/no-let
+  let testShoot: Shoot;
+
+  beforeAll(async () => {
+    await setupTestDatabase();
+    await resetAllFixtures();
+    app = new Hono().use("*", devalueMiddleware()).route("/", compositionsRoutes);
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetAllFixtures();
+    // Create a shoot for compositions to reference
+    const dataSource = getTestDataSource();
+    const shootRepo = dataSource.getRepository(Shoot);
+    testShoot = shootRepo.create({
+      name: "Test Shoot",
+      shootDate: new Date("2026-04-08"),
+    });
+    testShoot = await shootRepo.save(testShoot);
+  });
+
+  describe("POST /api/compositions", () => {
+    test("creates a composition and returns it with all fields", async () => {
+      const response = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          shootId: testShoot.id,
+          name: "Trailer v1",
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{
+        id: string;
+        shootId: string;
+        name: string;
+        segments: unknown[];
+        tracks: unknown[];
+        exportRegions: unknown[];
+        createdAt: string;
+        updatedAt: string;
+      }>(response);
+
+      expect(data?.id).toBeDefined();
+      expect(data?.shootId).toBe(testShoot.id);
+      expect(data?.name).toBe("Trailer v1");
+      expect(data?.segments).toEqual([]);
+      expect(data?.tracks).toEqual([]);
+      expect(data?.exportRegions).toEqual([]);
+    });
+  });
+
+  describe("PATCH /api/compositions/by-id/:id", () => {
+    test("updates composition name, segments, tracks, and exportRegions", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Original" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const segments = [
+        { id: "seg-1", sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 900 },
+      ];
+      const tracks = [
+        { id: "track-1", name: "Overlays", operations: [] },
+      ];
+      const exportRegions = [
+        { id: "er-1", startFrame: 0, endFrame: 450 },
+      ];
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "Updated",
+          segments,
+          tracks,
+          exportRegions,
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{
+        name: string;
+        segments: unknown[];
+        tracks: unknown[];
+        exportRegions: unknown[];
+      }>(response);
+      expect(data?.name).toBe("Updated");
+      expect(data?.segments).toHaveLength(1);
+      expect(data?.tracks).toHaveLength(1);
+      expect(data?.exportRegions).toHaveLength(1);
+    });
+
+    test("returns 404 for non-existent composition", async () => {
+      const response = await app.request("/api/compositions/by-id/nonexistent", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Nope" }),
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("GET /api/compositions/by-shoot/:shootId", () => {
+    test("lists all compositions for a shoot", async () => {
+      await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Comp A" }),
+      });
+      await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Comp B" }),
+      });
+
+      const response = await app.request(`/api/compositions/by-shoot/${testShoot.id}`);
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ id: string; name: string }[]>(response);
+      expect(data).toHaveLength(2);
+      const names = data?.map((c) => c.name).sort();
+      expect(names).toEqual(["Comp A", "Comp B"]);
+    });
+
+    test("returns empty array for shoot with no compositions", async () => {
+      const response = await app.request(`/api/compositions/by-shoot/${testShoot.id}`);
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<unknown[]>(response);
+      expect(data).toHaveLength(0);
+    });
+  });
+
+  describe("DELETE /api/compositions/by-id/:id", () => {
+    test("deletes a composition", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "To Delete" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`, {
+        method: "DELETE",
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ success: boolean }>(response);
+      expect(data?.success).toBe(true);
+
+      // Verify it's gone
+      const getResponse = await app.request(`/api/compositions/by-id/${created?.id}`);
+      expect(getResponse.status).toBe(404);
+    });
+
+    test("returns 404 for non-existent composition", async () => {
+      const response = await app.request("/api/compositions/by-id/nonexistent", {
+        method: "DELETE",
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("GET /api/compositions/by-id/:id", () => {
+    test("fetches a composition by ID", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Fetch Test" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`);
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ id: string; name: string }>(response);
+      expect(data?.id).toBe(created?.id);
+      expect(data?.name).toBe("Fetch Test");
+    });
+
+    test("returns 404 for non-existent composition", async () => {
+      const response = await app.request("/api/compositions/by-id/nonexistent");
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Schema validation", () => {
+    test("rejects update with invalid segment shape", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Validate Me" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          segments: [{ invalid: "shape" }],
+        }),
+      });
+      expect(response.status).toBe(422);
+    });
+
+    test("rejects create without required fields", async () => {
+      const response = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(response.status).toBe(422);
+    });
+  });
+
+  describe("Shoot cascade", () => {
+    test("deleting a shoot cascades to its compositions", async () => {
+      // Create a composition on the test shoot
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Will Be Cascaded" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      // Delete the shoot directly
+      const dataSource = getTestDataSource();
+      const shootRepo = dataSource.getRepository(Shoot);
+      await shootRepo.delete(testShoot.id);
+
+      // The composition should be gone
+      const getResponse = await app.request(`/api/compositions/by-id/${created?.id}`);
+      expect(getResponse.status).toBe(404);
+    });
+  });
+});

--- a/@fanslib/apps/server/src/features/compositions/routes.ts
+++ b/@fanslib/apps/server/src/features/compositions/routes.ts
@@ -1,0 +1,54 @@
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { validationError, notFound } from "../../lib/hono-utils";
+import {
+  CreateCompositionRequestBodySchema,
+  createComposition,
+} from "./operations/composition/create";
+import { deleteComposition } from "./operations/composition/delete";
+import { fetchCompositionById } from "./operations/composition/fetch-by-id";
+import { fetchCompositionsByShoot } from "./operations/composition/fetch-by-shoot";
+import {
+  UpdateCompositionRequestBodySchema,
+  updateComposition,
+} from "./operations/composition/update";
+
+export const compositionsRoutes = new Hono()
+  .basePath("/api/compositions")
+  .post(
+    "/",
+    zValidator("json", CreateCompositionRequestBodySchema, validationError),
+    async (c) => {
+      const body = c.req.valid("json");
+      const result = await createComposition(body);
+      return c.json(result);
+    },
+  )
+  .patch(
+    "/by-id/:id",
+    zValidator("json", UpdateCompositionRequestBodySchema, validationError),
+    async (c) => {
+      const id = c.req.param("id");
+      const body = c.req.valid("json");
+      const composition = await updateComposition(id, body);
+      if (!composition) return notFound(c, "Composition not found");
+      return c.json(composition);
+    },
+  )
+  .get("/by-id/:id", async (c) => {
+    const id = c.req.param("id");
+    const composition = await fetchCompositionById(id);
+    if (!composition) return notFound(c, "Composition not found");
+    return c.json(composition);
+  })
+  .get("/by-shoot/:shootId", async (c) => {
+    const shootId = c.req.param("shootId");
+    const compositions = await fetchCompositionsByShoot(shootId);
+    return c.json(compositions);
+  })
+  .delete("/by-id/:id", async (c) => {
+    const id = c.req.param("id");
+    const success = await deleteComposition(id);
+    if (!success) return notFound(c, "Composition not found");
+    return c.json({ success: true });
+  });

--- a/@fanslib/apps/server/src/features/library/entity.ts
+++ b/@fanslib/apps/server/src/features/library/entity.ts
@@ -46,6 +46,12 @@ export class Media {
   @Column({ type: "text", nullable: true, name: "description" })
   description: string | null = null;
 
+  @Column({ type: "varchar", default: "library", name: "category" })
+  category: "library" | "footage" = "library";
+
+  @Column({ type: "text", nullable: true, name: "note" })
+  note: string | null = null;
+
   @Column({ type: "boolean", default: false, name: "excluded" })
   excluded: boolean = false;
 

--- a/@fanslib/apps/server/src/features/library/fixtures-data.ts
+++ b/@fanslib/apps/server/src/features/library/fixtures-data.ts
@@ -17,6 +17,8 @@ export type MediaFixture = Omit<
   | "isManaged"
   | "derivedFromId"
   | "derivedFrom"
+  | "category"
+  | "note"
 >;
 
 export const MEDIA_FIXTURES: MediaFixture[] = [

--- a/@fanslib/apps/server/src/features/library/operations/media/check-composition-refs.ts
+++ b/@fanslib/apps/server/src/features/library/operations/media/check-composition-refs.ts
@@ -1,0 +1,19 @@
+import { db } from "../../../../lib/db";
+import { Composition } from "../../../compositions/entity";
+
+/**
+ * Find compositions that reference a media ID in their segments.
+ * Returns composition IDs, or empty array if none.
+ */
+export const findCompositionReferences = async (mediaId: string): Promise<string[]> => {
+  const dataSource = await db();
+  const repo = dataSource.getRepository(Composition);
+  const compositions = await repo.find();
+
+  return compositions
+    .filter((c) => {
+      const segments = c.segments as Array<{ sourceMediaId?: string }>;
+      return segments.some((s) => s.sourceMediaId === mediaId);
+    })
+    .map((c) => c.id);
+};

--- a/@fanslib/apps/server/src/features/library/operations/media/create.ts
+++ b/@fanslib/apps/server/src/features/library/operations/media/create.ts
@@ -9,6 +9,8 @@ export const createMedia = async ({
   duration,
   fileCreationDate,
   fileModificationDate,
+  category,
+  note,
 }: {
   relativePath: string;
   name: string;
@@ -17,6 +19,8 @@ export const createMedia = async ({
   duration?: number;
   fileCreationDate: Date;
   fileModificationDate: Date;
+  category?: "library" | "footage";
+  note?: string;
 }) => {
   const dataSource = await db();
   const repository = dataSource.getRepository(Media);
@@ -29,6 +33,8 @@ export const createMedia = async ({
     duration,
     fileCreationDate,
     fileModificationDate,
+    ...(category ? { category } : {}),
+    ...(note ? { note } : {}),
   });
 
   return repository.save(media);

--- a/@fanslib/apps/server/src/features/library/operations/upload/index.ts
+++ b/@fanslib/apps/server/src/features/library/operations/upload/index.ts
@@ -55,9 +55,11 @@ const resolveUniqueFilename = async (dir: string, filename: string): Promise<str
 export type UploadMediaInput = {
   shootId: string;
   file: File;
+  category?: "library" | "footage";
+  note?: string;
 };
 
-export const uploadMediaToShoot = async ({ shootId, file }: UploadMediaInput) => {
+export const uploadMediaToShoot = async ({ shootId, file, category = "library", note }: UploadMediaInput) => {
   const mediaPath = env().mediaPath;
 
   const database = await db();
@@ -73,7 +75,8 @@ export const uploadMediaToShoot = async ({ shootId, file }: UploadMediaInput) =>
   if (!type) throw new Error(`Cannot determine media type for: ${ext}`);
 
   const folderName = shootFolderName(shoot);
-  const targetDir = path.join(mediaPath, "shoots", folderName);
+  const baseDir = category === "footage" ? "footage" : "shoots";
+  const targetDir = path.join(mediaPath, baseDir, folderName);
   await fs.mkdir(targetDir, { recursive: true });
 
   const uniqueFilename = await resolveUniqueFilename(targetDir, file.name);
@@ -85,7 +88,7 @@ export const uploadMediaToShoot = async ({ shootId, file }: UploadMediaInput) =>
 
   const duration = type === "video" ? await getVideoDuration(absolutePath) : undefined;
 
-  const relativePath = path.join("shoots", folderName, uniqueFilename);
+  const relativePath = path.join(baseDir, folderName, uniqueFilename);
 
   const media = await createMedia({
     relativePath,
@@ -95,6 +98,8 @@ export const uploadMediaToShoot = async ({ shootId, file }: UploadMediaInput) =>
     duration,
     fileCreationDate: stats.birthtime,
     fileModificationDate: stats.mtime,
+    category,
+    note,
   });
 
   try {

--- a/@fanslib/apps/server/src/features/library/routes.test.ts
+++ b/@fanslib/apps/server/src/features/library/routes.test.ts
@@ -1,10 +1,14 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { Hono } from "hono";
+import { existsSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
 import "reflect-metadata";
 import { getTestDataSource, setupTestDatabase, teardownTestDatabase } from "../../lib/test-db";
 import { resetAllFixtures } from "../../lib/test-fixtures";
 import { devalueMiddleware } from "../../lib/devalue-middleware";
 import { parseResponse } from "../../test-utils/setup";
+import { Composition } from "../compositions/entity";
+import { Shoot } from "../shoots/entity";
 import { Media } from "./entity";
 import { MEDIA_FIXTURES } from "./fixtures-data";
 import { libraryRoutes } from "./routes";
@@ -354,6 +358,146 @@ describe("Library Routes", () => {
       const data = await parseResponse<{ previous: Media | null; next: Media | null }>(response);
       expect(data).toHaveProperty("previous");
       expect(data).toHaveProperty("next");
+    });
+  });
+
+  describe("Category defaults", () => {
+    test("existing media has category 'library' by default", async () => {
+      const fixtureMedia = MEDIA_FIXTURES[0];
+      if (!fixtureMedia) throw new Error("No fixtures");
+
+      const response = await app.request(`/api/media/by-id/${fixtureMedia.id}`);
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ category: string }>(response);
+      expect(data?.category).toBe("library");
+    });
+  });
+
+  describe("Footage upload", () => {
+    const TEST_MEDIA_DIR = join(import.meta.dir, "..", "..", "..", "tests", "fixtures", "test-media");
+
+    beforeEach(() => {
+      process.env.MEDIA_PATH = TEST_MEDIA_DIR;
+      if (existsSync(TEST_MEDIA_DIR)) rmSync(TEST_MEDIA_DIR, { recursive: true, force: true });
+      mkdirSync(TEST_MEDIA_DIR, { recursive: true });
+    });
+
+    afterAll(() => {
+      if (existsSync(TEST_MEDIA_DIR)) rmSync(TEST_MEDIA_DIR, { recursive: true, force: true });
+    });
+
+    test("uploads footage with category 'footage' and note", async () => {
+      // Create a shoot
+      const dataSource = getTestDataSource();
+      const shootRepo = dataSource.getRepository(Shoot);
+      const shoot = await shootRepo.save(
+        shootRepo.create({ name: "Footage Shoot", shootDate: new Date("2026-04-08") }),
+      );
+
+      const formData = new FormData();
+      formData.append("shootId", shoot.id);
+      formData.append("file", new Blob(["fake video"], { type: "video/mp4" }), "promo-clip.mp4");
+      formData.append("category", "footage");
+      formData.append("note", "Color-graded A-roll");
+
+      const response = await app.request("/api/media/upload", {
+        method: "POST",
+        body: formData,
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{
+        id: string;
+        category: string;
+        note: string | null;
+      }>(response);
+
+      expect(data?.category).toBe("footage");
+      expect(data?.note).toBe("Color-graded A-roll");
+    });
+
+    test("footage is stored in footage/ directory, not shoots/", async () => {
+      const dataSource = getTestDataSource();
+      const shootRepo = dataSource.getRepository(Shoot);
+      const shoot = await shootRepo.save(
+        shootRepo.create({ name: "Dir Test", shootDate: new Date("2026-04-08") }),
+      );
+
+      const formData = new FormData();
+      formData.append("shootId", shoot.id);
+      formData.append("file", new Blob(["fake"], { type: "video/mp4" }), "clip.mp4");
+      formData.append("category", "footage");
+
+      const response = await app.request("/api/media/upload", {
+        method: "POST",
+        body: formData,
+      });
+      const data = await parseResponse<{ relativePath: string }>(response);
+
+      expect(data?.relativePath).toMatch(/^footage\//);
+      expect(data?.relativePath).not.toMatch(/^shoots\//);
+    });
+
+    test("warns when deleting footage referenced by a composition", async () => {
+      const dataSource = getTestDataSource();
+      const shootRepo = dataSource.getRepository(Shoot);
+      const shoot = await shootRepo.save(
+        shootRepo.create({ name: "Warn Shoot", shootDate: new Date("2026-04-08") }),
+      );
+
+      // Upload footage
+      const formData = new FormData();
+      formData.append("shootId", shoot.id);
+      formData.append("file", new Blob(["fake"], { type: "video/mp4" }), "ref.mp4");
+      formData.append("category", "footage");
+      const uploadResponse = await app.request("/api/media/upload", {
+        method: "POST",
+        body: formData,
+      });
+      const footage = await parseResponse<{ id: string }>(uploadResponse);
+
+      // Create a composition referencing this footage in a segment
+      const compRepo = dataSource.getRepository(Composition);
+      await compRepo.save(
+        compRepo.create({
+          shootId: shoot.id,
+          name: "Uses Footage",
+          segments: [{ id: "seg-1", sourceMediaId: footage?.id, sourceStartFrame: 0, sourceEndFrame: 900 }],
+          tracks: [],
+          exportRegions: [],
+        }),
+      );
+
+      // Try to delete — should get a warning
+      const deleteResponse = await app.request(`/api/media/by-id/${footage?.id}`, {
+        method: "DELETE",
+      });
+      expect(deleteResponse.status).toBe(409);
+
+      const data = await parseResponse<{ error: string; compositionIds: string[] }>(deleteResponse);
+      expect(data?.error).toContain("referenced");
+      expect(data?.compositionIds).toHaveLength(1);
+    });
+
+    test("library upload still uses shoots/ directory", async () => {
+      const dataSource = getTestDataSource();
+      const shootRepo = dataSource.getRepository(Shoot);
+      const shoot = await shootRepo.save(
+        shootRepo.create({ name: "Lib Test", shootDate: new Date("2026-04-08") }),
+      );
+
+      const formData = new FormData();
+      formData.append("shootId", shoot.id);
+      formData.append("file", new Blob(["fake"], { type: "video/mp4" }), "clip.mp4");
+
+      const response = await app.request("/api/media/upload", {
+        method: "POST",
+        body: formData,
+      });
+      const data = await parseResponse<{ relativePath: string }>(response);
+
+      expect(data?.relativePath).toMatch(/^shoots\//);
     });
   });
 });

--- a/@fanslib/apps/server/src/features/library/routes.ts
+++ b/@fanslib/apps/server/src/features/library/routes.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { promises as fs } from "fs";
 import path from "path";
 import { validationError, notFound } from "../../lib/hono-utils";
+import { findCompositionReferences } from "./operations/media/check-composition-refs";
 import { deleteMedia } from "./operations/media/delete";
 import { fetchAllMedia } from "./operations/media/fetch-all";
 import { fetchMediaById } from "./operations/media/fetch-by-id";
@@ -153,6 +154,19 @@ export const libraryRoutes = new Hono()
   .delete("/by-id/:id", zValidator("query", DeleteMediaQuerySchema, validationError), async (c) => {
     const id = c.req.param("id");
     const query = c.req.valid("query");
+
+    // Check if media is referenced by any composition segments
+    const compositionIds = await findCompositionReferences(id);
+    if (compositionIds.length > 0) {
+      return c.json(
+        {
+          error: "Media is referenced by compositions and cannot be deleted",
+          compositionIds,
+        },
+        409,
+      );
+    }
+
     const deleteFile = query.deleteFile === "true";
     const success = await deleteMedia(id, deleteFile);
     if (!success) {
@@ -195,8 +209,16 @@ export const libraryRoutes = new Hono()
       return c.json({ error: "file is required" }, 400);
     }
 
+    const category = formData.get("category");
+    const note = formData.get("note");
+
     try {
-      const media = await uploadMediaToShoot({ shootId, file });
+      const media = await uploadMediaToShoot({
+        shootId,
+        file,
+        category: category === "footage" ? "footage" : "library",
+        note: typeof note === "string" ? note : undefined,
+      });
       return c.json(media);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Upload failed";

--- a/@fanslib/apps/server/src/features/library/schema.ts
+++ b/@fanslib/apps/server/src/features/library/schema.ts
@@ -13,6 +13,8 @@ export const MediaSchema = z.object({
   duration: z.number().nullable(),
   redgifsUrl: z.string().nullable(),
   description: z.string().nullable(),
+  category: z.enum(["library", "footage"]).default("library"),
+  note: z.string().nullable().default(null),
   excluded: z.boolean().default(false),
   contentRating: ContentRatingSchema.nullable().default(null),
   package: z.string().nullable().default(null),

--- a/@fanslib/apps/server/src/index.ts
+++ b/@fanslib/apps/server/src/index.ts
@@ -9,6 +9,7 @@ import { analyticsRoutes } from "./features/analytics/routes";
 import { assetsRoutes } from "./features/assets/routes";
 import { candidatesRoutes } from "./features/analytics/candidates/routes";
 import { channelsRoutes } from "./features/channels/routes";
+import { compositionsRoutes } from "./features/compositions/routes";
 import { contentSchedulesRoutes } from "./features/content-schedules/routes";
 import { filterPresetsRoutes } from "./features/filter-presets/routes";
 import { hashtagsRoutes } from "./features/hashtags/routes";
@@ -89,6 +90,7 @@ const app = new Hono()
   .route("/", subredditsRoutes)
   .route("/", tagsRoutes)
   .route("/", channelsRoutes)
+  .route("/", compositionsRoutes)
   .route("/", contentSchedulesRoutes)
   .route("/", libraryRoutes)
   .route("/", organizeRoutes)

--- a/@fanslib/apps/server/src/lib/db.ts
+++ b/@fanslib/apps/server/src/lib/db.ts
@@ -7,6 +7,7 @@ import "reflect-metadata";
 import initSqlJs from "sql.js";
 import { DataSource } from "typeorm";
 import { Asset } from "../features/assets/entity";
+import { Composition } from "../features/compositions/entity";
 import { FanslyMediaCandidate } from "../features/analytics/candidate-entity";
 import { FanslyAnalyticsAggregate, FanslyAnalyticsDatapoint } from "../features/analytics/entity";
 import { Channel, ChannelType } from "../features/channels/entity";
@@ -80,6 +81,7 @@ const createAppDataSource = (driver?: Awaited<ReturnType<typeof initSqlJs>>) => 
     ...(driver ? { driver } : {}),
     entities: [
       Asset,
+      Composition,
       Media,
       MediaEdit,
       Post,

--- a/@fanslib/apps/server/src/lib/test-db.ts
+++ b/@fanslib/apps/server/src/lib/test-db.ts
@@ -2,6 +2,7 @@
 import initSqlJs from "sql.js";
 import { DataSource } from "typeorm";
 import { Asset } from "../features/assets/entity";
+import { Composition } from "../features/compositions/entity";
 import { FanslyMediaCandidate } from "../features/analytics/candidate-entity";
 import { FanslyAnalyticsAggregate, FanslyAnalyticsDatapoint } from "../features/analytics/entity";
 import { Channel, ChannelType } from "../features/channels/entity";
@@ -39,6 +40,7 @@ export const createTestDataSource = (driver?: Awaited<ReturnType<typeof initSqlJ
     ...(driver ? { driver } : {}),
     entities: [
       Asset,
+      Composition,
       Media,
       MediaEdit,
       Post,
@@ -118,6 +120,7 @@ export const clearAllTables = async () => {
     "CaptionSnippet",
     "Subreddit",
     "Channel",
+    "Composition",
     "Shoot",
     "TagDefinition",
     "TagDimension",

--- a/@fanslib/apps/web/src/features/editor/components/CompositionEditor.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/CompositionEditor.tsx
@@ -3,6 +3,25 @@ import { useCompositionByIdQuery } from "~/lib/queries/compositions";
 import { useEditorStore } from "~/stores/editorStore";
 import { SourceBin } from "./SourceBin";
 
+const SourceModeIndicator = () => {
+  const selectedSourceId = useEditorStore((s) => s.selectedSourceId);
+  const pendingSourceMarkIn = useEditorStore((s) => s.pendingSourceMarkIn);
+
+  if (!selectedSourceId) return null;
+
+  return (
+    <div className="bg-muted/50 border-b px-4 py-2 text-sm" data-testid="source-mode-indicator">
+      <span className="text-muted-foreground">Source: </span>
+      <span className="font-medium">{selectedSourceId}</span>
+      {pendingSourceMarkIn !== null && (
+        <span className="text-muted-foreground ml-2">
+          Mark In: {pendingSourceMarkIn}
+        </span>
+      )}
+    </div>
+  );
+};
+
 type CompositionEditorProps = {
   shootId: string;
   compositionId: string;
@@ -58,7 +77,9 @@ export const CompositionEditor = ({ shootId, compositionId }: CompositionEditorP
         <aside className="border-r w-64 overflow-y-auto">
           <SourceBin shootId={shootId} />
         </aside>
-        <div className="flex-1" />
+        <div className="flex-1">
+          <SourceModeIndicator />
+        </div>
       </div>
     </div>
   );

--- a/@fanslib/apps/web/src/features/editor/components/CompositionEditor.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/CompositionEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useCompositionByIdQuery } from "~/lib/queries/compositions";
 import { useEditorStore } from "~/stores/editorStore";
+import { SourceBin } from "./SourceBin";
 
 type CompositionEditorProps = {
   shootId: string;
@@ -52,6 +53,12 @@ export const CompositionEditor = ({ shootId, compositionId }: CompositionEditorP
         <p className="text-muted-foreground text-sm">
           Shoot: {shootId} &middot; {composition.segments.length} segment{composition.segments.length !== 1 ? "s" : ""}
         </p>
+      </div>
+      <div className="flex min-h-0 flex-1">
+        <aside className="border-r w-64 overflow-y-auto">
+          <SourceBin shootId={shootId} />
+        </aside>
+        <div className="flex-1" />
       </div>
     </div>
   );

--- a/@fanslib/apps/web/src/features/editor/components/CompositionEditor.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/CompositionEditor.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from "react";
+import { useCompositionByIdQuery } from "~/lib/queries/compositions";
+import { useEditorStore } from "~/stores/editorStore";
+
+type CompositionEditorProps = {
+  shootId: string;
+  compositionId: string;
+};
+
+export const CompositionEditor = ({ shootId, compositionId }: CompositionEditorProps) => {
+  const { data: composition, isLoading, error } = useCompositionByIdQuery(compositionId);
+  const hydrate = useEditorStore((s) => s.hydrate);
+  const reset = useEditorStore((s) => s.reset);
+
+  useEffect(() => {
+    if (!composition) return;
+    // The API returns JSONValue[] for tracks/segments; runtime shapes match the store types.
+    hydrate({
+      tracks: composition.tracks,
+      segments: composition.segments,
+    } as Parameters<typeof hydrate>[0]);
+  }, [composition, hydrate]);
+
+  useEffect(() => {
+    return () => {
+      reset();
+    };
+  }, [reset]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center" data-testid="composition-loading">
+        <p className="text-muted-foreground">Loading composition...</p>
+      </div>
+    );
+  }
+
+  if (error || !composition) {
+    return (
+      <div className="flex h-full items-center justify-center" data-testid="composition-error">
+        <p className="text-destructive">
+          {error?.message ?? "Composition not found"}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col" data-testid="composition-editor">
+      <div className="border-b p-4">
+        <h1 className="text-lg font-semibold">{composition.name}</h1>
+        <p className="text-muted-foreground text-sm">
+          Shoot: {shootId} &middot; {composition.segments.length} segment{composition.segments.length !== 1 ? "s" : ""}
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/features/editor/components/CompositionEditor.vitest.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/CompositionEditor.vitest.tsx
@@ -1,0 +1,139 @@
+/// <reference types="@testing-library/jest-dom" />
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+
+// Mock the composition query hook
+vi.mock("~/lib/queries/compositions", () => ({
+  useCompositionByIdQuery: vi.fn(),
+}));
+
+// Mock the editor store
+const mockHydrate = vi.fn();
+const mockReset = vi.fn();
+vi.mock("~/stores/editorStore", () => ({
+  useEditorStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ hydrate: mockHydrate, reset: mockReset }),
+  ),
+}));
+
+import { useCompositionByIdQuery } from "~/lib/queries/compositions";
+
+// Import after mocks
+import { CompositionEditor } from "./CompositionEditor";
+
+const mockUseCompositionByIdQuery = vi.mocked(useCompositionByIdQuery);
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const makeComposition = (overrides?: Record<string, unknown>) => ({
+  id: "comp-1",
+  shootId: "shoot-1",
+  name: "My Composition",
+  segments: [
+    { id: "seg-1", sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 150 },
+    { id: "seg-2", sourceMediaId: "media-2", sourceStartFrame: 30, sourceEndFrame: 120 },
+  ],
+  tracks: [{ id: "track-1", name: "Track 1", operations: [] }],
+  exportRegions: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("CompositionEditor", () => {
+  test("shows loading state initially", () => {
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useCompositionByIdQuery>);
+
+    render(<CompositionEditor shootId="shoot-1" compositionId="comp-1" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByTestId("composition-loading")).toBeInTheDocument();
+    expect(screen.getByText("Loading composition...")).toBeInTheDocument();
+  });
+
+  test("shows error when composition not found", () => {
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("Composition not found"),
+    } as ReturnType<typeof useCompositionByIdQuery>);
+
+    render(<CompositionEditor shootId="shoot-1" compositionId="comp-1" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByTestId("composition-error")).toBeInTheDocument();
+    expect(screen.getByText("Composition not found")).toBeInTheDocument();
+  });
+
+  test("renders composition name when data loads", () => {
+    const composition = makeComposition();
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: composition,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCompositionByIdQuery>);
+
+    render(<CompositionEditor shootId="shoot-1" compositionId="comp-1" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByTestId("composition-editor")).toBeInTheDocument();
+    expect(screen.getByText("My Composition")).toBeInTheDocument();
+    expect(screen.getByText(/2 segments/)).toBeInTheDocument();
+  });
+
+  test("hydrates the editor store when composition loads", async () => {
+    const composition = makeComposition();
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: composition,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCompositionByIdQuery>);
+
+    render(<CompositionEditor shootId="shoot-1" compositionId="comp-1" />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(mockHydrate).toHaveBeenCalledWith({
+        tracks: composition.tracks,
+        segments: composition.segments,
+      });
+    });
+  });
+
+  test("resets the store on unmount", () => {
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useCompositionByIdQuery>);
+
+    const { unmount } = render(
+      <CompositionEditor shootId="shoot-1" compositionId="comp-1" />,
+      { wrapper: createWrapper() },
+    );
+
+    unmount();
+    expect(mockReset).toHaveBeenCalled();
+  });
+});

--- a/@fanslib/apps/web/src/features/editor/components/SourceBin.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/SourceBin.tsx
@@ -1,0 +1,110 @@
+import { useShootQuery } from "~/lib/queries/shoots";
+import { useEditorStore } from "~/stores/editorStore";
+
+type SourceMedia = {
+  id: string;
+  name: string;
+  category: "library" | "footage";
+  note: string | null;
+};
+
+type SourceBinProps = {
+  shootId: string;
+};
+
+export const SourceBin = ({ shootId }: SourceBinProps) => {
+  const { data: shoot } = useShootQuery({ id: shootId });
+  const selectedSourceId = useEditorStore((s) => s.selectedSourceId);
+  const selectSource = useEditorStore((s) => s.selectSource);
+
+  if (!shoot) return null;
+
+  const allMedia = (shoot as { media?: SourceMedia[] }).media ?? [];
+  const libraryMedia = allMedia.filter((m) => m.category !== "footage");
+  const footageMedia = allMedia.filter((m) => m.category === "footage");
+
+  const handleClick = (mediaId: string) => {
+    selectSource(selectedSourceId === mediaId ? null : mediaId);
+  };
+
+  return (
+    <div className="flex flex-col gap-4 overflow-y-auto p-3" data-testid="source-bin">
+      {libraryMedia.length > 0 && (
+        <section>
+          <h3 className="text-muted-foreground mb-2 text-xs font-semibold uppercase tracking-wider">
+            Media
+          </h3>
+          <ul className="flex flex-col gap-1">
+            {libraryMedia.map((media) => (
+              <SourceItem
+                key={media.id}
+                media={media}
+                isSelected={selectedSourceId === media.id}
+                onClick={() => handleClick(media.id)}
+              />
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {footageMedia.length > 0 && (
+        <section>
+          <h3 className="text-muted-foreground mb-2 text-xs font-semibold uppercase tracking-wider">
+            Footage
+          </h3>
+          <ul className="flex flex-col gap-1">
+            {footageMedia.map((media) => (
+              <SourceItem
+                key={media.id}
+                media={media}
+                isSelected={selectedSourceId === media.id}
+                onClick={() => handleClick(media.id)}
+                showBadge
+              />
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+};
+
+type SourceItemProps = {
+  media: SourceMedia;
+  isSelected: boolean;
+  onClick: () => void;
+  showBadge?: boolean;
+};
+
+const SourceItem = ({ media, isSelected, onClick, showBadge }: SourceItemProps) => (
+  <li>
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex w-full items-start gap-2 rounded-md p-2 text-left text-sm transition-colors ${
+        isSelected
+          ? "bg-accent text-accent-foreground ring-ring ring-1"
+          : "hover:bg-muted"
+      }`}
+    >
+      <img
+        src={`/api/media/${media.id}/thumbnail`}
+        alt={media.name}
+        className="h-10 w-14 flex-shrink-0 rounded object-cover"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <span className="truncate font-medium">{media.name}</span>
+          {showBadge && (
+            <span className="bg-muted text-muted-foreground flex-shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium">
+              Footage
+            </span>
+          )}
+        </div>
+        {media.note && (
+          <p className="text-muted-foreground mt-0.5 truncate text-xs">{media.note}</p>
+        )}
+      </div>
+    </button>
+  </li>
+);

--- a/@fanslib/apps/web/src/features/editor/components/SourceBin.vitest.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/SourceBin.vitest.tsx
@@ -1,0 +1,144 @@
+/// <reference types="@testing-library/jest-dom" />
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// Mock the shoot query hook
+vi.mock("~/lib/queries/shoots", () => ({
+  useShootQuery: vi.fn(),
+}));
+
+// Mock the editor store
+const mockSelectSource = vi.fn();
+let mockSelectedSourceId: string | null = null;
+
+vi.mock("~/stores/editorStore", () => ({
+  useEditorStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ selectedSourceId: mockSelectedSourceId, selectSource: mockSelectSource }),
+  ),
+}));
+
+import { useShootQuery } from "~/lib/queries/shoots";
+
+// Import after mocks
+import { SourceBin } from "./SourceBin";
+
+const mockUseShootQuery = vi.mocked(useShootQuery);
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const makeShootData = () => ({
+  id: "shoot-1",
+  name: "Test Shoot",
+  media: [
+    { id: "media-1", name: "clip-a.mp4", category: "library" as const, note: null },
+    { id: "media-2", name: "clip-b.mp4", category: "library" as const, note: null },
+    { id: "media-3", name: "footage-1.mp4", category: "footage" as const, note: "Wide angle establishing shot" },
+    { id: "media-4", name: "footage-2.mp4", category: "footage" as const, note: null },
+  ],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSelectedSourceId = null;
+});
+
+describe("SourceBin", () => {
+  test("renders media names from shoot", () => {
+    const shoot = makeShootData();
+    mockUseShootQuery.mockReturnValue({
+      data: shoot,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useShootQuery>);
+
+    render(<SourceBin shootId="shoot-1" />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("clip-a.mp4")).toBeInTheDocument();
+    expect(screen.getByText("clip-b.mp4")).toBeInTheDocument();
+    expect(screen.getByText("footage-1.mp4")).toBeInTheDocument();
+    expect(screen.getByText("footage-2.mp4")).toBeInTheDocument();
+  });
+
+  test("renders footage with notes", () => {
+    const shoot = makeShootData();
+    mockUseShootQuery.mockReturnValue({
+      data: shoot,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useShootQuery>);
+
+    render(<SourceBin shootId="shoot-1" />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("Wide angle establishing shot")).toBeInTheDocument();
+  });
+
+  test("renders section headings", () => {
+    const shoot = makeShootData();
+    mockUseShootQuery.mockReturnValue({
+      data: shoot,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useShootQuery>);
+
+    render(<SourceBin shootId="shoot-1" />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("Media")).toBeInTheDocument();
+    // "Footage" appears as both heading and badges; just verify it's present
+    expect(screen.getAllByText("Footage").length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("clicking a source calls selectSource", async () => {
+    const shoot = makeShootData();
+    mockUseShootQuery.mockReturnValue({
+      data: shoot,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useShootQuery>);
+
+    render(<SourceBin shootId="shoot-1" />, { wrapper: createWrapper() });
+
+    await userEvent.click(screen.getByText("clip-a.mp4"));
+    expect(mockSelectSource).toHaveBeenCalledWith("media-1");
+  });
+
+  test("clicking selected source calls selectSource(null)", async () => {
+    mockSelectedSourceId = "media-1";
+    const shoot = makeShootData();
+    mockUseShootQuery.mockReturnValue({
+      data: shoot,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useShootQuery>);
+
+    render(<SourceBin shootId="shoot-1" />, { wrapper: createWrapper() });
+
+    await userEvent.click(screen.getByText("clip-a.mp4"));
+    expect(mockSelectSource).toHaveBeenCalledWith(null);
+  });
+
+  test("renders footage badge for footage items", () => {
+    const shoot = makeShootData();
+    mockUseShootQuery.mockReturnValue({
+      data: shoot,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useShootQuery>);
+
+    render(<SourceBin shootId="shoot-1" />, { wrapper: createWrapper() });
+
+    // Footage items should have a "Footage" badge
+    const badges = screen.getAllByText("Footage");
+    // "Footage" heading + 2 footage badges
+    expect(badges.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/@fanslib/apps/web/src/features/editor/utils/sequence-engine.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/sequence-engine.ts
@@ -1,0 +1,80 @@
+export type Segment = {
+  id: string;
+  sourceMediaId: string;
+  sourceStartFrame: number;
+  sourceEndFrame: number;
+  transition?: {
+    type: "crossfade";
+    durationFrames: number;
+  };
+};
+
+export type SequencePosition = {
+  segmentId: string;
+  sequenceStartFrame: number;
+  sequenceEndFrame: number;
+};
+
+export type SequenceTimeline = {
+  positions: SequencePosition[];
+  totalDuration: number;
+};
+
+export type SourceFrameMapping = {
+  segmentId: string;
+  sourceMediaId: string;
+  sourceFrame: number;
+};
+
+export const mapSequenceFrameToSource = (
+  sequenceFrame: number,
+  timeline: SequenceTimeline,
+  segments: Segment[],
+): SourceFrameMapping[] =>
+  timeline.positions.reduce<SourceFrameMapping[]>((results, position, i) => {
+    const segment = segments[i]!;
+    if (sequenceFrame >= position.sequenceStartFrame && sequenceFrame < position.sequenceEndFrame) {
+      const offsetInSegment = sequenceFrame - position.sequenceStartFrame;
+      return [
+        ...results,
+        {
+          segmentId: segment.id,
+          sourceMediaId: segment.sourceMediaId,
+          sourceFrame: segment.sourceStartFrame + offsetInSegment,
+        },
+      ];
+    }
+    return results;
+  }, []);
+
+export const computeSequenceTimeline = (segments: Segment[]): SequenceTimeline => {
+  if (segments.length === 0) {
+    return { positions: [], totalDuration: 0 };
+  }
+
+  const positions = segments.reduce<{ positions: SequencePosition[]; cursor: number }>(
+    (acc, segment, i) => {
+      const segmentDuration = segment.sourceEndFrame - segment.sourceStartFrame;
+      const overlap = i > 0 && segment.transition ? segment.transition.durationFrames : 0;
+      const start = acc.cursor - overlap;
+
+      return {
+        positions: [
+          ...acc.positions,
+          {
+            segmentId: segment.id,
+            sequenceStartFrame: start,
+            sequenceEndFrame: start + segmentDuration,
+          },
+        ],
+        cursor: start + segmentDuration,
+      };
+    },
+    { positions: [], cursor: 0 },
+  );
+
+  return {
+    positions: positions.positions,
+    totalDuration: positions.cursor,
+  };
+};

--- a/@fanslib/apps/web/src/features/editor/utils/sequence-engine.vitest.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/sequence-engine.vitest.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "vitest";
+import { computeSequenceTimeline, mapSequenceFrameToSource } from "./sequence-engine";
+
+describe("sequence engine", () => {
+  describe("computeSequenceTimeline", () => {
+    test("single segment starts at frame 0", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+      ]);
+      expect(result.totalDuration).toBe(300);
+    });
+
+    test("crossfade transition causes segment overlap", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        {
+          id: "s2",
+          sourceMediaId: "m2",
+          sourceStartFrame: 0,
+          sourceEndFrame: 200,
+          transition: { type: "crossfade", durationFrames: 30 },
+        },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+        { segmentId: "s2", sequenceStartFrame: 270, sequenceEndFrame: 470 },
+      ]);
+      expect(result.totalDuration).toBe(470);
+    });
+
+    test("three segments with mixed transitions", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+        {
+          id: "s3",
+          sourceMediaId: "m3",
+          sourceStartFrame: 100,
+          sourceEndFrame: 250,
+          transition: { type: "crossfade", durationFrames: 20 },
+        },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+        { segmentId: "s2", sequenceStartFrame: 300, sequenceEndFrame: 500 },
+        { segmentId: "s3", sequenceStartFrame: 480, sequenceEndFrame: 630 },
+      ]);
+      expect(result.totalDuration).toBe(630);
+    });
+
+    test("total duration with crossfade is reduced by overlap amount", () => {
+      const withoutCrossfade = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ]);
+
+      const withCrossfade = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        {
+          id: "s2",
+          sourceMediaId: "m2",
+          sourceStartFrame: 0,
+          sourceEndFrame: 200,
+          transition: { type: "crossfade", durationFrames: 30 },
+        },
+      ]);
+
+      expect(withoutCrossfade.totalDuration - withCrossfade.totalDuration).toBe(30);
+    });
+
+    test("empty segments array returns totalDuration 0 and empty positions", () => {
+      const result = computeSequenceTimeline([]);
+
+      expect(result.positions).toEqual([]);
+      expect(result.totalDuration).toBe(0);
+    });
+
+    test("two segments with hard cuts are contiguous", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+        { segmentId: "s2", sequenceStartFrame: 300, sequenceEndFrame: 500 },
+      ]);
+      expect(result.totalDuration).toBe(500);
+    });
+  });
+
+  describe("mapSequenceFrameToSource", () => {
+    test("returns correct segment and source frame for frame in first segment", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 100, sourceEndFrame: 400 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ] as const;
+      const timeline = computeSequenceTimeline([...segments]);
+
+      const result = mapSequenceFrameToSource(50, timeline, [...segments]);
+
+      expect(result).toEqual([
+        { segmentId: "s1", sourceMediaId: "m1", sourceFrame: 150 },
+      ]);
+    });
+    test("during crossfade overlap returns both segments with correct source frames", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        {
+          id: "s2",
+          sourceMediaId: "m2",
+          sourceStartFrame: 0,
+          sourceEndFrame: 200,
+          transition: { type: "crossfade" as const, durationFrames: 30 },
+        },
+      ];
+      const timeline = computeSequenceTimeline(segments);
+
+      // s1: 0-300, s2: 270-470. Frame 280 is in the overlap region (270-300).
+      const result = mapSequenceFrameToSource(280, timeline, segments);
+
+      expect(result).toEqual([
+        { segmentId: "s1", sourceMediaId: "m1", sourceFrame: 280 },
+        { segmentId: "s2", sourceMediaId: "m2", sourceFrame: 10 },
+      ]);
+    });
+
+    test("frame exactly at hard-cut segment boundary belongs to second segment", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ];
+      const timeline = computeSequenceTimeline(segments);
+
+      // s1: [0, 300), s2: [300, 500). Frame 300 is the boundary.
+      const result = mapSequenceFrameToSource(300, timeline, segments);
+
+      expect(result).toEqual([
+        { segmentId: "s2", sourceMediaId: "m2", sourceFrame: 0 },
+      ]);
+    });
+
+    test("returns correct segment for frame in second segment after hard cut", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 50, sourceEndFrame: 250 },
+      ] as const;
+      const timeline = computeSequenceTimeline([...segments]);
+
+      const result = mapSequenceFrameToSource(350, timeline, [...segments]);
+
+      expect(result).toEqual([
+        { segmentId: "s2", sourceMediaId: "m2", sourceFrame: 100 },
+      ]);
+    });
+    test("single segment with 0-duration transition is ignored", () => {
+      const segments = [
+        {
+          id: "s1",
+          sourceMediaId: "m1",
+          sourceStartFrame: 0,
+          sourceEndFrame: 300,
+          transition: { type: "crossfade" as const, durationFrames: 0 },
+        },
+      ];
+      const timeline = computeSequenceTimeline(segments);
+
+      expect(timeline.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+      ]);
+      expect(timeline.totalDuration).toBe(300);
+    });
+  });
+});

--- a/@fanslib/apps/web/src/lib/queries/compositions.ts
+++ b/@fanslib/apps/web/src/lib/queries/compositions.ts
@@ -1,0 +1,23 @@
+import type { InferResponseType } from "hono";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/hono-client";
+import { QUERY_KEYS } from "./query-keys";
+
+type CompositionByIdResponse = InferResponseType<
+  (typeof api.api.compositions)["by-id"][":id"]["$get"],
+  200
+>;
+
+export type Composition = CompositionByIdResponse;
+
+export const useCompositionByIdQuery = (compositionId: string) =>
+  useQuery({
+    queryKey: QUERY_KEYS.compositions.byId(compositionId),
+    queryFn: async (): Promise<CompositionByIdResponse> => {
+      const result = await api.api.compositions["by-id"][":id"].$get({
+        param: { id: compositionId },
+      });
+      return result.json() as Promise<CompositionByIdResponse>;
+    },
+    enabled: !!compositionId,
+  });

--- a/@fanslib/apps/web/src/lib/queries/query-keys.ts
+++ b/@fanslib/apps/web/src/lib/queries/query-keys.ts
@@ -177,6 +177,11 @@ export const QUERY_KEYS = {
     health: () => ["companion", "health"] as const,
   },
 
+  compositions: {
+    byId: (id: string) => ["compositions", id] as const,
+    byShoot: (shootId: string) => ["shoots", "compositions", shootId] as const,
+  },
+
   organize: {
     unmanaged: () => ["organize", "unmanaged"] as const,
     knownRoles: () => ["organize", "known-roles"] as const,

--- a/@fanslib/apps/web/src/routeTree.gen.ts
+++ b/@fanslib/apps/web/src/routeTree.gen.ts
@@ -44,6 +44,7 @@ import { Route as ContentLibraryOrganizeRouteImport } from './routes/content/lib
 import { Route as ContentLibraryMediaRouteImport } from './routes/content/library/media'
 import { Route as LibraryMediaIdEditIndexRouteImport } from './routes/library/$mediaId/edit/index'
 import { Route as ContentLibraryMediaIndexRouteImport } from './routes/content/library/media/index'
+import { Route as ShootsShootIdCompositionsCompositionIdRouteImport } from './routes/shoots/$shootId/compositions/$compositionId'
 import { Route as LibraryMediaIdEditEditIdRouteImport } from './routes/library/$mediaId/edit/$editId'
 import { Route as ContentLibraryMediaMediaIdRouteImport } from './routes/content/library/media/$mediaId'
 
@@ -223,6 +224,12 @@ const ContentLibraryMediaIndexRoute =
     path: '/',
     getParentRoute: () => ContentLibraryMediaRoute,
   } as any)
+const ShootsShootIdCompositionsCompositionIdRoute =
+  ShootsShootIdCompositionsCompositionIdRouteImport.update({
+    id: '/compositions/$compositionId',
+    path: '/compositions/$compositionId',
+    getParentRoute: () => ShootsShootIdRoute,
+  } as any)
 const LibraryMediaIdEditEditIdRoute =
   LibraryMediaIdEditEditIdRouteImport.update({
     id: '/edit/$editId',
@@ -261,7 +268,7 @@ export interface FileRoutesByFullPath {
   '/settings/integrations': typeof SettingsIntegrationsRoute
   '/settings/repost': typeof SettingsRepostRoute
   '/settings/snippets': typeof SettingsSnippetsRoute
-  '/shoots/$shootId': typeof ShootsShootIdRoute
+  '/shoots/$shootId': typeof ShootsShootIdRouteWithChildren
   '/library/': typeof LibraryIndexRoute
   '/plan/': typeof PlanIndexRoute
   '/schedules/': typeof SchedulesIndexRoute
@@ -272,6 +279,7 @@ export interface FileRoutesByFullPath {
   '/library/$mediaId/': typeof LibraryMediaIdIndexRoute
   '/content/library/media/$mediaId': typeof ContentLibraryMediaMediaIdRoute
   '/library/$mediaId/edit/$editId': typeof LibraryMediaIdEditEditIdRoute
+  '/shoots/$shootId/compositions/$compositionId': typeof ShootsShootIdCompositionsCompositionIdRoute
   '/content/library/media/': typeof ContentLibraryMediaIndexRoute
   '/library/$mediaId/edit/': typeof LibraryMediaIdEditIndexRoute
 }
@@ -297,7 +305,7 @@ export interface FileRoutesByTo {
   '/settings/integrations': typeof SettingsIntegrationsRoute
   '/settings/repost': typeof SettingsRepostRoute
   '/settings/snippets': typeof SettingsSnippetsRoute
-  '/shoots/$shootId': typeof ShootsShootIdRoute
+  '/shoots/$shootId': typeof ShootsShootIdRouteWithChildren
   '/library': typeof LibraryIndexRoute
   '/plan': typeof PlanIndexRoute
   '/schedules': typeof SchedulesIndexRoute
@@ -307,6 +315,7 @@ export interface FileRoutesByTo {
   '/library/$mediaId': typeof LibraryMediaIdIndexRoute
   '/content/library/media/$mediaId': typeof ContentLibraryMediaMediaIdRoute
   '/library/$mediaId/edit/$editId': typeof LibraryMediaIdEditEditIdRoute
+  '/shoots/$shootId/compositions/$compositionId': typeof ShootsShootIdCompositionsCompositionIdRoute
   '/content/library/media': typeof ContentLibraryMediaIndexRoute
   '/library/$mediaId/edit': typeof LibraryMediaIdEditIndexRoute
 }
@@ -336,7 +345,7 @@ export interface FileRoutesById {
   '/settings/integrations': typeof SettingsIntegrationsRoute
   '/settings/repost': typeof SettingsRepostRoute
   '/settings/snippets': typeof SettingsSnippetsRoute
-  '/shoots/$shootId': typeof ShootsShootIdRoute
+  '/shoots/$shootId': typeof ShootsShootIdRouteWithChildren
   '/library/': typeof LibraryIndexRoute
   '/plan/': typeof PlanIndexRoute
   '/schedules/': typeof SchedulesIndexRoute
@@ -347,6 +356,7 @@ export interface FileRoutesById {
   '/library/$mediaId/': typeof LibraryMediaIdIndexRoute
   '/content/library/media/$mediaId': typeof ContentLibraryMediaMediaIdRoute
   '/library/$mediaId/edit/$editId': typeof LibraryMediaIdEditEditIdRoute
+  '/shoots/$shootId/compositions/$compositionId': typeof ShootsShootIdCompositionsCompositionIdRoute
   '/content/library/media/': typeof ContentLibraryMediaIndexRoute
   '/library/$mediaId/edit/': typeof LibraryMediaIdEditIndexRoute
 }
@@ -388,6 +398,7 @@ export interface FileRouteTypes {
     | '/library/$mediaId/'
     | '/content/library/media/$mediaId'
     | '/library/$mediaId/edit/$editId'
+    | '/shoots/$shootId/compositions/$compositionId'
     | '/content/library/media/'
     | '/library/$mediaId/edit/'
   fileRoutesByTo: FileRoutesByTo
@@ -423,6 +434,7 @@ export interface FileRouteTypes {
     | '/library/$mediaId'
     | '/content/library/media/$mediaId'
     | '/library/$mediaId/edit/$editId'
+    | '/shoots/$shootId/compositions/$compositionId'
     | '/content/library/media'
     | '/library/$mediaId/edit'
   id:
@@ -462,6 +474,7 @@ export interface FileRouteTypes {
     | '/library/$mediaId/'
     | '/content/library/media/$mediaId'
     | '/library/$mediaId/edit/$editId'
+    | '/shoots/$shootId/compositions/$compositionId'
     | '/content/library/media/'
     | '/library/$mediaId/edit/'
   fileRoutesById: FileRoutesById
@@ -480,7 +493,7 @@ export interface RootRouteChildren {
   FanslyFypRoute: typeof FanslyFypRoute
   LibraryMediaIdRoute: typeof LibraryMediaIdRouteWithChildren
   PostsPostIdRoute: typeof PostsPostIdRoute
-  ShootsShootIdRoute: typeof ShootsShootIdRoute
+  ShootsShootIdRoute: typeof ShootsShootIdRouteWithChildren
   LibraryIndexRoute: typeof LibraryIndexRoute
   PlanIndexRoute: typeof PlanIndexRoute
   ShootsIndexRoute: typeof ShootsIndexRoute
@@ -733,6 +746,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ContentLibraryMediaIndexRouteImport
       parentRoute: typeof ContentLibraryMediaRoute
     }
+    '/shoots/$shootId/compositions/$compositionId': {
+      id: '/shoots/$shootId/compositions/$compositionId'
+      path: '/compositions/$compositionId'
+      fullPath: '/shoots/$shootId/compositions/$compositionId'
+      preLoaderRoute: typeof ShootsShootIdCompositionsCompositionIdRouteImport
+      parentRoute: typeof ShootsShootIdRoute
+    }
     '/library/$mediaId/edit/$editId': {
       id: '/library/$mediaId/edit/$editId'
       path: '/edit/$editId'
@@ -848,6 +868,19 @@ const LibraryMediaIdRouteWithChildren = LibraryMediaIdRoute._addFileChildren(
   LibraryMediaIdRouteChildren,
 )
 
+interface ShootsShootIdRouteChildren {
+  ShootsShootIdCompositionsCompositionIdRoute: typeof ShootsShootIdCompositionsCompositionIdRoute
+}
+
+const ShootsShootIdRouteChildren: ShootsShootIdRouteChildren = {
+  ShootsShootIdCompositionsCompositionIdRoute:
+    ShootsShootIdCompositionsCompositionIdRoute,
+}
+
+const ShootsShootIdRouteWithChildren = ShootsShootIdRoute._addFileChildren(
+  ShootsShootIdRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CaptioningRoute: CaptioningRoute,
@@ -862,7 +895,7 @@ const rootRouteChildren: RootRouteChildren = {
   FanslyFypRoute: FanslyFypRoute,
   LibraryMediaIdRoute: LibraryMediaIdRouteWithChildren,
   PostsPostIdRoute: PostsPostIdRoute,
-  ShootsShootIdRoute: ShootsShootIdRoute,
+  ShootsShootIdRoute: ShootsShootIdRouteWithChildren,
   LibraryIndexRoute: LibraryIndexRoute,
   PlanIndexRoute: PlanIndexRoute,
   ShootsIndexRoute: ShootsIndexRoute,
@@ -870,12 +903,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}

--- a/@fanslib/apps/web/src/routes/shoots/$shootId/compositions/$compositionId.tsx
+++ b/@fanslib/apps/web/src/routes/shoots/$shootId/compositions/$compositionId.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { CompositionEditor } from "~/features/editor/components/CompositionEditor";
+
+const CompositionEditorRoute = () => {
+  const { shootId, compositionId } = Route.useParams();
+  return <CompositionEditor shootId={shootId} compositionId={compositionId} />;
+};
+
+export const Route = createFileRoute("/shoots/$shootId/compositions/$compositionId")({
+  component: CompositionEditorRoute,
+});

--- a/@fanslib/apps/web/src/stores/editorStore.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { type CropOperation, normalizeCropOperation } from "~/features/editor/utils/crop-operation";
+import type { Segment } from "~/features/editor/utils/sequence-engine";
 
 type Track = {
   id: string;
@@ -9,6 +10,8 @@ type Track = {
 
 type EditorState = {
   tracks: Track[];
+  segments: Segment[];
+  selectedSegmentId: string | null;
   operations: unknown[];
   selectedOperationIndex: number | null;
   selectedOperationId: string | null;
@@ -71,6 +74,14 @@ type EditorState = {
   // Watermark convenience
   addWatermark: (assetId: string) => void;
 
+  // Segment mutations
+  addSegment: (segment: Omit<Segment, "id">) => void;
+  removeSegment: (segmentId: string) => void;
+  reorderSegments: (segmentId: string, newIndex: number) => void;
+  trimSegmentStart: (segmentId: string, newSourceStartFrame: number) => void;
+  trimSegmentEnd: (segmentId: string, newSourceEndFrame: number) => void;
+  selectSegment: (segmentId: string | null) => void;
+
   // Track management
   addTrack: () => void;
   removeTrack: (trackId: string) => void;
@@ -86,15 +97,15 @@ type EditorState = {
   markClean: () => void;
 
   // Hydrate from existing MediaEdit
-  hydrate: (data: unknown[] | { tracks: Track[] }) => void;
-  // Restore tracks from unified history snapshot (does not touch per-store undo stacks)
-  restoreTracks: (tracks: unknown[]) => void;
+  hydrate: (data: unknown[] | { tracks: Track[]; segments?: Segment[] }) => void;
+  // Restore tracks (and optionally segments) from unified history snapshot (does not touch per-store undo stacks)
+  restoreTracks: (tracks: unknown[], segments?: Segment[]) => void;
 
   // Reset
   reset: () => void;
 };
 
-type HistoryEntry = Track[];
+type HistoryEntry = { tracks: Track[]; segments: Segment[] };
 
 const makeDefaultTrack = (): Track => ({
   id: crypto.randomUUID(),
@@ -158,8 +169,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
     return tracks.length - 1;
   };
 
+  const cloneSegments = (segments: Segment[]): Segment[] =>
+    segments.map((s) => ({ ...s, transition: s.transition ? { ...s.transition } : undefined }));
+
   const pushHistory = () => {
-    undoStack.push(cloneTracks(get().tracks));
+    const state = get();
+    undoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
     redoStack = []; // Clear redo on new mutation
   };
 
@@ -173,6 +188,8 @@ export const useEditorStore = create<EditorState>((set, get) => {
 
   return {
     tracks: [initialTrack],
+    segments: [],
+    selectedSegmentId: null,
     operations: [],
     selectedOperationIndex: null,
     selectedOperationId: null,
@@ -373,10 +390,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
     undo: () => {
       const previous = undoStack.pop();
       if (previous === undefined) return;
-      redoStack.push(cloneTracks(get().tracks));
+      const state = get();
+      redoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
       set({
-        tracks: previous,
-        operations: flattenTracks(previous),
+        tracks: previous.tracks,
+        segments: previous.segments,
+        operations: flattenTracks(previous.tracks),
         canUndo: undoStack.length > 0,
         canRedo: true,
         cropEditingOperationIndex: null,
@@ -387,10 +406,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
     redo: () => {
       const next = redoStack.pop();
       if (next === undefined) return;
-      undoStack.push(cloneTracks(get().tracks));
+      const state = get();
+      undoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
       set({
-        tracks: next,
-        operations: flattenTracks(next),
+        tracks: next.tracks,
+        segments: next.segments,
+        operations: flattenTracks(next.tracks),
         canUndo: true,
         canRedo: redoStack.length > 0,
         cropEditingOperationIndex: null,
@@ -697,6 +718,60 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set({ selectedOperationId: id });
     },
 
+    addSegment: (segment) => {
+      pushHistory();
+      set((state) => ({
+        segments: [...state.segments, { ...segment, id: crypto.randomUUID() }],
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    removeSegment: (segmentId) => {
+      pushHistory();
+      set((state) => ({
+        segments: state.segments.filter((s) => s.id !== segmentId),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    reorderSegments: (segmentId, newIndex) => {
+      pushHistory();
+      set((state) => {
+        const segments = [...state.segments];
+        const fromIndex = segments.findIndex((s) => s.id === segmentId);
+        if (fromIndex === -1) return { ...updateUndoRedoFlags() };
+        const [moved] = segments.splice(fromIndex, 1);
+        // Drop transition if moved to index 0
+        const placed = newIndex === 0 ? { ...moved, transition: undefined } : moved;
+        segments.splice(newIndex, 0, placed);
+        return { segments, ...updateUndoRedoFlags() };
+      });
+    },
+
+    trimSegmentStart: (segmentId, newSourceStartFrame) => {
+      pushHistory();
+      set((state) => ({
+        segments: state.segments.map((s) =>
+          s.id === segmentId ? { ...s, sourceStartFrame: newSourceStartFrame } : s,
+        ),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    trimSegmentEnd: (segmentId, newSourceEndFrame) => {
+      pushHistory();
+      set((state) => ({
+        segments: state.segments.map((s) =>
+          s.id === segmentId ? { ...s, sourceEndFrame: newSourceEndFrame } : s,
+        ),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    selectSegment: (segmentId) => {
+      set({ selectedSegmentId: segmentId });
+    },
+
     addTrack: () => {
       pushHistory();
       set((state) => {
@@ -763,7 +838,8 @@ export const useEditorStore = create<EditorState>((set, get) => {
       redoStack = [];
 
       // Detect format: array = legacy flat operations, object with tracks = new format
-      const tracks: Track[] = Array.isArray(data)
+      const isLegacy = Array.isArray(data);
+      const tracks: Track[] = isLegacy
         ? [
             {
               id: crypto.randomUUID(),
@@ -779,11 +855,17 @@ export const useEditorStore = create<EditorState>((set, get) => {
           ]
         : (data as { tracks: Track[] }).tracks;
 
+      const segments: Segment[] = isLegacy
+        ? []
+        : (data as { segments?: Segment[] }).segments ?? [];
+
       set({
         tracks,
+        segments,
         operations: flattenTracks(tracks),
         selectedOperationIndex: null,
         selectedOperationId: null,
+        selectedSegmentId: null,
         cropEditingOperationIndex: null,
         cropEditingOperationId: null,
         canUndo: false,
@@ -792,11 +874,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
       });
     },
 
-    restoreTracks: (rawTracks) => {
+    restoreTracks: (rawTracks, segments) => {
       const tracks = rawTracks as Track[];
       set({
         tracks,
         operations: flattenTracks(tracks),
+        ...(segments !== undefined ? { segments } : {}),
       });
     },
 
@@ -805,6 +888,8 @@ export const useEditorStore = create<EditorState>((set, get) => {
       redoStack = [];
       set({
         tracks: [makeDefaultTrack()],
+        segments: [],
+        selectedSegmentId: null,
         operations: [],
         selectedOperationIndex: null,
         selectedOperationId: null,

--- a/@fanslib/apps/web/src/stores/editorStore.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.ts
@@ -24,6 +24,7 @@ type EditorState = {
   sourceMediaId: string | null;
   editId: string | null;
   selectedSourceId: string | null;
+  pendingSourceMarkIn: number | null;
 
   // Mutation actions (push to undo stack)
   addOperation: (op: unknown) => void;
@@ -94,6 +95,9 @@ type EditorState = {
 
   // Source bin
   selectSource: (id: string | null) => void;
+  setSourceMarkIn: (frame: number) => void;
+  clearSourceMarkIn: () => void;
+  commitSourceSegment: (markOutFrame: number) => void;
 
   // Metadata
   setSourceMediaId: (id: string) => void;
@@ -204,6 +208,7 @@ export const useEditorStore = create<EditorState>((set, get) => {
     sourceMediaId: null,
     editId: null,
     selectedSourceId: null,
+    pendingSourceMarkIn: null,
     canRedo: false,
 
     addOperation: (op) => {
@@ -827,7 +832,30 @@ export const useEditorStore = create<EditorState>((set, get) => {
     flattenOperations: () => flattenTracks(get().tracks),
 
     selectSource: (id) => {
-      set({ selectedSourceId: id });
+      set({ selectedSourceId: id, pendingSourceMarkIn: null });
+    },
+
+    setSourceMarkIn: (frame) => {
+      set({ pendingSourceMarkIn: frame });
+    },
+
+    clearSourceMarkIn: () => {
+      set({ pendingSourceMarkIn: null });
+    },
+
+    commitSourceSegment: (markOutFrame) => {
+      const state = get();
+      if (state.selectedSourceId === null) return;
+      if (state.pendingSourceMarkIn === null) return;
+      const markIn = state.pendingSourceMarkIn;
+      const sourceStartFrame = Math.min(markIn, markOutFrame);
+      const sourceEndFrame = Math.max(markIn, markOutFrame);
+      get().addSegment({
+        sourceMediaId: state.selectedSourceId,
+        sourceStartFrame,
+        sourceEndFrame,
+      });
+      set({ pendingSourceMarkIn: null });
     },
 
     setSourceMediaId: (id) => {
@@ -910,6 +938,7 @@ export const useEditorStore = create<EditorState>((set, get) => {
         sourceMediaId: null,
         editId: null,
         selectedSourceId: null,
+        pendingSourceMarkIn: null,
       });
     },
   };

--- a/@fanslib/apps/web/src/stores/editorStore.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.ts
@@ -23,6 +23,7 @@ type EditorState = {
   isDirty: boolean;
   sourceMediaId: string | null;
   editId: string | null;
+  selectedSourceId: string | null;
 
   // Mutation actions (push to undo stack)
   addOperation: (op: unknown) => void;
@@ -90,6 +91,9 @@ type EditorState = {
 
   // Derived
   flattenOperations: () => unknown[];
+
+  // Source bin
+  selectSource: (id: string | null) => void;
 
   // Metadata
   setSourceMediaId: (id: string) => void;
@@ -199,6 +203,7 @@ export const useEditorStore = create<EditorState>((set, get) => {
     isDirty: false,
     sourceMediaId: null,
     editId: null,
+    selectedSourceId: null,
     canRedo: false,
 
     addOperation: (op) => {
@@ -821,6 +826,10 @@ export const useEditorStore = create<EditorState>((set, get) => {
 
     flattenOperations: () => flattenTracks(get().tracks),
 
+    selectSource: (id) => {
+      set({ selectedSourceId: id });
+    },
+
     setSourceMediaId: (id) => {
       set({ sourceMediaId: id });
     },
@@ -900,6 +909,7 @@ export const useEditorStore = create<EditorState>((set, get) => {
         isDirty: false,
         sourceMediaId: null,
         editId: null,
+        selectedSourceId: null,
       });
     },
   };

--- a/@fanslib/apps/web/src/stores/editorStore.vitest.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.vitest.ts
@@ -786,4 +786,22 @@ describe("editorStore", () => {
       expect(useEditorStore.getState().operations).toHaveLength(0);
     });
   });
+
+  describe("selectSource", () => {
+    test("selectSource sets and clears selectedSourceId", () => {
+      expect(useEditorStore.getState().selectedSourceId).toBeNull();
+
+      useEditorStore.getState().selectSource("media-1");
+      expect(useEditorStore.getState().selectedSourceId).toBe("media-1");
+
+      useEditorStore.getState().selectSource(null);
+      expect(useEditorStore.getState().selectedSourceId).toBeNull();
+    });
+
+    test("reset clears selectedSourceId", () => {
+      useEditorStore.getState().selectSource("media-1");
+      useEditorStore.getState().reset();
+      expect(useEditorStore.getState().selectedSourceId).toBeNull();
+    });
+  });
 });

--- a/@fanslib/apps/web/src/stores/editorStore.vitest.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.vitest.ts
@@ -631,6 +631,132 @@ describe("editorStore", () => {
     });
   });
 
+  describe("segments", () => {
+    test("addSegment appends a segment with generated id", () => {
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "media-1",
+        sourceStartFrame: 0,
+        sourceEndFrame: 90,
+      });
+      const segments = useEditorStore.getState().segments;
+      expect(segments).toHaveLength(1);
+      expect(segments[0].sourceMediaId).toBe("media-1");
+      expect(segments[0].sourceStartFrame).toBe(0);
+      expect(segments[0].sourceEndFrame).toBe(90);
+      expect(typeof segments[0].id).toBe("string");
+      expect(segments[0].id.length).toBeGreaterThan(0);
+    });
+
+    test("removeSegment removes by id", () => {
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "media-1",
+        sourceStartFrame: 0,
+        sourceEndFrame: 90,
+      });
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "media-2",
+        sourceStartFrame: 0,
+        sourceEndFrame: 60,
+      });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().removeSegment(id);
+      const segments = useEditorStore.getState().segments;
+      expect(segments).toHaveLength(1);
+      expect(segments[0].sourceMediaId).toBe("media-2");
+    });
+
+    test("reorderSegments moves to new index", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "a", sourceStartFrame: 0, sourceEndFrame: 30 });
+      useEditorStore.getState().addSegment({ sourceMediaId: "b", sourceStartFrame: 0, sourceEndFrame: 30 });
+      useEditorStore.getState().addSegment({ sourceMediaId: "c", sourceStartFrame: 0, sourceEndFrame: 30 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().reorderSegments(id, 2);
+      const segments = useEditorStore.getState().segments;
+      expect(segments[0].sourceMediaId).toBe("b");
+      expect(segments[1].sourceMediaId).toBe("c");
+      expect(segments[2].sourceMediaId).toBe("a");
+    });
+
+    test("reorderSegments drops transition when segment moves to index 0", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "a", sourceStartFrame: 0, sourceEndFrame: 30 });
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "b",
+        sourceStartFrame: 0,
+        sourceEndFrame: 30,
+        transition: { type: "crossfade", durationFrames: 10 },
+      });
+      const id = useEditorStore.getState().segments[1].id;
+      useEditorStore.getState().reorderSegments(id, 0);
+      const segments = useEditorStore.getState().segments;
+      expect(segments[0].sourceMediaId).toBe("b");
+      expect(segments[0].transition).toBeUndefined();
+    });
+
+    test("trimSegmentStart adjusts sourceStartFrame", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().trimSegmentStart(id, 15);
+      expect(useEditorStore.getState().segments[0].sourceStartFrame).toBe(15);
+    });
+
+    test("trimSegmentEnd adjusts sourceEndFrame", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().trimSegmentEnd(id, 60);
+      expect(useEditorStore.getState().segments[0].sourceEndFrame).toBe(60);
+    });
+
+    test("selectSegment sets selectedSegmentId", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().selectSegment(id);
+      expect(useEditorStore.getState().selectedSegmentId).toBe(id);
+      useEditorStore.getState().selectSegment(null);
+      expect(useEditorStore.getState().selectedSegmentId).toBeNull();
+    });
+
+    test("undo/redo works for segment mutations", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      expect(useEditorStore.getState().segments).toHaveLength(1);
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().segments).toHaveLength(0);
+      useEditorStore.getState().redo();
+      expect(useEditorStore.getState().segments).toHaveLength(1);
+      expect(useEditorStore.getState().segments[0].sourceMediaId).toBe("media-1");
+    });
+
+    test("undo/redo still works for operation mutations (regression)", () => {
+      useEditorStore.getState().addOperation({ type: "blur" });
+      expect(useEditorStore.getState().operations).toHaveLength(1);
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().operations).toHaveLength(0);
+      useEditorStore.getState().redo();
+      expect(useEditorStore.getState().operations).toHaveLength(1);
+    });
+
+    test("hydrate accepts and restores segments", () => {
+      const data = {
+        tracks: [{ id: "t1", name: "Track 1", operations: [] }],
+        segments: [
+          { id: "s1", sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 },
+          { id: "s2", sourceMediaId: "media-2", sourceStartFrame: 10, sourceEndFrame: 50 },
+        ],
+      };
+      useEditorStore.getState().hydrate(data);
+      expect(useEditorStore.getState().segments).toHaveLength(2);
+      expect(useEditorStore.getState().segments[0].id).toBe("s1");
+      expect(useEditorStore.getState().segments[1].sourceMediaId).toBe("media-2");
+    });
+
+    test("reset clears segments and selectedSegmentId", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      useEditorStore.getState().selectSegment(useEditorStore.getState().segments[0].id);
+      useEditorStore.getState().reset();
+      expect(useEditorStore.getState().segments).toEqual([]);
+      expect(useEditorStore.getState().selectedSegmentId).toBeNull();
+    });
+  });
+
   describe("zoom operations", () => {
     test("addZoom adds a zoom operation with default values", () => {
       useEditorStore.getState().addZoom();

--- a/@fanslib/apps/web/src/stores/editorStore.vitest.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.vitest.ts
@@ -804,4 +804,101 @@ describe("editorStore", () => {
       expect(useEditorStore.getState().selectedSourceId).toBeNull();
     });
   });
+
+  describe("source mode", () => {
+    test("setSourceMarkIn sets pending mark-in frame", () => {
+      useEditorStore.getState().setSourceMarkIn(42);
+      expect(useEditorStore.getState().pendingSourceMarkIn).toBe(42);
+    });
+
+    test("commitSourceSegment creates segment with correct sourceMediaId, sourceStartFrame, sourceEndFrame", () => {
+      useEditorStore.getState().selectSource("media-1");
+      useEditorStore.getState().setSourceMarkIn(10);
+      useEditorStore.getState().commitSourceSegment(50);
+
+      const segments = useEditorStore.getState().segments;
+      expect(segments).toHaveLength(1);
+      expect(segments[0].sourceMediaId).toBe("media-1");
+      expect(segments[0].sourceStartFrame).toBe(10);
+      expect(segments[0].sourceEndFrame).toBe(50);
+      expect(typeof segments[0].id).toBe("string");
+    });
+
+    test("commitSourceSegment clears pendingSourceMarkIn", () => {
+      useEditorStore.getState().selectSource("media-1");
+      useEditorStore.getState().setSourceMarkIn(10);
+      useEditorStore.getState().commitSourceSegment(50);
+      expect(useEditorStore.getState().pendingSourceMarkIn).toBeNull();
+    });
+
+    test("commitSourceSegment no-ops when no selectedSourceId", () => {
+      useEditorStore.getState().setSourceMarkIn(10);
+      useEditorStore.getState().commitSourceSegment(50);
+      expect(useEditorStore.getState().segments).toHaveLength(0);
+      // markIn should NOT be cleared on no-op
+      expect(useEditorStore.getState().pendingSourceMarkIn).toBe(10);
+    });
+
+    test("commitSourceSegment no-ops when no pendingSourceMarkIn", () => {
+      useEditorStore.getState().selectSource("media-1");
+      useEditorStore.getState().commitSourceSegment(50);
+      expect(useEditorStore.getState().segments).toHaveLength(0);
+    });
+
+    test("selectSource clears pendingSourceMarkIn when switching sources", () => {
+      useEditorStore.getState().selectSource("media-1");
+      useEditorStore.getState().setSourceMarkIn(10);
+      useEditorStore.getState().selectSource("media-2");
+      expect(useEditorStore.getState().pendingSourceMarkIn).toBeNull();
+    });
+
+    test("selectSource clears pendingSourceMarkIn when deselecting", () => {
+      useEditorStore.getState().selectSource("media-1");
+      useEditorStore.getState().setSourceMarkIn(10);
+      useEditorStore.getState().selectSource(null);
+      expect(useEditorStore.getState().pendingSourceMarkIn).toBeNull();
+    });
+
+    test("multiple segments can be pushed from same source (markIn clears after each commit)", () => {
+      useEditorStore.getState().selectSource("media-1");
+
+      useEditorStore.getState().setSourceMarkIn(0);
+      useEditorStore.getState().commitSourceSegment(30);
+
+      useEditorStore.getState().setSourceMarkIn(60);
+      useEditorStore.getState().commitSourceSegment(90);
+
+      const segments = useEditorStore.getState().segments;
+      expect(segments).toHaveLength(2);
+      expect(segments[0].sourceStartFrame).toBe(0);
+      expect(segments[0].sourceEndFrame).toBe(30);
+      expect(segments[1].sourceStartFrame).toBe(60);
+      expect(segments[1].sourceEndFrame).toBe(90);
+      // selectedSourceId should persist
+      expect(useEditorStore.getState().selectedSourceId).toBe("media-1");
+    });
+
+    test("commitSourceSegment swaps markIn and markOut when markOut < markIn", () => {
+      useEditorStore.getState().selectSource("media-1");
+      useEditorStore.getState().setSourceMarkIn(50);
+      useEditorStore.getState().commitSourceSegment(10);
+
+      const segments = useEditorStore.getState().segments;
+      expect(segments).toHaveLength(1);
+      expect(segments[0].sourceStartFrame).toBe(10);
+      expect(segments[0].sourceEndFrame).toBe(50);
+    });
+
+    test("clearSourceMarkIn clears pendingSourceMarkIn", () => {
+      useEditorStore.getState().setSourceMarkIn(42);
+      useEditorStore.getState().clearSourceMarkIn();
+      expect(useEditorStore.getState().pendingSourceMarkIn).toBeNull();
+    });
+
+    test("reset clears pendingSourceMarkIn", () => {
+      useEditorStore.getState().setSourceMarkIn(42);
+      useEditorStore.getState().reset();
+      expect(useEditorStore.getState().pendingSourceMarkIn).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Source mode state: `pendingSourceMarkIn`, `setSourceMarkIn`, `clearSourceMarkIn`
- `commitSourceSegment(markOutFrame)` creates segment from mark-in to mark-out using selected source
- Auto-swaps frames when marking backwards
- Source selection clears pending mark-in state
- Source mode indicator in CompositionEditor
- 10 new store tests, 81 total passing

Stacked on #375 (Source bin panel)

Closes #344

## Test plan

- [x] setSourceMarkIn sets pending frame
- [x] commitSourceSegment creates segment with correct fields
- [x] commitSourceSegment clears markIn
- [x] No-ops when no selectedSourceId or no markIn
- [x] selectSource clears markIn on switch/deselect
- [x] Multiple segments from same source
- [x] Backwards marking auto-swaps
- [x] clearSourceMarkIn and reset clear state
- [x] 81 total tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)