### PR TITLE
feat(compositions): snapshot composition + region → MediaEdit render jobs

### DIFF
--- a/@fanslib/apps/server/src/features/compositions/entity.ts
+++ b/@fanslib/apps/server/src/features/compositions/entity.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import type { Relation } from "typeorm";
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { Shoot } from "../shoots/entity";
+
+@Entity("composition")
+export class Composition {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ type: "varchar", name: "shootId" })
+  shootId!: string;
+
+  @ManyToOne(() => Shoot, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "shootId" })
+  shoot!: Relation<Shoot>;
+
+  @Column({ type: "varchar", name: "name" })
+  name!: string;
+
+  @Column({ type: "simple-json", name: "segments", default: "[]" })
+  segments: unknown[] = [];
+
+  @Column({ type: "simple-json", name: "tracks", default: "[]" })
+  tracks: unknown[] = [];
+
+  @Column({ type: "simple-json", name: "exportRegions", default: "[]" })
+  exportRegions: unknown[] = [];
+
+  @CreateDateColumn({ type: "datetime", name: "createdAt" })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: "datetime", name: "updatedAt" })
+  updatedAt!: Date;
+}
+
+const SegmentTransitionSchema = z.object({
+  type: z.literal("crossfade"),
+  durationFrames: z.number(),
+  easing: z.string().optional(),
+});
+
+export const SegmentSchema = z.object({
+  id: z.string(),
+  sourceMediaId: z.string(),
+  sourceStartFrame: z.number(),
+  sourceEndFrame: z.number(),
+  transition: SegmentTransitionSchema.optional(),
+});
+
+export const TrackSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  operations: z.array(z.unknown()),
+});
+
+export const ExportRegionSchema = z.object({
+  id: z.string(),
+  startFrame: z.number(),
+  endFrame: z.number(),
+  package: z.string().nullable().optional(),
+  role: z.string().nullable().optional(),
+  contentRating: z.string().nullable().optional(),
+  quality: z.string().nullable().optional(),
+});
+
+export const CompositionSchema = z.object({
+  id: z.string(),
+  shootId: z.string(),
+  name: z.string(),
+  segments: z.array(SegmentSchema),
+  tracks: z.array(TrackSchema),
+  exportRegions: z.array(ExportRegionSchema),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});

--- a/@fanslib/apps/server/src/features/compositions/export.test.ts
+++ b/@fanslib/apps/server/src/features/compositions/export.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import "reflect-metadata";
+import { getTestDataSource, setupTestDatabase, teardownTestDatabase } from "../../lib/test-db";
+import { resetAllFixtures } from "../../lib/test-fixtures";
+import { createTestMedia } from "../../test-utils/setup";
+import { Shoot } from "../shoots/entity";
+import { Composition } from "./entity";
+import { MediaEdit } from "../media-edits/entity";
+import { exportComposition } from "./operations/composition/export";
+
+describe("exportComposition", () => {
+  beforeAll(async () => {
+    await setupTestDatabase();
+    await resetAllFixtures();
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetAllFixtures();
+  });
+
+  const createTestShoot = async () => {
+    const dataSource = getTestDataSource();
+    const shootRepo = dataSource.getRepository(Shoot);
+    const shoot = shootRepo.create({
+      name: "Test Shoot",
+      shootDate: new Date("2026-04-08"),
+    });
+    return shootRepo.save(shoot);
+  };
+
+  const createTestComposition = async (
+    shootId: string,
+    overrides: Partial<Composition> = {},
+  ) => {
+    const dataSource = getTestDataSource();
+    const compRepo = dataSource.getRepository(Composition);
+    const composition = compRepo.create({
+      shootId,
+      name: "Test Composition",
+      segments: [
+        {
+          id: "seg-1",
+          sourceMediaId: "media-1",
+          sourceStartFrame: 0,
+          sourceEndFrame: 900,
+        },
+        {
+          id: "seg-2",
+          sourceMediaId: "media-2",
+          sourceStartFrame: 0,
+          sourceEndFrame: 600,
+        },
+      ],
+      tracks: [
+        { id: "track-1", name: "Overlays", operations: [{ type: "watermark" }] },
+      ],
+      exportRegions: [],
+      ...overrides,
+    });
+    return compRepo.save(composition);
+  };
+
+  test("composition with no export regions creates one MediaEdit spanning whole timeline", async () => {
+    const shoot = await createTestShoot();
+    const composition = await createTestComposition(shoot.id, {
+      exportRegions: [],
+    });
+
+    const edits = await exportComposition(composition.id);
+
+    expect(edits).toHaveLength(1);
+    expect(edits[0]!.compositionId).toBe(composition.id);
+    expect(edits[0]!.type).toBe("composition");
+    expect(edits[0]!.status).toBe("queued");
+    expect(edits[0]!.segments).toEqual(composition.segments);
+    expect(edits[0]!.tracks).toEqual(composition.tracks);
+    expect(edits[0]!.exportRegion).toBeNull();
+    expect(edits[0]!.operations).toEqual([]);
+  });
+
+  test("composition with two export regions creates two MediaEdits", async () => {
+    const shoot = await createTestShoot();
+    const composition = await createTestComposition(shoot.id, {
+      exportRegions: [
+        { id: "er-1", startFrame: 0, endFrame: 450 },
+        { id: "er-2", startFrame: 450, endFrame: 900 },
+      ],
+    });
+
+    const edits = await exportComposition(composition.id);
+
+    expect(edits).toHaveLength(2);
+    expect(edits[0]!.exportRegion).toEqual({ startFrame: 0, endFrame: 450 });
+    expect(edits[1]!.exportRegion).toEqual({ startFrame: 450, endFrame: 900 });
+  });
+
+  test("each MediaEdit has correct compositionId, segments, and tracks", async () => {
+    const shoot = await createTestShoot();
+    const composition = await createTestComposition(shoot.id, {
+      exportRegions: [
+        { id: "er-1", startFrame: 0, endFrame: 450 },
+      ],
+    });
+
+    const edits = await exportComposition(composition.id);
+
+    expect(edits).toHaveLength(1);
+    expect(edits[0]!.compositionId).toBe(composition.id);
+    expect(edits[0]!.segments).toEqual(composition.segments);
+    expect(edits[0]!.tracks).toEqual(composition.tracks);
+  });
+
+  test("per-region metadata is propagated to MediaEdit", async () => {
+    const shoot = await createTestShoot();
+    const composition = await createTestComposition(shoot.id, {
+      exportRegions: [
+        {
+          id: "er-1",
+          startFrame: 0,
+          endFrame: 450,
+          package: "premium",
+          role: "teaser",
+          contentRating: "sfw",
+          quality: "1080p",
+        },
+      ],
+    });
+
+    const edits = await exportComposition(composition.id);
+
+    expect(edits).toHaveLength(1);
+    expect(edits[0]!.package).toBe("premium");
+    expect(edits[0]!.role).toBe("teaser");
+    expect(edits[0]!.contentRating).toBe("sfw");
+    expect(edits[0]!.quality).toBe("1080p");
+  });
+
+  test("MediaEdits are created with queued status", async () => {
+    const shoot = await createTestShoot();
+    const composition = await createTestComposition(shoot.id, {
+      exportRegions: [
+        { id: "er-1", startFrame: 0, endFrame: 300 },
+        { id: "er-2", startFrame: 300, endFrame: 600 },
+      ],
+    });
+
+    const edits = await exportComposition(composition.id);
+
+    for (const edit of edits) {
+      expect(edit.status).toBe("queued");
+    }
+  });
+
+  test("composition not found returns error", async () => {
+    await expect(exportComposition("nonexistent-id")).rejects.toThrow(
+      "Composition not found",
+    );
+  });
+});

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/create.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/create.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const CreateCompositionRequestBodySchema = z.object({
+  shootId: z.string(),
+  name: z.string(),
+});
+
+export const createComposition = async (
+  payload: z.infer<typeof CreateCompositionRequestBodySchema>,
+): Promise<Composition> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+
+  const composition = repo.create({
+    shootId: payload.shootId,
+    name: payload.name,
+    segments: [],
+    tracks: [],
+    exportRegions: [],
+  });
+
+  await repo.save(composition);
+  const created = await repo.findOne({ where: { id: composition.id } });
+  if (!created) throw new Error(`Failed to fetch created composition ${composition.id}`);
+  return created;
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/delete.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/delete.ts
@@ -1,0 +1,11 @@
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const deleteComposition = async (id: string): Promise<boolean> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+  const composition = await repo.findOne({ where: { id } });
+  if (!composition) return false;
+  await repo.delete(id);
+  return true;
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/export.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/export.ts
@@ -1,0 +1,83 @@
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+import { MediaEdit } from "../../../media-edits/entity";
+
+type ExportRegionData = {
+  id: string;
+  startFrame: number;
+  endFrame: number;
+  package?: string | null;
+  role?: string | null;
+  contentRating?: string | null;
+  quality?: string | null;
+};
+
+type SegmentData = {
+  id: string;
+  sourceMediaId: string;
+  sourceStartFrame: number;
+  sourceEndFrame: number;
+};
+
+export const exportComposition = async (
+  compositionId: string,
+): Promise<MediaEdit[]> => {
+  const database = await db();
+  const compRepo = database.getRepository(Composition);
+  const editRepo = database.getRepository(MediaEdit);
+
+  const composition = await compRepo.findOne({ where: { id: compositionId } });
+  if (!composition) {
+    throw new Error("Composition not found");
+  }
+
+  const segments = composition.segments as SegmentData[];
+  const tracks = composition.tracks as unknown[];
+  const exportRegions = composition.exportRegions as ExportRegionData[];
+
+  // Use the first segment's sourceMediaId as the primary source media reference.
+  // For compositions with no segments, this will fail — but that's an invalid state.
+  const primarySourceMediaId = segments[0]?.sourceMediaId;
+  if (!primarySourceMediaId) {
+    throw new Error("Composition has no segments");
+  }
+
+  if (exportRegions.length === 0) {
+    // No export regions: treat whole timeline as one region
+    const edit = editRepo.create({
+      sourceMediaId: primarySourceMediaId,
+      compositionId: composition.id,
+      type: "composition" as const,
+      operations: [],
+      tracks,
+      segments,
+      exportRegion: null,
+      status: "queued",
+    });
+    const saved = await editRepo.save(edit);
+    return [saved];
+  }
+
+  // Create one MediaEdit per export region
+  const edits: MediaEdit[] = [];
+  for (const region of exportRegions) {
+    const edit = editRepo.create({
+      sourceMediaId: primarySourceMediaId,
+      compositionId: composition.id,
+      type: "composition" as const,
+      operations: [],
+      tracks,
+      segments,
+      exportRegion: { startFrame: region.startFrame, endFrame: region.endFrame },
+      package: region.package ?? null,
+      role: region.role ?? null,
+      contentRating: region.contentRating ?? null,
+      quality: region.quality ?? null,
+      status: "queued",
+    });
+    const saved = await editRepo.save(edit);
+    edits.push(saved);
+  }
+
+  return edits;
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-id.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-id.ts
@@ -1,0 +1,8 @@
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const fetchCompositionById = async (id: string): Promise<Composition | null> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+  return repo.findOne({ where: { id } });
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-shoot.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-shoot.ts
@@ -1,0 +1,11 @@
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const fetchCompositionsByShoot = async (shootId: string): Promise<Composition[]> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+  return repo.find({
+    where: { shootId },
+    order: { createdAt: "DESC" },
+  });
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/update.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/update.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { db } from "../../../../lib/db";
+import { Composition, SegmentSchema, TrackSchema, ExportRegionSchema } from "../../entity";
+
+export const UpdateCompositionRequestBodySchema = z.object({
+  name: z.string().optional(),
+  segments: z.array(SegmentSchema).optional(),
+  tracks: z.array(TrackSchema).optional(),
+  exportRegions: z.array(ExportRegionSchema).optional(),
+});
+
+export const updateComposition = async (
+  id: string,
+  payload: z.infer<typeof UpdateCompositionRequestBodySchema>,
+): Promise<Composition | null> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+
+  const composition = await repo.findOne({ where: { id } });
+  if (!composition) return null;
+
+  if (payload.name !== undefined) composition.name = payload.name;
+  if (payload.segments !== undefined) composition.segments = payload.segments;
+  if (payload.tracks !== undefined) composition.tracks = payload.tracks;
+  if (payload.exportRegions !== undefined) composition.exportRegions = payload.exportRegions;
+
+  await repo.save(composition);
+  return composition;
+};

