### PR TITLE
feat(editor): add per-region metadata UI for export dialog

### DIFF
--- a/@fanslib/apps/web/src/features/editor/components/ExportDialog.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/ExportDialog.tsx
@@ -5,6 +5,7 @@ import { useEditorStore } from "~/stores/editorStore";
 import { useClipStore } from "~/stores/clipStore";
 import { QUERY_KEYS } from "~/lib/queries/query-keys";
 import { intersectOperationsWithClip } from "../utils/clip-intersection";
+import { ExportRegionList } from "./ExportRegionList";
 import type { Track } from "@fanslib/video/types";
 
 type ExportDialogProps = {
@@ -26,10 +27,6 @@ export const ExportDialog = ({ open, onOpenChange }: ExportDialogProps) => {
 
   const isClipExport = clipRanges.length > 0;
 
-  const [role, setRole] = useState("");
-  const [pkg, setPkg] = useState("");
-  const [contentRating, setContentRating] = useState("sg");
-  const [quality, setQuality] = useState("pretty");
   const [exporting, setExporting] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -181,54 +178,7 @@ export const ExportDialog = ({ open, onOpenChange }: ExportDialogProps) => {
           <div className="text-success text-center py-8">Queued for rendering!</div>
         ) : (
           <div className="flex flex-col gap-4">
-            <label className="flex flex-col gap-1">
-              <span className="text-sm font-medium text-base-content/70">Role</span>
-              <input
-                type="text"
-                className="input input-bordered input-sm w-full"
-                value={role}
-                onChange={(e) => setRole(e.target.value)}
-                placeholder="e.g. main, alt"
-              />
-            </label>
-
-            <label className="flex flex-col gap-1">
-              <span className="text-sm font-medium text-base-content/70">Package</span>
-              <input
-                type="text"
-                className="input input-bordered input-sm w-full"
-                value={pkg}
-                onChange={(e) => setPkg(e.target.value)}
-                placeholder="e.g. premium, free"
-              />
-            </label>
-
-            <label className="flex flex-col gap-1">
-              <span className="text-sm font-medium text-base-content/70">Content Rating</span>
-              <select
-                className="select select-bordered select-sm w-full"
-                value={contentRating}
-                onChange={(e) => setContentRating(e.target.value)}
-              >
-                <option value="sf">SF - Safe</option>
-                <option value="sg">SG - Suggestive</option>
-                <option value="cn">CN - Cautionary Nudity</option>
-                <option value="uc">UC - Uncensored</option>
-                <option value="xt">XT - Explicit</option>
-              </select>
-            </label>
-
-            <label className="flex flex-col gap-1">
-              <span className="text-sm font-medium text-base-content/70">Quality</span>
-              <select
-                className="select select-bordered select-sm w-full"
-                value={quality}
-                onChange={(e) => setQuality(e.target.value)}
-              >
-                <option value="fast">Fast</option>
-                <option value="pretty">Pretty</option>
-              </select>
-            </label>
+            <ExportRegionList />
 
             {error && <div className="text-error text-sm">{error}</div>}
 

--- a/@fanslib/apps/web/src/features/editor/components/ExportRegionList.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/ExportRegionList.tsx
@@ -1,0 +1,35 @@
+import { useEditorStore, type ExportRegion } from "~/stores/editorStore";
+import { ExportRegionMetadata } from "./ExportRegionMetadata";
+
+const WHOLE_TIMELINE_REGION: ExportRegion = {
+  id: "__whole_timeline__",
+  startFrame: 0,
+  endFrame: 0,
+};
+
+export const ExportRegionList = () => {
+  const exportRegions = useEditorStore((s) => s.exportRegions);
+  const updateExportRegion = useEditorStore((s) => s.updateExportRegion);
+
+  if (exportRegions.length === 0) {
+    return (
+      <ExportRegionMetadata
+        region={WHOLE_TIMELINE_REGION}
+        onUpdate={() => {}}
+        showHeader={false}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {exportRegions.map((region) => (
+        <ExportRegionMetadata
+          key={region.id}
+          region={region}
+          onUpdate={(updates) => updateExportRegion(region.id, updates)}
+        />
+      ))}
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/features/editor/components/ExportRegionList.vitest.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/ExportRegionList.vitest.tsx
@@ -1,0 +1,65 @@
+/// <reference types="@testing-library/jest-dom" />
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { useEditorStore } from "~/stores/editorStore";
+
+import { ExportRegionList } from "./ExportRegionList";
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  useEditorStore.getState().reset();
+});
+
+describe("ExportRegionList", () => {
+  test("shows single metadata form when no export regions", () => {
+    render(<ExportRegionList />);
+
+    // Should show metadata fields but no region header
+    expect(screen.getByLabelText("Package")).toBeInTheDocument();
+    expect(screen.getByLabelText("Role")).toBeInTheDocument();
+    expect(screen.getByLabelText("Content Rating")).toBeInTheDocument();
+    expect(screen.getByLabelText("Quality")).toBeInTheDocument();
+    expect(screen.queryByText(/Region:/)).not.toBeInTheDocument();
+  });
+
+  test("shows one metadata form per region when regions exist", () => {
+    const store = useEditorStore.getState();
+    store.addExportRegion({ startFrame: 0, endFrame: 450 });
+    store.addExportRegion({ startFrame: 500, endFrame: 900 });
+
+    render(<ExportRegionList />);
+
+    const packageInputs = screen.getAllByLabelText("Package");
+    expect(packageInputs).toHaveLength(2);
+
+    const roleInputs = screen.getAllByLabelText("Role");
+    expect(roleInputs).toHaveLength(2);
+  });
+
+  test("region header shows frame range", () => {
+    const store = useEditorStore.getState();
+    store.addExportRegion({ startFrame: 0, endFrame: 450 });
+    store.addExportRegion({ startFrame: 500, endFrame: 900 });
+
+    render(<ExportRegionList />);
+
+    expect(screen.getByText("Region: 0–450")).toBeInTheDocument();
+    expect(screen.getByText("Region: 500–900")).toBeInTheDocument();
+  });
+
+  test("changing package field calls updateExportRegion", () => {
+    const store = useEditorStore.getState();
+    store.addExportRegion({ startFrame: 0, endFrame: 450 });
+    const updateSpy = vi.spyOn(useEditorStore.getState(), "updateExportRegion");
+
+    render(<ExportRegionList />);
+
+    const packageInput = screen.getByLabelText("Package");
+    fireEvent.change(packageInput, { target: { value: "premium" } });
+    fireEvent.blur(packageInput);
+
+    const regionId = useEditorStore.getState().exportRegions[0].id;
+    expect(updateSpy).toHaveBeenCalledWith(regionId, { package: "premium" });
+  });
+});

--- a/@fanslib/apps/web/src/features/editor/components/ExportRegionMetadata.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/ExportRegionMetadata.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import type { ExportRegion } from "~/stores/editorStore";
+
+type ExportRegionMetadataProps = {
+  region: ExportRegion;
+  onUpdate: (updates: Partial<ExportRegion>) => void;
+  showHeader?: boolean;
+};
+
+export const ExportRegionMetadata = ({
+  region,
+  onUpdate,
+  showHeader = true,
+}: ExportRegionMetadataProps) => {
+  const [pkg, setPkg] = useState(region.package ?? "");
+  const [role, setRole] = useState(region.role ?? "");
+  const [contentRating, setContentRating] = useState(region.contentRating ?? "sg");
+  const [quality, setQuality] = useState(region.quality ?? "pretty");
+
+  return (
+    <div className="flex flex-col gap-3">
+      {showHeader && (
+        <h4 className="text-sm font-semibold text-base-content/80">
+          Region: {region.startFrame}&ndash;{region.endFrame}
+        </h4>
+      )}
+
+      <label className="flex flex-col gap-1">
+        <span className="text-sm font-medium text-base-content/70">Package</span>
+        <input
+          type="text"
+          aria-label="Package"
+          className="input input-bordered input-sm w-full"
+          value={pkg}
+          onChange={(e) => setPkg(e.target.value)}
+          onBlur={() => onUpdate({ package: pkg })}
+          placeholder="e.g. premium, free"
+        />
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-sm font-medium text-base-content/70">Role</span>
+        <input
+          type="text"
+          aria-label="Role"
+          className="input input-bordered input-sm w-full"
+          value={role}
+          onChange={(e) => setRole(e.target.value)}
+          onBlur={() => onUpdate({ role })}
+          placeholder="e.g. main, alt"
+        />
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-sm font-medium text-base-content/70">Content Rating</span>
+        <select
+          aria-label="Content Rating"
+          className="select select-bordered select-sm w-full"
+          value={contentRating}
+          onChange={(e) => {
+            setContentRating(e.target.value);
+            onUpdate({ contentRating: e.target.value });
+          }}
+        >
+          <option value="sf">SF - Safe</option>
+          <option value="sg">SG - Suggestive</option>
+          <option value="cn">CN - Cautionary Nudity</option>
+          <option value="uc">UC - Uncensored</option>
+          <option value="xt">XT - Explicit</option>
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-sm font-medium text-base-content/70">Quality</span>
+        <select
+          aria-label="Quality"
+          className="select select-bordered select-sm w-full"
+          value={quality}
+          onChange={(e) => {
+            setQuality(e.target.value);
+            onUpdate({ quality: e.target.value });
+          }}
+        >
+          <option value="fast">Fast</option>
+          <option value="pretty">Pretty</option>
+        </select>
+      </label>
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/stores/editorStore.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.ts
@@ -8,7 +8,7 @@ type Track = {
   operations: unknown[];
 };
 
-type ExportRegion = {
+export type ExportRegion = {
   id: string;
   startFrame: number;
   endFrame: number;


### PR DESCRIPTION
## Summary

- `ExportRegionMetadata` form with package, role, contentRating, quality fields
- `ExportRegionList` shows one form per region, or single form for whole-timeline
- Wired to `updateExportRegion` store mutation
- Replaces inline metadata state in ExportDialog
- `ExportRegion` type exported from editor store

Stacked on #373 (Export regions store)

Closes #356

## Test plan

- [x] Single form when no export regions
- [x] One form per region when regions exist
- [x] Region header shows frame range
- [x] Field changes call updateExportRegion
- [x] 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)