--- a/@fanslib/apps/server/src/features/compositions/routes.test.ts
+++ b/@fanslib/apps/server/src/features/compositions/routes.test.ts
@@ -1,0 +1,257 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import "reflect-metadata";
+import { getTestDataSource, setupTestDatabase, teardownTestDatabase } from "../../lib/test-db";
+import { resetAllFixtures } from "../../lib/test-fixtures";
+import { devalueMiddleware } from "../../lib/devalue-middleware";
+import { parseResponse } from "../../test-utils/setup";
+import { Shoot } from "../shoots/entity";
+import { compositionsRoutes } from "./routes";
+
+describe("Compositions Routes", () => {
+  // eslint-disable-next-line functional/no-let
+  let app: Hono;
+  // eslint-disable-next-line functional/no-let
+  let testShoot: Shoot;
+
+  beforeAll(async () => {
+    await setupTestDatabase();
+    await resetAllFixtures();
+    app = new Hono().use("*", devalueMiddleware()).route("/", compositionsRoutes);
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetAllFixtures();
+    // Create a shoot for compositions to reference
+    const dataSource = getTestDataSource();
+    const shootRepo = dataSource.getRepository(Shoot);
+    testShoot = shootRepo.create({
+      name: "Test Shoot",
+      shootDate: new Date("2026-04-08"),
+    });
+    testShoot = await shootRepo.save(testShoot);
+  });
+
+  describe("POST /api/compositions", () => {
+    test("creates a composition and returns it with all fields", async () => {
+      const response = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          shootId: testShoot.id,
+          name: "Trailer v1",
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{
+        id: string;
+        shootId: string;
+        name: string;
+        segments: unknown[];
+        tracks: unknown[];
+        exportRegions: unknown[];
+        createdAt: string;
+        updatedAt: string;
+      }>(response);
+
+      expect(data?.id).toBeDefined();
+      expect(data?.shootId).toBe(testShoot.id);
+      expect(data?.name).toBe("Trailer v1");
+      expect(data?.segments).toEqual([]);
+      expect(data?.tracks).toEqual([]);
+      expect(data?.exportRegions).toEqual([]);
+    });
+  });
+
+  describe("PATCH /api/compositions/by-id/:id", () => {
+    test("updates composition name, segments, tracks, and exportRegions", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Original" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const segments = [
+        { id: "seg-1", sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 900 },
+      ];
+      const tracks = [
+        { id: "track-1", name: "Overlays", operations: [] },
+      ];
+      const exportRegions = [
+        { id: "er-1", startFrame: 0, endFrame: 450 },
+      ];
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "Updated",
+          segments,
+          tracks,
+          exportRegions,
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{
+        name: string;
+        segments: unknown[];
+        tracks: unknown[];
+        exportRegions: unknown[];
+      }>(response);
+      expect(data?.name).toBe("Updated");
+      expect(data?.segments).toHaveLength(1);
+      expect(data?.tracks).toHaveLength(1);
+      expect(data?.exportRegions).toHaveLength(1);
+    });
+
+    test("returns 404 for non-existent composition", async () => {
+      const response = await app.request("/api/compositions/by-id/nonexistent", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Nope" }),
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("GET /api/compositions/by-shoot/:shootId", () => {
+    test("lists all compositions for a shoot", async () => {
+      await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Comp A" }),
+      });
+      await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Comp B" }),
+      });
+
+      const response = await app.request(`/api/compositions/by-shoot/${testShoot.id}`);
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ id: string; name: string }[]>(response);
+      expect(data).toHaveLength(2);
+      const names = data?.map((c) => c.name).sort();
+      expect(names).toEqual(["Comp A", "Comp B"]);
+    });
+
+    test("returns empty array for shoot with no compositions", async () => {
+      const response = await app.request(`/api/compositions/by-shoot/${testShoot.id}`);
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<unknown[]>(response);
+      expect(data).toHaveLength(0);
+    });
+  });
+
+  describe("DELETE /api/compositions/by-id/:id", () => {
+    test("deletes a composition", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "To Delete" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`, {
+        method: "DELETE",
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ success: boolean }>(response);
+      expect(data?.success).toBe(true);
+
+      // Verify it's gone
+      const getResponse = await app.request(`/api/compositions/by-id/${created?.id}`);
+      expect(getResponse.status).toBe(404);
+    });
+
+    test("returns 404 for non-existent composition", async () => {
+      const response = await app.request("/api/compositions/by-id/nonexistent", {
+        method: "DELETE",
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("GET /api/compositions/by-id/:id", () => {
+    test("fetches a composition by ID", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Fetch Test" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`);
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ id: string; name: string }>(response);
+      expect(data?.id).toBe(created?.id);
+      expect(data?.name).toBe("Fetch Test");
+    });
+
+    test("returns 404 for non-existent composition", async () => {
+      const response = await app.request("/api/compositions/by-id/nonexistent");
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Schema validation", () => {
+    test("rejects update with invalid segment shape", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Validate Me" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          segments: [{ invalid: "shape" }],
+        }),
+      });
+      expect(response.status).toBe(422);
+    });
+
+    test("rejects create without required fields", async () => {
+      const response = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(response.status).toBe(422);
+    });
+  });
+
+  describe("Shoot cascade", () => {
+    test("deleting a shoot cascades to its compositions", async () => {
+      // Create a composition on the test shoot
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Will Be Cascaded" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      // Delete the shoot directly
+      const dataSource = getTestDataSource();
+      const shootRepo = dataSource.getRepository(Shoot);
+      await shootRepo.delete(testShoot.id);
+
+      // The composition should be gone
+      const getResponse = await app.request(`/api/compositions/by-id/${created?.id}`);
+      expect(getResponse.status).toBe(404);
+    });
+  });
+});

--- a/@fanslib/apps/server/src/features/compositions/routes.test.ts
+++ b/@fanslib/apps/server/src/features/compositions/routes.test.ts
@@ -234,6 +234,54 @@ describe("Compositions Routes", () => {
     });
   });
 
+  describe("POST /api/compositions/by-id/:id/export", () => {
+    test("exports a composition and returns MediaEdit array", async () => {
+      // Create composition with segments and export regions
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Export Test" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      // Add segments (need a real media for FK)
+      const { createTestMedia } = await import("../../test-utils/setup");
+      const media = await createTestMedia();
+
+      await app.request(`/api/compositions/by-id/${created?.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          segments: [
+            { id: "seg-1", sourceMediaId: media.id, sourceStartFrame: 0, sourceEndFrame: 900 },
+          ],
+          tracks: [{ id: "t-1", name: "Overlays", operations: [] }],
+          exportRegions: [
+            { id: "er-1", startFrame: 0, endFrame: 450, package: "pkg", role: "main", contentRating: "sfw" },
+          ],
+        }),
+      });
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}/export`, {
+        method: "POST",
+      });
+      expect(response.status).toBe(200);
+
+      const edits = await parseResponse<{ id: string; compositionId: string; type: string; status: string }[]>(response);
+      expect(edits).toHaveLength(1);
+      expect(edits?.[0]?.compositionId).toBe(created?.id);
+      expect(edits?.[0]?.type).toBe("composition");
+      expect(edits?.[0]?.status).toBe("queued");
+    });
+
+    test("returns 404 for non-existent composition", async () => {
+      const response = await app.request("/api/compositions/by-id/nonexistent/export", {
+        method: "POST",
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
   describe("Shoot cascade", () => {
     test("deleting a shoot cascades to its compositions", async () => {
       // Create a composition on the test shoot

--- a/@fanslib/apps/server/src/features/compositions/routes.ts
+++ b/@fanslib/apps/server/src/features/compositions/routes.ts
@@ -6,6 +6,7 @@ import {
   createComposition,
 } from "./operations/composition/create";
 import { deleteComposition } from "./operations/composition/delete";
+import { exportComposition } from "./operations/composition/export";
 import { fetchCompositionById } from "./operations/composition/fetch-by-id";
 import { fetchCompositionsByShoot } from "./operations/composition/fetch-by-shoot";
 import {
@@ -45,6 +46,18 @@ export const compositionsRoutes = new Hono()
     const shootId = c.req.param("shootId");
     const compositions = await fetchCompositionsByShoot(shootId);
     return c.json(compositions);
+  })
+  .post("/by-id/:id/export", async (c) => {
+    const id = c.req.param("id");
+    try {
+      const edits = await exportComposition(id);
+      return c.json(edits);
+    } catch (error) {
+      if (error instanceof Error && error.message === "Composition not found") {
+        return notFound(c, "Composition not found");
+      }
+      throw error;
+    }
   })
   .delete("/by-id/:id", async (c) => {
     const id = c.req.param("id");

--- a/@fanslib/apps/server/src/features/compositions/routes.ts
+++ b/@fanslib/apps/server/src/features/compositions/routes.ts
@@ -1,0 +1,54 @@
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { validationError, notFound } from "../../lib/hono-utils";
+import {
+  CreateCompositionRequestBodySchema,
+  createComposition,
+} from "./operations/composition/create";
+import { deleteComposition } from "./operations/composition/delete";
+import { fetchCompositionById } from "./operations/composition/fetch-by-id";
+import { fetchCompositionsByShoot } from "./operations/composition/fetch-by-shoot";
+import {
+  UpdateCompositionRequestBodySchema,
+  updateComposition,
+} from "./operations/composition/update";
+
+export const compositionsRoutes = new Hono()
+  .basePath("/api/compositions")
+  .post(
+    "/",
+    zValidator("json", CreateCompositionRequestBodySchema, validationError),
+    async (c) => {
+      const body = c.req.valid("json");
+      const result = await createComposition(body);
+      return c.json(result);
+    },
+  )
+  .patch(
+    "/by-id/:id",
+    zValidator("json", UpdateCompositionRequestBodySchema, validationError),
+    async (c) => {
+      const id = c.req.param("id");
+      const body = c.req.valid("json");
+      const composition = await updateComposition(id, body);
+      if (!composition) return notFound(c, "Composition not found");
+      return c.json(composition);
+    },
+  )
+  .get("/by-id/:id", async (c) => {
+    const id = c.req.param("id");
+    const composition = await fetchCompositionById(id);
+    if (!composition) return notFound(c, "Composition not found");
+    return c.json(composition);
+  })
+  .get("/by-shoot/:shootId", async (c) => {
+    const shootId = c.req.param("shootId");
+    const compositions = await fetchCompositionsByShoot(shootId);
+    return c.json(compositions);
+  })
+  .delete("/by-id/:id", async (c) => {
+    const id = c.req.param("id");
+    const success = await deleteComposition(id);
+    if (!success) return notFound(c, "Composition not found");
+    return c.json({ success: true });
+  });

--- a/@fanslib/apps/server/src/features/media-edits/entity.ts
+++ b/@fanslib/apps/server/src/features/media-edits/entity.ts
@@ -10,8 +10,9 @@ import {
   UpdateDateColumn,
 } from "typeorm";
 import { Media } from "../library/entity";
+import { Composition } from "../compositions/entity";
 
-export type MediaEditType = "transform" | "clip";
+export type MediaEditType = "transform" | "clip" | "composition";
 export type MediaEditStatus = "draft" | "queued" | "rendering" | "completed" | "failed";
 
 @Entity("media_edit")
@@ -42,6 +43,31 @@ export class MediaEdit {
   @Column({ type: "simple-json", nullable: true, name: "tracks" })
   tracks: unknown[] | null = null;
 
+  @Column({ type: "varchar", nullable: true, name: "compositionId" })
+  compositionId: string | null = null;
+
+  @ManyToOne(() => Composition, { nullable: true, onDelete: "SET NULL" })
+  @JoinColumn({ name: "compositionId" })
+  composition!: Relation<Composition> | null;
+
+  @Column({ type: "simple-json", nullable: true, name: "segments" })
+  segments: unknown[] | null = null;
+
+  @Column({ type: "simple-json", nullable: true, name: "exportRegion" })
+  exportRegion: { startFrame: number; endFrame: number } | null = null;
+
+  @Column({ type: "varchar", nullable: true, name: "package" })
+  package: string | null = null;
+
+  @Column({ type: "varchar", nullable: true, name: "role" })
+  role: string | null = null;
+
+  @Column({ type: "varchar", nullable: true, name: "contentRating" })
+  contentRating: string | null = null;
+
+  @Column({ type: "varchar", nullable: true, name: "quality" })
+  quality: string | null = null;
+
   @Column({ type: "varchar", default: "draft", name: "status" })
   status: MediaEditStatus = "draft";
 
@@ -55,7 +81,7 @@ export class MediaEdit {
   updatedAt!: Date;
 }
 
-export const MediaEditTypeSchema = z.enum(["transform", "clip"]);
+export const MediaEditTypeSchema = z.enum(["transform", "clip", "composition"]);
 export const MediaEditStatusSchema = z.enum([
   "draft",
   "queued",
@@ -70,13 +96,25 @@ export const TrackSchema = z.object({
   operations: z.array(z.unknown()),
 });
 
+export const ExportRegionSnapshotSchema = z.object({
+  startFrame: z.number(),
+  endFrame: z.number(),
+});
+
 export const MediaEditSchema = z.object({
   id: z.string(),
   sourceMediaId: z.string(),
   outputMediaId: z.string().nullable(),
+  compositionId: z.string().nullable(),
   type: MediaEditTypeSchema,
   operations: z.array(z.unknown()),
   tracks: z.array(TrackSchema).nullable(),
+  segments: z.array(z.unknown()).nullable(),
+  exportRegion: ExportRegionSnapshotSchema.nullable(),
+  package: z.string().nullable(),
+  role: z.string().nullable(),
+  contentRating: z.string().nullable(),
+  quality: z.string().nullable(),
   status: MediaEditStatusSchema,
   error: z.string().nullable(),
   createdAt: z.coerce.date(),

--- a/@fanslib/apps/server/src/index.ts
+++ b/@fanslib/apps/server/src/index.ts
@@ -9,6 +9,7 @@ import { analyticsRoutes } from "./features/analytics/routes";
 import { assetsRoutes } from "./features/assets/routes";
 import { candidatesRoutes } from "./features/analytics/candidates/routes";
 import { channelsRoutes } from "./features/channels/routes";
+import { compositionsRoutes } from "./features/compositions/routes";
 import { contentSchedulesRoutes } from "./features/content-schedules/routes";
 import { filterPresetsRoutes } from "./features/filter-presets/routes";
 import { hashtagsRoutes } from "./features/hashtags/routes";
@@ -89,6 +90,7 @@ const app = new Hono()
   .route("/", subredditsRoutes)
   .route("/", tagsRoutes)
   .route("/", channelsRoutes)
+  .route("/", compositionsRoutes)
   .route("/", contentSchedulesRoutes)
   .route("/", libraryRoutes)
   .route("/", organizeRoutes)

--- a/@fanslib/apps/server/src/lib/db.ts
+++ b/@fanslib/apps/server/src/lib/db.ts
@@ -7,6 +7,7 @@ import "reflect-metadata";
 import initSqlJs from "sql.js";
 import { DataSource } from "typeorm";
 import { Asset } from "../features/assets/entity";
+import { Composition } from "../features/compositions/entity";
 import { FanslyMediaCandidate } from "../features/analytics/candidate-entity";
 import { FanslyAnalyticsAggregate, FanslyAnalyticsDatapoint } from "../features/analytics/entity";
 import { Channel, ChannelType } from "../features/channels/entity";
@@ -80,6 +81,7 @@ const createAppDataSource = (driver?: Awaited<ReturnType<typeof initSqlJs>>) => 
     ...(driver ? { driver } : {}),
     entities: [
       Asset,
+      Composition,
       Media,
       MediaEdit,
       Post,

--- a/@fanslib/apps/server/src/lib/test-db.ts
+++ b/@fanslib/apps/server/src/lib/test-db.ts
@@ -2,6 +2,7 @@
 import initSqlJs from "sql.js";
 import { DataSource } from "typeorm";
 import { Asset } from "../features/assets/entity";
+import { Composition } from "../features/compositions/entity";
 import { FanslyMediaCandidate } from "../features/analytics/candidate-entity";
 import { FanslyAnalyticsAggregate, FanslyAnalyticsDatapoint } from "../features/analytics/entity";
 import { Channel, ChannelType } from "../features/channels/entity";
@@ -39,6 +40,7 @@ export const createTestDataSource = (driver?: Awaited<ReturnType<typeof initSqlJ
     ...(driver ? { driver } : {}),
     entities: [
       Asset,
+      Composition,
       Media,
       MediaEdit,
       Post,
@@ -118,6 +120,7 @@ export const clearAllTables = async () => {
     "CaptionSnippet",
     "Subreddit",
     "Channel",
+    "Composition",
     "Shoot",
     "TagDefinition",
     "TagDimension",

--- a/@fanslib/apps/web/src/features/editor/utils/region-intersection.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/region-intersection.ts
@@ -1,0 +1,126 @@
+import type { Track } from "@fanslib/video/types";
+import type { Segment } from "./sequence-engine";
+import { computeSequenceTimeline } from "./sequence-engine";
+
+type ExportRegion = { startFrame: number; endFrame: number };
+
+type ClippedSegment = {
+  id: string;
+  sourceMediaId: string;
+  sourceStartFrame: number;
+  sourceEndFrame: number;
+  sequenceStartFrame: number;
+  sequenceEndFrame: number;
+  transition?: { type: "crossfade"; durationFrames: number; easing?: string };
+};
+
+type ClippedOperation = {
+  [key: string]: unknown;
+  startFrame: number;
+  endFrame: number;
+};
+
+type RegionIntersectionResult = {
+  segments: ClippedSegment[];
+  operations: ClippedOperation[];
+  totalDuration: number;
+};
+
+export const intersectRegion = (
+  segments: Segment[],
+  tracks: Track[],
+  region: ExportRegion,
+): RegionIntersectionResult => {
+  const regionDuration = region.endFrame - region.startFrame;
+
+  if (regionDuration <= 0) {
+    return { segments: [], operations: [], totalDuration: 0 };
+  }
+
+  const timeline = computeSequenceTimeline(segments);
+
+  // Intersect segments
+  const clippedSegments: ClippedSegment[] = [];
+  for (let i = 0; i < timeline.positions.length; i++) {
+    const pos = timeline.positions[i]!;
+    const segment = segments[i]!;
+
+    // Check overlap
+    if (pos.sequenceEndFrame <= region.startFrame || pos.sequenceStartFrame >= region.endFrame) {
+      continue;
+    }
+
+    const clampedSeqStart = Math.max(pos.sequenceStartFrame, region.startFrame);
+    const clampedSeqEnd = Math.min(pos.sequenceEndFrame, region.endFrame);
+
+    // How much was clipped from the start of this segment
+    const startClip = clampedSeqStart - pos.sequenceStartFrame;
+    const endClip = pos.sequenceEndFrame - clampedSeqEnd;
+
+    const clipped: ClippedSegment = {
+      id: segment.id,
+      sourceMediaId: segment.sourceMediaId,
+      sourceStartFrame: segment.sourceStartFrame + startClip,
+      sourceEndFrame: segment.sourceEndFrame - endClip,
+      sequenceStartFrame: clampedSeqStart - region.startFrame,
+      sequenceEndFrame: clampedSeqEnd - region.startFrame,
+    };
+
+    // Handle transitions
+    if (segment.transition) {
+      const transitionStart = pos.sequenceStartFrame;
+      const transitionEnd = pos.sequenceStartFrame + segment.transition.durationFrames;
+
+      if (transitionEnd > region.startFrame && transitionStart < region.endFrame) {
+        const effectiveStart = Math.max(transitionStart, region.startFrame);
+        const effectiveDuration = transitionEnd - effectiveStart;
+
+        if (effectiveDuration > 0) {
+          clipped.transition = {
+            type: segment.transition.type,
+            durationFrames: effectiveDuration,
+          };
+        }
+      }
+    }
+
+    clippedSegments.push(clipped);
+  }
+
+  // Intersect operations across all tracks
+  const clippedOperations: ClippedOperation[] = [];
+  for (const track of tracks) {
+    for (const op of track.operations) {
+      const typedOp = op as { startFrame?: number; endFrame?: number; [key: string]: unknown };
+
+      // Operations without both startFrame and endFrame pass through unchanged
+      if (typedOp.startFrame == null || typedOp.endFrame == null) {
+        clippedOperations.push(typedOp as ClippedOperation);
+        continue;
+      }
+
+      const opStart = typedOp.startFrame;
+      const opEnd = typedOp.endFrame;
+
+      // Check overlap
+      if (opEnd <= region.startFrame || opStart >= region.endFrame) {
+        continue;
+      }
+
+      const clampedStart = Math.max(opStart, region.startFrame) - region.startFrame;
+      const clampedEnd = Math.min(opEnd, region.endFrame) - region.startFrame;
+
+      clippedOperations.push({
+        ...typedOp,
+        startFrame: clampedStart,
+        endFrame: clampedEnd,
+      });
+    }
+  }
+
+  return {
+    segments: clippedSegments,
+    operations: clippedOperations,
+    totalDuration: regionDuration,
+  };
+};

--- a/@fanslib/apps/web/src/features/editor/utils/region-intersection.vitest.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/region-intersection.vitest.ts
@@ -1,0 +1,338 @@
+import { describe, expect, test } from "vitest";
+import { intersectRegion } from "./region-intersection";
+import type { Segment } from "./sequence-engine";
+import type { Track } from "@fanslib/video/types";
+
+const makeSegment = (
+  id: string,
+  sourceMediaId: string,
+  sourceStartFrame: number,
+  sourceEndFrame: number,
+  transition?: Segment["transition"],
+): Segment => ({
+  id,
+  sourceMediaId,
+  sourceStartFrame,
+  sourceEndFrame,
+  ...(transition && { transition }),
+});
+
+const makeTrack = (name: string, operations: Track["operations"]): Track => ({
+  id: `track-${name}`,
+  name,
+  operations,
+});
+
+describe("intersectRegion", () => {
+  test("segment fully inside region — included with remapped frames", () => {
+    const segments = [
+      makeSegment("s1", "media-1", 0, 300),
+    ];
+    const region = { startFrame: 50, endFrame: 250 };
+
+    const result = intersectRegion(segments, [], region);
+
+    expect(result.segments).toHaveLength(1);
+    expect(result.segments[0]).toEqual({
+      id: "s1",
+      sourceMediaId: "media-1",
+      sourceStartFrame: 50,
+      sourceEndFrame: 250,
+      sequenceStartFrame: 0,
+      sequenceEndFrame: 200,
+    });
+  });
+
+  test("segment fully outside region — excluded", () => {
+    const segments = [
+      makeSegment("s1", "media-1", 0, 100),
+      makeSegment("s2", "media-2", 0, 100),
+    ];
+    // s1 occupies [0,100), s2 occupies [100,200) in sequence
+    const region = { startFrame: 300, endFrame: 500 };
+
+    const result = intersectRegion(segments, [], region);
+
+    expect(result.segments).toHaveLength(0);
+  });
+
+  test("segment partially overlapping — region clips start", () => {
+    // Single segment: source [100,400), sequence [0,300)
+    const segments = [makeSegment("s1", "media-1", 100, 400)];
+    // Region starts at 50 into the segment
+    const region = { startFrame: 50, endFrame: 300 };
+
+    const result = intersectRegion(segments, [], region);
+
+    expect(result.segments).toHaveLength(1);
+    expect(result.segments[0]).toEqual({
+      id: "s1",
+      sourceMediaId: "media-1",
+      sourceStartFrame: 150, // 100 + 50 clipped from start
+      sourceEndFrame: 400,
+      sequenceStartFrame: 0,
+      sequenceEndFrame: 250,
+    });
+  });
+
+  test("segment partially overlapping — region clips end", () => {
+    // Single segment: source [0,300), sequence [0,300)
+    const segments = [makeSegment("s1", "media-1", 0, 300)];
+    const region = { startFrame: 0, endFrame: 200 };
+
+    const result = intersectRegion(segments, [], region);
+
+    expect(result.segments).toHaveLength(1);
+    expect(result.segments[0]).toEqual({
+      id: "s1",
+      sourceMediaId: "media-1",
+      sourceStartFrame: 0,
+      sourceEndFrame: 200,
+      sequenceStartFrame: 0,
+      sequenceEndFrame: 200,
+    });
+  });
+
+  test("operations fully inside — included with remapped frames", () => {
+    const tracks = [
+      makeTrack("T1", [
+        {
+          type: "caption",
+          id: "op1",
+          text: "Hello",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 150,
+          endFrame: 250,
+        },
+      ]),
+    ];
+    const region = { startFrame: 100, endFrame: 400 };
+
+    const result = intersectRegion([], tracks, region);
+
+    expect(result.operations).toHaveLength(1);
+    expect(result.operations[0].startFrame).toBe(50); // 150 - 100
+    expect(result.operations[0].endFrame).toBe(150); // 250 - 100
+  });
+
+  test("operations partially overlapping — clipped and remapped", () => {
+    const tracks = [
+      makeTrack("T1", [
+        {
+          type: "caption",
+          id: "op1",
+          text: "Hello",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 50,
+          endFrame: 250,
+        },
+      ]),
+    ];
+    const region = { startFrame: 100, endFrame: 200 };
+
+    const result = intersectRegion([], tracks, region);
+
+    expect(result.operations).toHaveLength(1);
+    expect(result.operations[0].startFrame).toBe(0); // clamped to region start
+    expect(result.operations[0].endFrame).toBe(100); // clamped to region end: 200 - 100
+  });
+
+  test("operations fully outside — excluded", () => {
+    const tracks = [
+      makeTrack("T1", [
+        {
+          type: "caption",
+          id: "op1",
+          text: "Hello",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 500,
+          endFrame: 600,
+        },
+      ]),
+    ];
+    const region = { startFrame: 100, endFrame: 200 };
+
+    const result = intersectRegion([], tracks, region);
+
+    expect(result.operations).toHaveLength(0);
+  });
+
+  test("total duration equals region length", () => {
+    const region = { startFrame: 100, endFrame: 350 };
+    const result = intersectRegion([], [], region);
+
+    expect(result.totalDuration).toBe(250);
+  });
+
+  test("empty region (startFrame === endFrame) returns empty", () => {
+    const segments = [makeSegment("s1", "media-1", 0, 300)];
+    const tracks = [
+      makeTrack("T1", [
+        {
+          type: "caption",
+          id: "op1",
+          text: "Hello",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 0,
+          endFrame: 100,
+        },
+      ]),
+    ];
+    const region = { startFrame: 100, endFrame: 100 };
+
+    const result = intersectRegion(segments, tracks, region);
+
+    expect(result.segments).toHaveLength(0);
+    expect(result.operations).toHaveLength(0);
+    expect(result.totalDuration).toBe(0);
+  });
+
+  test("region spanning single segment", () => {
+    // Two segments: s1 [0,200), s2 [200,500) in sequence
+    const segments = [
+      makeSegment("s1", "media-1", 0, 200),
+      makeSegment("s2", "media-2", 0, 300),
+    ];
+    // Region covers only s2
+    const region = { startFrame: 200, endFrame: 500 };
+
+    const result = intersectRegion(segments, [], region);
+
+    expect(result.segments).toHaveLength(1);
+    expect(result.segments[0]).toEqual({
+      id: "s2",
+      sourceMediaId: "media-2",
+      sourceStartFrame: 0,
+      sourceEndFrame: 300,
+      sequenceStartFrame: 0,
+      sequenceEndFrame: 300,
+    });
+  });
+
+  test("operations without frame ranges pass through unchanged", () => {
+    const tracks = [
+      makeTrack("T1", [
+        {
+          type: "crop",
+          id: "op1",
+          x: 0,
+          y: 0,
+          width: 1,
+          height: 1,
+        } as Track["operations"][0],
+      ]),
+    ];
+    const region = { startFrame: 0, endFrame: 100 };
+
+    const result = intersectRegion([], tracks, region);
+
+    expect(result.operations).toHaveLength(1);
+    expect((result.operations[0] as Record<string, unknown>).type).toBe("crop");
+  });
+
+  test("transition at region boundary is reduced", () => {
+    // s1: source [0,200), seq [0,200)
+    // s2: source [0,200), transition 30 frames crossfade, seq [170,370)
+    const segments = [
+      makeSegment("s1", "media-1", 0, 200),
+      makeSegment("s2", "media-2", 0, 200, { type: "crossfade", durationFrames: 30 }),
+    ];
+    // Region starts at 180, which is 10 frames into s2's transition (which starts at 170)
+    const region = { startFrame: 180, endFrame: 370 };
+
+    const result = intersectRegion(segments, [], region);
+
+    // s1 overlaps [170..200) mapped to [0..200), region clips to [180,200) => seq [0,20)
+    // s2 overlaps [170..370), region clips to [180,370) => seq [0,190)
+    const s2 = result.segments.find((s) => s.id === "s2");
+    expect(s2).toBeDefined();
+    // Transition originally 30 frames starting at 170. Region starts at 180, so 20 frames remain
+    expect(s2!.transition).toEqual({ type: "crossfade", durationFrames: 20 });
+  });
+
+  test("transition fully inside region is preserved", () => {
+    const segments = [
+      makeSegment("s1", "media-1", 0, 200),
+      makeSegment("s2", "media-2", 0, 200, { type: "crossfade", durationFrames: 30 }),
+    ];
+    // Region covers everything: [0, 370)
+    const region = { startFrame: 0, endFrame: 370 };
+
+    const result = intersectRegion(segments, [], region);
+
+    const s2 = result.segments.find((s) => s.id === "s2");
+    expect(s2).toBeDefined();
+    expect(s2!.transition).toEqual({ type: "crossfade", durationFrames: 30 });
+  });
+
+  test("multiple segments and operations together", () => {
+    const segments = [
+      makeSegment("s1", "media-1", 0, 200),
+      makeSegment("s2", "media-2", 50, 350),
+    ];
+    // seq: s1 [0,200), s2 [200,500)
+    const tracks = [
+      makeTrack("T1", [
+        {
+          type: "caption",
+          id: "op1",
+          text: "A",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 100,
+          endFrame: 300,
+        },
+        {
+          type: "caption",
+          id: "op2",
+          text: "B",
+          x: 0.5,
+          y: 0.5,
+          fontSize: 0.05,
+          color: "#fff",
+          animation: "fade-in" as const,
+          startFrame: 600,
+          endFrame: 700,
+        },
+      ]),
+    ];
+    const region = { startFrame: 150, endFrame: 400 };
+
+    const result = intersectRegion(segments, tracks, region);
+
+    // s1 overlaps: [150,200) in seq => source [150,200), remapped [0,50)
+    // s2 overlaps: [200,400) in seq => source [50,250), remapped [50,250)
+    expect(result.segments).toHaveLength(2);
+    expect(result.segments[0].sequenceStartFrame).toBe(0);
+    expect(result.segments[0].sequenceEndFrame).toBe(50);
+    expect(result.segments[1].sequenceStartFrame).toBe(50);
+    expect(result.segments[1].sequenceEndFrame).toBe(250);
+
+    // op1: [100,300) intersects [150,400) => clamped [150,300) => remapped [0,150)
+    // op2: fully outside
+    expect(result.operations).toHaveLength(1);
+    expect(result.operations[0].startFrame).toBe(0);
+    expect(result.operations[0].endFrame).toBe(150);
+
+    expect(result.totalDuration).toBe(250);
+  });
+});

--- a/@fanslib/apps/web/src/features/editor/utils/sequence-engine.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/sequence-engine.ts
@@ -1,0 +1,80 @@
+export type Segment = {
+  id: string;
+  sourceMediaId: string;
+  sourceStartFrame: number;
+  sourceEndFrame: number;
+  transition?: {
+    type: "crossfade";
+    durationFrames: number;
+  };
+};
+
+export type SequencePosition = {
+  segmentId: string;
+  sequenceStartFrame: number;
+  sequenceEndFrame: number;
+};
+
+export type SequenceTimeline = {
+  positions: SequencePosition[];
+  totalDuration: number;
+};
+
+export type SourceFrameMapping = {
+  segmentId: string;
+  sourceMediaId: string;
+  sourceFrame: number;
+};
+
+export const mapSequenceFrameToSource = (
+  sequenceFrame: number,
+  timeline: SequenceTimeline,
+  segments: Segment[],
+): SourceFrameMapping[] =>
+  timeline.positions.reduce<SourceFrameMapping[]>((results, position, i) => {
+    const segment = segments[i]!;
+    if (sequenceFrame >= position.sequenceStartFrame && sequenceFrame < position.sequenceEndFrame) {
+      const offsetInSegment = sequenceFrame - position.sequenceStartFrame;
+      return [
+        ...results,
+        {
+          segmentId: segment.id,
+          sourceMediaId: segment.sourceMediaId,
+          sourceFrame: segment.sourceStartFrame + offsetInSegment,
+        },
+      ];
+    }
+    return results;
+  }, []);
+
+export const computeSequenceTimeline = (segments: Segment[]): SequenceTimeline => {
+  if (segments.length === 0) {
+    return { positions: [], totalDuration: 0 };
+  }
+
+  const positions = segments.reduce<{ positions: SequencePosition[]; cursor: number }>(
+    (acc, segment, i) => {
+      const segmentDuration = segment.sourceEndFrame - segment.sourceStartFrame;
+      const overlap = i > 0 && segment.transition ? segment.transition.durationFrames : 0;
+      const start = acc.cursor - overlap;
+
+      return {
+        positions: [
+          ...acc.positions,
+          {
+            segmentId: segment.id,
+            sequenceStartFrame: start,
+            sequenceEndFrame: start + segmentDuration,
+          },
+        ],
+        cursor: start + segmentDuration,
+      };
+    },
+    { positions: [], cursor: 0 },
+  );
+
+  return {
+    positions: positions.positions,
+    totalDuration: positions.cursor,
+  };
+};

--- a/@fanslib/apps/web/src/features/editor/utils/sequence-engine.vitest.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/sequence-engine.vitest.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "vitest";
+import { computeSequenceTimeline, mapSequenceFrameToSource } from "./sequence-engine";
+
+describe("sequence engine", () => {
+  describe("computeSequenceTimeline", () => {
+    test("single segment starts at frame 0", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+      ]);
+      expect(result.totalDuration).toBe(300);
+    });
+
+    test("crossfade transition causes segment overlap", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        {
+          id: "s2",
+          sourceMediaId: "m2",
+          sourceStartFrame: 0,
+          sourceEndFrame: 200,
+          transition: { type: "crossfade", durationFrames: 30 },
+        },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+        { segmentId: "s2", sequenceStartFrame: 270, sequenceEndFrame: 470 },
+      ]);
+      expect(result.totalDuration).toBe(470);
+    });
+
+    test("three segments with mixed transitions", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+        {
+          id: "s3",
+          sourceMediaId: "m3",
+          sourceStartFrame: 100,
+          sourceEndFrame: 250,
+          transition: { type: "crossfade", durationFrames: 20 },
+        },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+        { segmentId: "s2", sequenceStartFrame: 300, sequenceEndFrame: 500 },
+        { segmentId: "s3", sequenceStartFrame: 480, sequenceEndFrame: 630 },
+      ]);
+      expect(result.totalDuration).toBe(630);
+    });
+
+    test("total duration with crossfade is reduced by overlap amount", () => {
+      const withoutCrossfade = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ]);
+
+      const withCrossfade = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        {
+          id: "s2",
+          sourceMediaId: "m2",
+          sourceStartFrame: 0,
+          sourceEndFrame: 200,
+          transition: { type: "crossfade", durationFrames: 30 },
+        },
+      ]);
+
+      expect(withoutCrossfade.totalDuration - withCrossfade.totalDuration).toBe(30);
+    });
+
+    test("empty segments array returns totalDuration 0 and empty positions", () => {
+      const result = computeSequenceTimeline([]);
+
+      expect(result.positions).toEqual([]);
+      expect(result.totalDuration).toBe(0);
+    });
+
+    test("two segments with hard cuts are contiguous", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+        { segmentId: "s2", sequenceStartFrame: 300, sequenceEndFrame: 500 },
+      ]);
+      expect(result.totalDuration).toBe(500);
+    });
+  });
+
+  describe("mapSequenceFrameToSource", () => {
+    test("returns correct segment and source frame for frame in first segment", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 100, sourceEndFrame: 400 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ] as const;
+      const timeline = computeSequenceTimeline([...segments]);
+
+      const result = mapSequenceFrameToSource(50, timeline, [...segments]);
+
+      expect(result).toEqual([
+        { segmentId: "s1", sourceMediaId: "m1", sourceFrame: 150 },
+      ]);
+    });
+    test("during crossfade overlap returns both segments with correct source frames", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        {
+          id: "s2",
+          sourceMediaId: "m2",
+          sourceStartFrame: 0,
+          sourceEndFrame: 200,
+          transition: { type: "crossfade" as const, durationFrames: 30 },
+        },
+      ];
+      const timeline = computeSequenceTimeline(segments);
+
+      // s1: 0-300, s2: 270-470. Frame 280 is in the overlap region (270-300).
+      const result = mapSequenceFrameToSource(280, timeline, segments);
+
+      expect(result).toEqual([
+        { segmentId: "s1", sourceMediaId: "m1", sourceFrame: 280 },
+        { segmentId: "s2", sourceMediaId: "m2", sourceFrame: 10 },
+      ]);
+    });
+
+    test("frame exactly at hard-cut segment boundary belongs to second segment", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ];
+      const timeline = computeSequenceTimeline(segments);
+
+      // s1: [0, 300), s2: [300, 500). Frame 300 is the boundary.
+      const result = mapSequenceFrameToSource(300, timeline, segments);
+
+      expect(result).toEqual([
+        { segmentId: "s2", sourceMediaId: "m2", sourceFrame: 0 },
+      ]);
+    });
+
+    test("returns correct segment for frame in second segment after hard cut", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 50, sourceEndFrame: 250 },
+      ] as const;
+      const timeline = computeSequenceTimeline([...segments]);
+
+      const result = mapSequenceFrameToSource(350, timeline, [...segments]);
+
+      expect(result).toEqual([
+        { segmentId: "s2", sourceMediaId: "m2", sourceFrame: 100 },
+      ]);
+    });
+    test("single segment with 0-duration transition is ignored", () => {
+      const segments = [
+        {
+          id: "s1",
+          sourceMediaId: "m1",
+          sourceStartFrame: 0,
+          sourceEndFrame: 300,
+          transition: { type: "crossfade" as const, durationFrames: 0 },
+        },
+      ];
+      const timeline = computeSequenceTimeline(segments);
+
+      expect(timeline.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+      ]);
+      expect(timeline.totalDuration).toBe(300);
+    });
+  });
+});

--- a/@fanslib/apps/web/src/stores/editorStore.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { type CropOperation, normalizeCropOperation } from "~/features/editor/utils/crop-operation";
+import type { Segment } from "~/features/editor/utils/sequence-engine";
 
 type Track = {
   id: string;
@@ -9,6 +10,8 @@ type Track = {
 
 type EditorState = {
   tracks: Track[];
+  segments: Segment[];
+  selectedSegmentId: string | null;
   operations: unknown[];
   selectedOperationIndex: number | null;
   selectedOperationId: string | null;
@@ -71,6 +74,14 @@ type EditorState = {
   // Watermark convenience
   addWatermark: (assetId: string) => void;
 
+  // Segment mutations
+  addSegment: (segment: Omit<Segment, "id">) => void;
+  removeSegment: (segmentId: string) => void;
+  reorderSegments: (segmentId: string, newIndex: number) => void;
+  trimSegmentStart: (segmentId: string, newSourceStartFrame: number) => void;
+  trimSegmentEnd: (segmentId: string, newSourceEndFrame: number) => void;
+  selectSegment: (segmentId: string | null) => void;
+
   // Track management
   addTrack: () => void;
   removeTrack: (trackId: string) => void;
@@ -86,15 +97,15 @@ type EditorState = {
   markClean: () => void;
 
   // Hydrate from existing MediaEdit
-  hydrate: (data: unknown[] | { tracks: Track[] }) => void;
-  // Restore tracks from unified history snapshot (does not touch per-store undo stacks)
-  restoreTracks: (tracks: unknown[]) => void;
+  hydrate: (data: unknown[] | { tracks: Track[]; segments?: Segment[] }) => void;
+  // Restore tracks (and optionally segments) from unified history snapshot (does not touch per-store undo stacks)
+  restoreTracks: (tracks: unknown[], segments?: Segment[]) => void;
 
   // Reset
   reset: () => void;
 };
 
-type HistoryEntry = Track[];
+type HistoryEntry = { tracks: Track[]; segments: Segment[] };
 
 const makeDefaultTrack = (): Track => ({
   id: crypto.randomUUID(),
@@ -158,8 +169,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
     return tracks.length - 1;
   };
 
+  const cloneSegments = (segments: Segment[]): Segment[] =>
+    segments.map((s) => ({ ...s, transition: s.transition ? { ...s.transition } : undefined }));
+
   const pushHistory = () => {
-    undoStack.push(cloneTracks(get().tracks));
+    const state = get();
+    undoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
     redoStack = []; // Clear redo on new mutation
   };
 
@@ -173,6 +188,8 @@ export const useEditorStore = create<EditorState>((set, get) => {
 
   return {
     tracks: [initialTrack],
+    segments: [],
+    selectedSegmentId: null,
     operations: [],
     selectedOperationIndex: null,
     selectedOperationId: null,
@@ -373,10 +390,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
     undo: () => {
       const previous = undoStack.pop();
       if (previous === undefined) return;
-      redoStack.push(cloneTracks(get().tracks));
+      const state = get();
+      redoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
       set({
-        tracks: previous,
-        operations: flattenTracks(previous),
+        tracks: previous.tracks,
+        segments: previous.segments,
+        operations: flattenTracks(previous.tracks),
         canUndo: undoStack.length > 0,
         canRedo: true,
         cropEditingOperationIndex: null,
@@ -387,10 +406,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
     redo: () => {
       const next = redoStack.pop();
       if (next === undefined) return;
-      undoStack.push(cloneTracks(get().tracks));
+      const state = get();
+      undoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
       set({
-        tracks: next,
-        operations: flattenTracks(next),
+        tracks: next.tracks,
+        segments: next.segments,
+        operations: flattenTracks(next.tracks),
         canUndo: true,
         canRedo: redoStack.length > 0,
         cropEditingOperationIndex: null,
@@ -697,6 +718,60 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set({ selectedOperationId: id });
     },
 
+    addSegment: (segment) => {
+      pushHistory();
+      set((state) => ({
+        segments: [...state.segments, { ...segment, id: crypto.randomUUID() }],
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    removeSegment: (segmentId) => {
+      pushHistory();
+      set((state) => ({
+        segments: state.segments.filter((s) => s.id !== segmentId),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    reorderSegments: (segmentId, newIndex) => {
+      pushHistory();
+      set((state) => {
+        const segments = [...state.segments];
+        const fromIndex = segments.findIndex((s) => s.id === segmentId);
+        if (fromIndex === -1) return { ...updateUndoRedoFlags() };
+        const [moved] = segments.splice(fromIndex, 1);
+        // Drop transition if moved to index 0
+        const placed = newIndex === 0 ? { ...moved, transition: undefined } : moved;
+        segments.splice(newIndex, 0, placed);
+        return { segments, ...updateUndoRedoFlags() };
+      });
+    },
+
+    trimSegmentStart: (segmentId, newSourceStartFrame) => {
+      pushHistory();
+      set((state) => ({
+        segments: state.segments.map((s) =>
+          s.id === segmentId ? { ...s, sourceStartFrame: newSourceStartFrame } : s,
+        ),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    trimSegmentEnd: (segmentId, newSourceEndFrame) => {
+      pushHistory();
+      set((state) => ({
+        segments: state.segments.map((s) =>
+          s.id === segmentId ? { ...s, sourceEndFrame: newSourceEndFrame } : s,
+        ),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    selectSegment: (segmentId) => {
+      set({ selectedSegmentId: segmentId });
+    },
+
     addTrack: () => {
       pushHistory();
       set((state) => {
@@ -763,7 +838,8 @@ export const useEditorStore = create<EditorState>((set, get) => {
       redoStack = [];
 
       // Detect format: array = legacy flat operations, object with tracks = new format
-      const tracks: Track[] = Array.isArray(data)
+      const isLegacy = Array.isArray(data);
+      const tracks: Track[] = isLegacy
         ? [
             {
               id: crypto.randomUUID(),
@@ -779,11 +855,17 @@ export const useEditorStore = create<EditorState>((set, get) => {
           ]
         : (data as { tracks: Track[] }).tracks;
 
+      const segments: Segment[] = isLegacy
+        ? []
+        : (data as { segments?: Segment[] }).segments ?? [];
+
       set({
         tracks,
+        segments,
         operations: flattenTracks(tracks),
         selectedOperationIndex: null,
         selectedOperationId: null,
+        selectedSegmentId: null,
         cropEditingOperationIndex: null,
         cropEditingOperationId: null,
         canUndo: false,
@@ -792,11 +874,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
       });
     },
 
-    restoreTracks: (rawTracks) => {
+    restoreTracks: (rawTracks, segments) => {
       const tracks = rawTracks as Track[];
       set({
         tracks,
         operations: flattenTracks(tracks),
+        ...(segments !== undefined ? { segments } : {}),
       });
     },
 
@@ -805,6 +888,8 @@ export const useEditorStore = create<EditorState>((set, get) => {
       redoStack = [];
       set({
         tracks: [makeDefaultTrack()],
+        segments: [],
+        selectedSegmentId: null,
         operations: [],
         selectedOperationIndex: null,
         selectedOperationId: null,

--- a/@fanslib/apps/web/src/stores/editorStore.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.ts
@@ -8,6 +8,16 @@ type Track = {
   operations: unknown[];
 };
 
+type ExportRegion = {
+  id: string;
+  startFrame: number;
+  endFrame: number;
+  package?: string | null;
+  role?: string | null;
+  contentRating?: string | null;
+  quality?: string | null;
+};
+
 type EditorState = {
   tracks: Track[];
   segments: Segment[];
@@ -23,6 +33,12 @@ type EditorState = {
   isDirty: boolean;
   sourceMediaId: string | null;
   editId: string | null;
+
+  // Export region state
+  exportRegions: ExportRegion[];
+  exportRegionMode: boolean;
+  selectedExportRegionId: string | null;
+  pendingExportMarkIn: number | null;
 
   // Mutation actions (push to undo stack)
   addOperation: (op: unknown) => void;
@@ -74,6 +90,15 @@ type EditorState = {
   // Watermark convenience
   addWatermark: (assetId: string) => void;
 
+  // Export region mutations
+  toggleExportRegionMode: () => void;
+  setExportMarkIn: (frame: number) => void;
+  commitExportMarkOut: (frame: number) => void;
+  addExportRegion: (region: Omit<ExportRegion, "id">) => void;
+  removeExportRegion: (id: string) => void;
+  updateExportRegion: (id: string, updates: Partial<ExportRegion>) => void;
+  selectExportRegion: (id: string | null) => void;
+
   // Segment mutations
   addSegment: (segment: Omit<Segment, "id">) => void;
   removeSegment: (segmentId: string) => void;
@@ -97,7 +122,7 @@ type EditorState = {
   markClean: () => void;
 
   // Hydrate from existing MediaEdit
-  hydrate: (data: unknown[] | { tracks: Track[]; segments?: Segment[] }) => void;
+  hydrate: (data: unknown[] | { tracks: Track[]; segments?: Segment[]; exportRegions?: ExportRegion[] }) => void;
   // Restore tracks (and optionally segments) from unified history snapshot (does not touch per-store undo stacks)
   restoreTracks: (tracks: unknown[], segments?: Segment[]) => void;
 
@@ -105,7 +130,7 @@ type EditorState = {
   reset: () => void;
 };
 
-type HistoryEntry = { tracks: Track[]; segments: Segment[] };
+type HistoryEntry = { tracks: Track[]; segments: Segment[]; exportRegions: ExportRegion[] };
 
 const makeDefaultTrack = (): Track => ({
   id: crypto.randomUUID(),
@@ -172,9 +197,16 @@ export const useEditorStore = create<EditorState>((set, get) => {
   const cloneSegments = (segments: Segment[]): Segment[] =>
     segments.map((s) => ({ ...s, transition: s.transition ? { ...s.transition } : undefined }));
 
+  const cloneExportRegions = (regions: ExportRegion[]): ExportRegion[] =>
+    regions.map((r) => ({ ...r }));
+
   const pushHistory = () => {
     const state = get();
-    undoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
+    undoStack.push({
+      tracks: cloneTracks(state.tracks),
+      segments: cloneSegments(state.segments),
+      exportRegions: cloneExportRegions(state.exportRegions),
+    });
     redoStack = []; // Clear redo on new mutation
   };
 
@@ -200,6 +232,10 @@ export const useEditorStore = create<EditorState>((set, get) => {
     sourceMediaId: null,
     editId: null,
     canRedo: false,
+    exportRegions: [],
+    exportRegionMode: false,
+    selectedExportRegionId: null,
+    pendingExportMarkIn: null,
 
     addOperation: (op) => {
       pushHistory();
@@ -391,10 +427,15 @@ export const useEditorStore = create<EditorState>((set, get) => {
       const previous = undoStack.pop();
       if (previous === undefined) return;
       const state = get();
-      redoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
+      redoStack.push({
+        tracks: cloneTracks(state.tracks),
+        segments: cloneSegments(state.segments),
+        exportRegions: cloneExportRegions(state.exportRegions),
+      });
       set({
         tracks: previous.tracks,
         segments: previous.segments,
+        exportRegions: previous.exportRegions,
         operations: flattenTracks(previous.tracks),
         canUndo: undoStack.length > 0,
         canRedo: true,
@@ -407,10 +448,15 @@ export const useEditorStore = create<EditorState>((set, get) => {
       const next = redoStack.pop();
       if (next === undefined) return;
       const state = get();
-      undoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
+      undoStack.push({
+        tracks: cloneTracks(state.tracks),
+        segments: cloneSegments(state.segments),
+        exportRegions: cloneExportRegions(state.exportRegions),
+      });
       set({
         tracks: next.tracks,
         segments: next.segments,
+        exportRegions: next.exportRegions,
         operations: flattenTracks(next.tracks),
         canUndo: true,
         canRedo: redoStack.length > 0,
@@ -718,6 +764,64 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set({ selectedOperationId: id });
     },
 
+    toggleExportRegionMode: () => {
+      set((state) => ({ exportRegionMode: !state.exportRegionMode }));
+    },
+
+    setExportMarkIn: (frame) => {
+      set({ pendingExportMarkIn: frame });
+    },
+
+    commitExportMarkOut: (frame) => {
+      const state = get();
+      const markIn = state.pendingExportMarkIn;
+      if (markIn === null) return;
+      const startFrame = Math.min(markIn, frame);
+      const endFrame = Math.max(markIn, frame);
+      pushHistory();
+      set((prev) => ({
+        exportRegions: [
+          ...prev.exportRegions,
+          { id: crypto.randomUUID(), startFrame, endFrame },
+        ],
+        pendingExportMarkIn: null,
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    addExportRegion: (region) => {
+      pushHistory();
+      set((state) => ({
+        exportRegions: [
+          ...state.exportRegions,
+          { ...region, id: crypto.randomUUID() },
+        ],
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    removeExportRegion: (id) => {
+      pushHistory();
+      set((state) => ({
+        exportRegions: state.exportRegions.filter((r) => r.id !== id),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    updateExportRegion: (id, updates) => {
+      pushHistory();
+      set((state) => ({
+        exportRegions: state.exportRegions.map((r) =>
+          r.id === id ? { ...r, ...updates, id } : r,
+        ),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    selectExportRegion: (id) => {
+      set({ selectedExportRegionId: id });
+    },
+
     addSegment: (segment) => {
       pushHistory();
       set((state) => ({
@@ -859,15 +963,23 @@ export const useEditorStore = create<EditorState>((set, get) => {
         ? []
         : (data as { segments?: Segment[] }).segments ?? [];
 
+      const exportRegions: ExportRegion[] = isLegacy
+        ? []
+        : (data as { exportRegions?: ExportRegion[] }).exportRegions ?? [];
+
       set({
         tracks,
         segments,
+        exportRegions,
         operations: flattenTracks(tracks),
         selectedOperationIndex: null,
         selectedOperationId: null,
         selectedSegmentId: null,
+        selectedExportRegionId: null,
         cropEditingOperationIndex: null,
         cropEditingOperationId: null,
+        exportRegionMode: false,
+        pendingExportMarkIn: null,
         canUndo: false,
         canRedo: false,
         isDirty: false,
@@ -895,6 +1007,10 @@ export const useEditorStore = create<EditorState>((set, get) => {
         selectedOperationId: null,
         cropEditingOperationIndex: null,
         cropEditingOperationId: null,
+        exportRegions: [],
+        exportRegionMode: false,
+        selectedExportRegionId: null,
+        pendingExportMarkIn: null,
         canUndo: false,
         canRedo: false,
         isDirty: false,

--- a/@fanslib/apps/web/src/stores/editorStore.vitest.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.vitest.ts
@@ -757,6 +757,126 @@ describe("editorStore", () => {
     });
   });
 
+  describe("export regions", () => {
+    test("addExportRegion appends with generated id", () => {
+      useEditorStore.getState().addExportRegion({
+        startFrame: 0,
+        endFrame: 90,
+      });
+      const regions = useEditorStore.getState().exportRegions;
+      expect(regions).toHaveLength(1);
+      expect(regions[0].startFrame).toBe(0);
+      expect(regions[0].endFrame).toBe(90);
+      expect(typeof regions[0].id).toBe("string");
+      expect(regions[0].id.length).toBeGreaterThan(0);
+    });
+
+    test("removeExportRegion removes by id", () => {
+      useEditorStore.getState().addExportRegion({ startFrame: 0, endFrame: 90 });
+      useEditorStore.getState().addExportRegion({ startFrame: 100, endFrame: 200 });
+      const id = useEditorStore.getState().exportRegions[0].id;
+      useEditorStore.getState().removeExportRegion(id);
+      const regions = useEditorStore.getState().exportRegions;
+      expect(regions).toHaveLength(1);
+      expect(regions[0].startFrame).toBe(100);
+    });
+
+    test("updateExportRegion modifies metadata", () => {
+      useEditorStore.getState().addExportRegion({ startFrame: 0, endFrame: 90 });
+      const id = useEditorStore.getState().exportRegions[0].id;
+      useEditorStore.getState().updateExportRegion(id, {
+        package: "premium",
+        role: "trailer",
+        contentRating: "PG",
+        quality: "1080p",
+      });
+      const region = useEditorStore.getState().exportRegions[0];
+      expect(region.package).toBe("premium");
+      expect(region.role).toBe("trailer");
+      expect(region.contentRating).toBe("PG");
+      expect(region.quality).toBe("1080p");
+      expect(region.startFrame).toBe(0);
+      expect(region.endFrame).toBe(90);
+    });
+
+    test("I/O marking: setExportMarkIn + commitExportMarkOut creates a region", () => {
+      useEditorStore.getState().setExportMarkIn(10);
+      expect(useEditorStore.getState().pendingExportMarkIn).toBe(10);
+      useEditorStore.getState().commitExportMarkOut(50);
+      const regions = useEditorStore.getState().exportRegions;
+      expect(regions).toHaveLength(1);
+      expect(regions[0].startFrame).toBe(10);
+      expect(regions[0].endFrame).toBe(50);
+    });
+
+    test("commitExportMarkOut clears pendingExportMarkIn", () => {
+      useEditorStore.getState().setExportMarkIn(10);
+      useEditorStore.getState().commitExportMarkOut(50);
+      expect(useEditorStore.getState().pendingExportMarkIn).toBeNull();
+    });
+
+    test("commitExportMarkOut swaps frames when markIn > frame (backward marking)", () => {
+      useEditorStore.getState().setExportMarkIn(80);
+      useEditorStore.getState().commitExportMarkOut(20);
+      const region = useEditorStore.getState().exportRegions[0];
+      expect(region.startFrame).toBe(20);
+      expect(region.endFrame).toBe(80);
+    });
+
+    test("toggleExportRegionMode toggles the boolean", () => {
+      expect(useEditorStore.getState().exportRegionMode).toBe(false);
+      useEditorStore.getState().toggleExportRegionMode();
+      expect(useEditorStore.getState().exportRegionMode).toBe(true);
+      useEditorStore.getState().toggleExportRegionMode();
+      expect(useEditorStore.getState().exportRegionMode).toBe(false);
+    });
+
+    test("selectExportRegion sets selection", () => {
+      useEditorStore.getState().addExportRegion({ startFrame: 0, endFrame: 90 });
+      const id = useEditorStore.getState().exportRegions[0].id;
+      useEditorStore.getState().selectExportRegion(id);
+      expect(useEditorStore.getState().selectedExportRegionId).toBe(id);
+      useEditorStore.getState().selectExportRegion(null);
+      expect(useEditorStore.getState().selectedExportRegionId).toBeNull();
+    });
+
+    test("undo reverts addExportRegion", () => {
+      useEditorStore.getState().addExportRegion({ startFrame: 0, endFrame: 90 });
+      expect(useEditorStore.getState().exportRegions).toHaveLength(1);
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().exportRegions).toHaveLength(0);
+      useEditorStore.getState().redo();
+      expect(useEditorStore.getState().exportRegions).toHaveLength(1);
+    });
+
+    test("hydrate restores exportRegions", () => {
+      const data = {
+        tracks: [{ id: "t1", name: "Track 1", operations: [] }],
+        exportRegions: [
+          { id: "er1", startFrame: 0, endFrame: 90, package: "basic" },
+          { id: "er2", startFrame: 100, endFrame: 200 },
+        ],
+      };
+      useEditorStore.getState().hydrate(data);
+      expect(useEditorStore.getState().exportRegions).toHaveLength(2);
+      expect(useEditorStore.getState().exportRegions[0].id).toBe("er1");
+      expect(useEditorStore.getState().exportRegions[0].package).toBe("basic");
+      expect(useEditorStore.getState().exportRegions[1].startFrame).toBe(100);
+    });
+
+    test("reset clears exportRegions", () => {
+      useEditorStore.getState().addExportRegion({ startFrame: 0, endFrame: 90 });
+      useEditorStore.getState().toggleExportRegionMode();
+      useEditorStore.getState().selectExportRegion(useEditorStore.getState().exportRegions[0].id);
+      useEditorStore.getState().setExportMarkIn(10);
+      useEditorStore.getState().reset();
+      expect(useEditorStore.getState().exportRegions).toEqual([]);
+      expect(useEditorStore.getState().exportRegionMode).toBe(false);
+      expect(useEditorStore.getState().selectedExportRegionId).toBeNull();
+      expect(useEditorStore.getState().pendingExportMarkIn).toBeNull();
+    });
+  });
+
   describe("zoom operations", () => {
     test("addZoom adds a zoom operation with default values", () => {
       useEditorStore.getState().addZoom();

--- a/@fanslib/apps/web/src/stores/editorStore.vitest.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.vitest.ts
@@ -631,6 +631,132 @@ describe("editorStore", () => {
     });
   });
 
+  describe("segments", () => {
+    test("addSegment appends a segment with generated id", () => {
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "media-1",
+        sourceStartFrame: 0,
+        sourceEndFrame: 90,
+      });
+      const segments = useEditorStore.getState().segments;
+      expect(segments).toHaveLength(1);
+      expect(segments[0].sourceMediaId).toBe("media-1");
+      expect(segments[0].sourceStartFrame).toBe(0);
+      expect(segments[0].sourceEndFrame).toBe(90);
+      expect(typeof segments[0].id).toBe("string");
+      expect(segments[0].id.length).toBeGreaterThan(0);
+    });
+
+    test("removeSegment removes by id", () => {
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "media-1",
+        sourceStartFrame: 0,
+        sourceEndFrame: 90,
+      });
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "media-2",
+        sourceStartFrame: 0,
+        sourceEndFrame: 60,
+      });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().removeSegment(id);
+      const segments = useEditorStore.getState().segments;
+      expect(segments).toHaveLength(1);
+      expect(segments[0].sourceMediaId).toBe("media-2");
+    });
+
+    test("reorderSegments moves to new index", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "a", sourceStartFrame: 0, sourceEndFrame: 30 });
+      useEditorStore.getState().addSegment({ sourceMediaId: "b", sourceStartFrame: 0, sourceEndFrame: 30 });
+      useEditorStore.getState().addSegment({ sourceMediaId: "c", sourceStartFrame: 0, sourceEndFrame: 30 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().reorderSegments(id, 2);
+      const segments = useEditorStore.getState().segments;
+      expect(segments[0].sourceMediaId).toBe("b");
+      expect(segments[1].sourceMediaId).toBe("c");
+      expect(segments[2].sourceMediaId).toBe("a");
+    });
+
+    test("reorderSegments drops transition when segment moves to index 0", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "a", sourceStartFrame: 0, sourceEndFrame: 30 });
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "b",
+        sourceStartFrame: 0,
+        sourceEndFrame: 30,
+        transition: { type: "crossfade", durationFrames: 10 },
+      });
+      const id = useEditorStore.getState().segments[1].id;
+      useEditorStore.getState().reorderSegments(id, 0);
+      const segments = useEditorStore.getState().segments;
+      expect(segments[0].sourceMediaId).toBe("b");
+      expect(segments[0].transition).toBeUndefined();
+    });
+
+    test("trimSegmentStart adjusts sourceStartFrame", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().trimSegmentStart(id, 15);
+      expect(useEditorStore.getState().segments[0].sourceStartFrame).toBe(15);
+    });
+
+    test("trimSegmentEnd adjusts sourceEndFrame", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().trimSegmentEnd(id, 60);
+      expect(useEditorStore.getState().segments[0].sourceEndFrame).toBe(60);
+    });
+
+    test("selectSegment sets selectedSegmentId", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().selectSegment(id);
+      expect(useEditorStore.getState().selectedSegmentId).toBe(id);
+      useEditorStore.getState().selectSegment(null);
+      expect(useEditorStore.getState().selectedSegmentId).toBeNull();
+    });
+
+    test("undo/redo works for segment mutations", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      expect(useEditorStore.getState().segments).toHaveLength(1);
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().segments).toHaveLength(0);
+      useEditorStore.getState().redo();
+      expect(useEditorStore.getState().segments).toHaveLength(1);
+      expect(useEditorStore.getState().segments[0].sourceMediaId).toBe("media-1");
+    });
+
+    test("undo/redo still works for operation mutations (regression)", () => {
+      useEditorStore.getState().addOperation({ type: "blur" });
+      expect(useEditorStore.getState().operations).toHaveLength(1);
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().operations).toHaveLength(0);
+      useEditorStore.getState().redo();
+      expect(useEditorStore.getState().operations).toHaveLength(1);
+    });
+
+    test("hydrate accepts and restores segments", () => {
+      const data = {
+        tracks: [{ id: "t1", name: "Track 1", operations: [] }],
+        segments: [
+          { id: "s1", sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 },
+          { id: "s2", sourceMediaId: "media-2", sourceStartFrame: 10, sourceEndFrame: 50 },
+        ],
+      };
+      useEditorStore.getState().hydrate(data);
+      expect(useEditorStore.getState().segments).toHaveLength(2);
+      expect(useEditorStore.getState().segments[0].id).toBe("s1");
+      expect(useEditorStore.getState().segments[1].sourceMediaId).toBe("media-2");
+    });
+
+    test("reset clears segments and selectedSegmentId", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      useEditorStore.getState().selectSegment(useEditorStore.getState().segments[0].id);
+      useEditorStore.getState().reset();
+      expect(useEditorStore.getState().segments).toEqual([]);
+      expect(useEditorStore.getState().selectedSegmentId).toBeNull();
+    });
+  });
+
   describe("zoom operations", () => {
     test("addZoom adds a zoom operation with default values", () => {
       useEditorStore.getState().addZoom();


### PR DESCRIPTION
## Summary

- MediaEdit entity gains `compositionId` FK, `segments` snapshot, `exportRegion` boundaries, per-region metadata
- `"composition"` added to MediaEdit type union
- `POST /api/compositions/by-id/:id/export` creates queued MediaEdits per export region
- No regions = one MediaEdit spanning whole timeline; N regions = N MediaEdits
- Per-region metadata (package, role, contentRating, quality) propagated to each MediaEdit

Stacked on #374 (Export region intersection) + merges #364 (Composition entity)

Closes #358

## Test plan

- [x] No export regions → one MediaEdit
- [x] Two export regions → two MediaEdits with correct boundaries
- [x] Each MediaEdit has compositionId, segments, tracks
- [x] Per-region metadata propagated
- [x] All edits created with "queued" status
- [x] Composition not found → error
- [x] Route returns MediaEdit array / 404
- [x] 20 composition tests pass, 8 new

🤖 Generated with [Claude Code](https://claude.com/claude-code)