### PR TITLE
feat(editor): add segment drag reorder and edge trim interactions

### DIFF
--- a/@fanslib/apps/server/src/features/compositions/entity.ts
+++ b/@fanslib/apps/server/src/features/compositions/entity.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import type { Relation } from "typeorm";
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { Shoot } from "../shoots/entity";
+
+@Entity("composition")
+export class Composition {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ type: "varchar", name: "shootId" })
+  shootId!: string;
+
+  @ManyToOne(() => Shoot, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "shootId" })
+  shoot!: Relation<Shoot>;
+
+  @Column({ type: "varchar", name: "name" })
+  name!: string;
+
+  @Column({ type: "simple-json", name: "segments", default: "[]" })
+  segments: unknown[] = [];
+
+  @Column({ type: "simple-json", name: "tracks", default: "[]" })
+  tracks: unknown[] = [];
+
+  @Column({ type: "simple-json", name: "exportRegions", default: "[]" })
+  exportRegions: unknown[] = [];
+
+  @CreateDateColumn({ type: "datetime", name: "createdAt" })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: "datetime", name: "updatedAt" })
+  updatedAt!: Date;
+}
+
+const SegmentTransitionSchema = z.object({
+  type: z.literal("crossfade"),
+  durationFrames: z.number(),
+  easing: z.string().optional(),
+});
+
+export const SegmentSchema = z.object({
+  id: z.string(),
+  sourceMediaId: z.string(),
+  sourceStartFrame: z.number(),
+  sourceEndFrame: z.number(),
+  transition: SegmentTransitionSchema.optional(),
+});
+
+export const TrackSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  operations: z.array(z.unknown()),
+});
+
+export const ExportRegionSchema = z.object({
+  id: z.string(),
+  startFrame: z.number(),
+  endFrame: z.number(),
+  package: z.string().nullable().optional(),
+  role: z.string().nullable().optional(),
+  contentRating: z.string().nullable().optional(),
+  quality: z.string().nullable().optional(),
+});
+
+export const CompositionSchema = z.object({
+  id: z.string(),
+  shootId: z.string(),
+  name: z.string(),
+  segments: z.array(SegmentSchema),
+  tracks: z.array(TrackSchema),
+  exportRegions: z.array(ExportRegionSchema),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/create.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/create.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const CreateCompositionRequestBodySchema = z.object({
+  shootId: z.string(),
+  name: z.string(),
+});
+
+export const createComposition = async (
+  payload: z.infer<typeof CreateCompositionRequestBodySchema>,
+): Promise<Composition> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+
+  const composition = repo.create({
+    shootId: payload.shootId,
+    name: payload.name,
+    segments: [],
+    tracks: [],
+    exportRegions: [],
+  });
+
+  await repo.save(composition);
+  const created = await repo.findOne({ where: { id: composition.id } });
+  if (!created) throw new Error(`Failed to fetch created composition ${composition.id}`);
+  return created;
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/delete.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/delete.ts
@@ -1,0 +1,11 @@
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const deleteComposition = async (id: string): Promise<boolean> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+  const composition = await repo.findOne({ where: { id } });
+  if (!composition) return false;
+  await repo.delete(id);
+  return true;
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-id.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-id.ts
@@ -1,0 +1,8 @@
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const fetchCompositionById = async (id: string): Promise<Composition | null> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+  return repo.findOne({ where: { id } });
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-shoot.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-shoot.ts
@@ -1,0 +1,11 @@
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const fetchCompositionsByShoot = async (shootId: string): Promise<Composition[]> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+  return repo.find({
+    where: { shootId },
+    order: { createdAt: "DESC" },
+  });
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/update.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/update.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { db } from "../../../../lib/db";
+import { Composition, SegmentSchema, TrackSchema, ExportRegionSchema } from "../../entity";
+
+export const UpdateCompositionRequestBodySchema = z.object({
+  name: z.string().optional(),
+  segments: z.array(SegmentSchema).optional(),
+  tracks: z.array(TrackSchema).optional(),
+  exportRegions: z.array(ExportRegionSchema).optional(),
+});
+
+export const updateComposition = async (
+  id: string,
+  payload: z.infer<typeof UpdateCompositionRequestBodySchema>,
+): Promise<Composition | null> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+
+  const composition = await repo.findOne({ where: { id } });
+  if (!composition) return null;
+
+  if (payload.name !== undefined) composition.name = payload.name;
+  if (payload.segments !== undefined) composition.segments = payload.segments;
+  if (payload.tracks !== undefined) composition.tracks = payload.tracks;
+  if (payload.exportRegions !== undefined) composition.exportRegions = payload.exportRegions;
+
+  await repo.save(composition);
+  return composition;
+};

--- a/@fanslib/apps/server/src/features/compositions/routes.test.ts
+++ b/@fanslib/apps/server/src/features/compositions/routes.test.ts
@@ -1,0 +1,257 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import "reflect-metadata";
+import { getTestDataSource, setupTestDatabase, teardownTestDatabase } from "../../lib/test-db";
+import { resetAllFixtures } from "../../lib/test-fixtures";
+import { devalueMiddleware } from "../../lib/devalue-middleware";
+import { parseResponse } from "../../test-utils/setup";
+import { Shoot } from "../shoots/entity";
+import { compositionsRoutes } from "./routes";
+
+describe("Compositions Routes", () => {
+  // eslint-disable-next-line functional/no-let
+  let app: Hono;
+  // eslint-disable-next-line functional/no-let
+  let testShoot: Shoot;
+
+  beforeAll(async () => {
+    await setupTestDatabase();
+    await resetAllFixtures();
+    app = new Hono().use("*", devalueMiddleware()).route("/", compositionsRoutes);
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetAllFixtures();
+    // Create a shoot for compositions to reference
+    const dataSource = getTestDataSource();
+    const shootRepo = dataSource.getRepository(Shoot);
+    testShoot = shootRepo.create({
+      name: "Test Shoot",
+      shootDate: new Date("2026-04-08"),
+    });
+    testShoot = await shootRepo.save(testShoot);
+  });
+
+  describe("POST /api/compositions", () => {
+    test("creates a composition and returns it with all fields", async () => {
+      const response = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          shootId: testShoot.id,
+          name: "Trailer v1",
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{
+        id: string;
+        shootId: string;
+        name: string;
+        segments: unknown[];
+        tracks: unknown[];
+        exportRegions: unknown[];
+        createdAt: string;
+        updatedAt: string;
+      }>(response);
+
+      expect(data?.id).toBeDefined();
+      expect(data?.shootId).toBe(testShoot.id);
+      expect(data?.name).toBe("Trailer v1");
+      expect(data?.segments).toEqual([]);
+      expect(data?.tracks).toEqual([]);
+      expect(data?.exportRegions).toEqual([]);
+    });
+  });
+
+  describe("PATCH /api/compositions/by-id/:id", () => {
+    test("updates composition name, segments, tracks, and exportRegions", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Original" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const segments = [
+        { id: "seg-1", sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 900 },
+      ];
+      const tracks = [
+        { id: "track-1", name: "Overlays", operations: [] },
+      ];
+      const exportRegions = [
+        { id: "er-1", startFrame: 0, endFrame: 450 },
+      ];
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "Updated",
+          segments,
+          tracks,
+          exportRegions,
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{
+        name: string;
+        segments: unknown[];
+        tracks: unknown[];
+        exportRegions: unknown[];
+      }>(response);
+      expect(data?.name).toBe("Updated");
+      expect(data?.segments).toHaveLength(1);
+      expect(data?.tracks).toHaveLength(1);
+      expect(data?.exportRegions).toHaveLength(1);
+    });
+
+    test("returns 404 for non-existent composition", async () => {
+      const response = await app.request("/api/compositions/by-id/nonexistent", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Nope" }),
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("GET /api/compositions/by-shoot/:shootId", () => {
+    test("lists all compositions for a shoot", async () => {
+      await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Comp A" }),
+      });
+      await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Comp B" }),
+      });
+
+      const response = await app.request(`/api/compositions/by-shoot/${testShoot.id}`);
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ id: string; name: string }[]>(response);
+      expect(data).toHaveLength(2);
+      const names = data?.map((c) => c.name).sort();
+      expect(names).toEqual(["Comp A", "Comp B"]);
+    });
+
+    test("returns empty array for shoot with no compositions", async () => {
+      const response = await app.request(`/api/compositions/by-shoot/${testShoot.id}`);
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<unknown[]>(response);
+      expect(data).toHaveLength(0);
+    });
+  });
+
+  describe("DELETE /api/compositions/by-id/:id", () => {
+    test("deletes a composition", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "To Delete" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`, {
+        method: "DELETE",
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ success: boolean }>(response);
+      expect(data?.success).toBe(true);
+
+      // Verify it's gone
+      const getResponse = await app.request(`/api/compositions/by-id/${created?.id}`);
+      expect(getResponse.status).toBe(404);
+    });
+
+    test("returns 404 for non-existent composition", async () => {
+      const response = await app.request("/api/compositions/by-id/nonexistent", {
+        method: "DELETE",
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("GET /api/compositions/by-id/:id", () => {
+    test("fetches a composition by ID", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Fetch Test" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`);
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ id: string; name: string }>(response);
+      expect(data?.id).toBe(created?.id);
+      expect(data?.name).toBe("Fetch Test");
+    });
+
+    test("returns 404 for non-existent composition", async () => {
+      const response = await app.request("/api/compositions/by-id/nonexistent");
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Schema validation", () => {
+    test("rejects update with invalid segment shape", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Validate Me" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          segments: [{ invalid: "shape" }],
+        }),
+      });
+      expect(response.status).toBe(422);
+    });
+
+    test("rejects create without required fields", async () => {
+      const response = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(response.status).toBe(422);
+    });
+  });
+
+  describe("Shoot cascade", () => {
+    test("deleting a shoot cascades to its compositions", async () => {
+      // Create a composition on the test shoot
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Will Be Cascaded" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      // Delete the shoot directly
+      const dataSource = getTestDataSource();
+      const shootRepo = dataSource.getRepository(Shoot);
+      await shootRepo.delete(testShoot.id);
+
+      // The composition should be gone
+      const getResponse = await app.request(`/api/compositions/by-id/${created?.id}`);
+      expect(getResponse.status).toBe(404);
+    });
+  });
+});

--- a/@fanslib/apps/server/src/features/compositions/routes.ts
+++ b/@fanslib/apps/server/src/features/compositions/routes.ts
@@ -1,0 +1,54 @@
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { validationError, notFound } from "../../lib/hono-utils";
+import {
+  CreateCompositionRequestBodySchema,
+  createComposition,
+} from "./operations/composition/create";
+import { deleteComposition } from "./operations/composition/delete";
+import { fetchCompositionById } from "./operations/composition/fetch-by-id";
+import { fetchCompositionsByShoot } from "./operations/composition/fetch-by-shoot";
+import {
+  UpdateCompositionRequestBodySchema,
+  updateComposition,
+} from "./operations/composition/update";
+
+export const compositionsRoutes = new Hono()
+  .basePath("/api/compositions")
+  .post(
+    "/",
+    zValidator("json", CreateCompositionRequestBodySchema, validationError),
+    async (c) => {
+      const body = c.req.valid("json");
+      const result = await createComposition(body);
+      return c.json(result);
+    },
+  )
+  .patch(
+    "/by-id/:id",
+    zValidator("json", UpdateCompositionRequestBodySchema, validationError),
+    async (c) => {
+      const id = c.req.param("id");
+      const body = c.req.valid("json");
+      const composition = await updateComposition(id, body);
+      if (!composition) return notFound(c, "Composition not found");
+      return c.json(composition);
+    },
+  )
+  .get("/by-id/:id", async (c) => {
+    const id = c.req.param("id");
+    const composition = await fetchCompositionById(id);
+    if (!composition) return notFound(c, "Composition not found");
+    return c.json(composition);
+  })
+  .get("/by-shoot/:shootId", async (c) => {
+    const shootId = c.req.param("shootId");
+    const compositions = await fetchCompositionsByShoot(shootId);
+    return c.json(compositions);
+  })
+  .delete("/by-id/:id", async (c) => {
+    const id = c.req.param("id");
+    const success = await deleteComposition(id);
+    if (!success) return notFound(c, "Composition not found");
+    return c.json({ success: true });
+  });

--- a/@fanslib/apps/server/src/index.ts
+++ b/@fanslib/apps/server/src/index.ts
@@ -9,6 +9,7 @@ import { analyticsRoutes } from "./features/analytics/routes";
 import { assetsRoutes } from "./features/assets/routes";
 import { candidatesRoutes } from "./features/analytics/candidates/routes";
 import { channelsRoutes } from "./features/channels/routes";
+import { compositionsRoutes } from "./features/compositions/routes";
 import { contentSchedulesRoutes } from "./features/content-schedules/routes";
 import { filterPresetsRoutes } from "./features/filter-presets/routes";
 import { hashtagsRoutes } from "./features/hashtags/routes";
@@ -89,6 +90,7 @@ const app = new Hono()
   .route("/", subredditsRoutes)
   .route("/", tagsRoutes)
   .route("/", channelsRoutes)
+  .route("/", compositionsRoutes)
   .route("/", contentSchedulesRoutes)
   .route("/", libraryRoutes)
   .route("/", organizeRoutes)

--- a/@fanslib/apps/server/src/lib/db.ts
+++ b/@fanslib/apps/server/src/lib/db.ts
@@ -7,6 +7,7 @@ import "reflect-metadata";
 import initSqlJs from "sql.js";
 import { DataSource } from "typeorm";
 import { Asset } from "../features/assets/entity";
+import { Composition } from "../features/compositions/entity";
 import { FanslyMediaCandidate } from "../features/analytics/candidate-entity";
 import { FanslyAnalyticsAggregate, FanslyAnalyticsDatapoint } from "../features/analytics/entity";
 import { Channel, ChannelType } from "../features/channels/entity";
@@ -80,6 +81,7 @@ const createAppDataSource = (driver?: Awaited<ReturnType<typeof initSqlJs>>) => 
     ...(driver ? { driver } : {}),
     entities: [
       Asset,
+      Composition,
       Media,
       MediaEdit,
       Post,

--- a/@fanslib/apps/server/src/lib/test-db.ts
+++ b/@fanslib/apps/server/src/lib/test-db.ts
@@ -2,6 +2,7 @@
 import initSqlJs from "sql.js";
 import { DataSource } from "typeorm";
 import { Asset } from "../features/assets/entity";
+import { Composition } from "../features/compositions/entity";
 import { FanslyMediaCandidate } from "../features/analytics/candidate-entity";
 import { FanslyAnalyticsAggregate, FanslyAnalyticsDatapoint } from "../features/analytics/entity";
 import { Channel, ChannelType } from "../features/channels/entity";
@@ -39,6 +40,7 @@ export const createTestDataSource = (driver?: Awaited<ReturnType<typeof initSqlJ
     ...(driver ? { driver } : {}),
     entities: [
       Asset,
+      Composition,
       Media,
       MediaEdit,
       Post,
@@ -118,6 +120,7 @@ export const clearAllTables = async () => {
     "CaptionSnippet",
     "Subreddit",
     "Channel",
+    "Composition",
     "Shoot",
     "TagDefinition",
     "TagDimension",

--- a/@fanslib/apps/web/src/features/editor/components/CompositionEditor.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/CompositionEditor.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from "react";
+import { useCompositionByIdQuery } from "~/lib/queries/compositions";
+import { useEditorStore } from "~/stores/editorStore";
+
+type CompositionEditorProps = {
+  shootId: string;
+  compositionId: string;
+};
+
+export const CompositionEditor = ({ shootId, compositionId }: CompositionEditorProps) => {
+  const { data: composition, isLoading, error } = useCompositionByIdQuery(compositionId);
+  const hydrate = useEditorStore((s) => s.hydrate);
+  const reset = useEditorStore((s) => s.reset);
+
+  useEffect(() => {
+    if (!composition) return;
+    // The API returns JSONValue[] for tracks/segments; runtime shapes match the store types.
+    hydrate({
+      tracks: composition.tracks,
+      segments: composition.segments,
+    } as Parameters<typeof hydrate>[0]);
+  }, [composition, hydrate]);
+
+  useEffect(() => {
+    return () => {
+      reset();
+    };
+  }, [reset]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center" data-testid="composition-loading">
+        <p className="text-muted-foreground">Loading composition...</p>
+      </div>
+    );
+  }
+
+  if (error || !composition) {
+    return (
+      <div className="flex h-full items-center justify-center" data-testid="composition-error">
+        <p className="text-destructive">
+          {error?.message ?? "Composition not found"}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col" data-testid="composition-editor">
+      <div className="border-b p-4">
+        <h1 className="text-lg font-semibold">{composition.name}</h1>
+        <p className="text-muted-foreground text-sm">
+          Shoot: {shootId} &middot; {composition.segments.length} segment{composition.segments.length !== 1 ? "s" : ""}
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/features/editor/components/CompositionEditor.vitest.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/CompositionEditor.vitest.tsx
@@ -1,0 +1,139 @@
+/// <reference types="@testing-library/jest-dom" />
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+
+// Mock the composition query hook
+vi.mock("~/lib/queries/compositions", () => ({
+  useCompositionByIdQuery: vi.fn(),
+}));
+
+// Mock the editor store
+const mockHydrate = vi.fn();
+const mockReset = vi.fn();
+vi.mock("~/stores/editorStore", () => ({
+  useEditorStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ hydrate: mockHydrate, reset: mockReset }),
+  ),
+}));
+
+import { useCompositionByIdQuery } from "~/lib/queries/compositions";
+
+// Import after mocks
+import { CompositionEditor } from "./CompositionEditor";
+
+const mockUseCompositionByIdQuery = vi.mocked(useCompositionByIdQuery);
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const makeComposition = (overrides?: Record<string, unknown>) => ({
+  id: "comp-1",
+  shootId: "shoot-1",
+  name: "My Composition",
+  segments: [
+    { id: "seg-1", sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 150 },
+    { id: "seg-2", sourceMediaId: "media-2", sourceStartFrame: 30, sourceEndFrame: 120 },
+  ],
+  tracks: [{ id: "track-1", name: "Track 1", operations: [] }],
+  exportRegions: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("CompositionEditor", () => {
+  test("shows loading state initially", () => {
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useCompositionByIdQuery>);
+
+    render(<CompositionEditor shootId="shoot-1" compositionId="comp-1" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByTestId("composition-loading")).toBeInTheDocument();
+    expect(screen.getByText("Loading composition...")).toBeInTheDocument();
+  });
+
+  test("shows error when composition not found", () => {
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("Composition not found"),
+    } as ReturnType<typeof useCompositionByIdQuery>);
+
+    render(<CompositionEditor shootId="shoot-1" compositionId="comp-1" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByTestId("composition-error")).toBeInTheDocument();
+    expect(screen.getByText("Composition not found")).toBeInTheDocument();
+  });
+
+  test("renders composition name when data loads", () => {
+    const composition = makeComposition();
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: composition,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCompositionByIdQuery>);
+
+    render(<CompositionEditor shootId="shoot-1" compositionId="comp-1" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByTestId("composition-editor")).toBeInTheDocument();
+    expect(screen.getByText("My Composition")).toBeInTheDocument();
+    expect(screen.getByText(/2 segments/)).toBeInTheDocument();
+  });
+
+  test("hydrates the editor store when composition loads", async () => {
+    const composition = makeComposition();
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: composition,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCompositionByIdQuery>);
+
+    render(<CompositionEditor shootId="shoot-1" compositionId="comp-1" />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(mockHydrate).toHaveBeenCalledWith({
+        tracks: composition.tracks,
+        segments: composition.segments,
+      });
+    });
+  });
+
+  test("resets the store on unmount", () => {
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useCompositionByIdQuery>);
+
+    const { unmount } = render(
+      <CompositionEditor shootId="shoot-1" compositionId="comp-1" />,
+      { wrapper: createWrapper() },
+    );
+
+    unmount();
+    expect(mockReset).toHaveBeenCalled();
+  });
+});

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/SegmentTrack.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/SegmentTrack.tsx
@@ -1,7 +1,11 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Film, Trash2 } from "lucide-react";
 import { useEditorStore } from "~/stores/editorStore";
 import { computeSequenceTimeline } from "~/features/editor/utils/sequence-engine";
+import { detectEdge } from "./block-drag";
+import { computeSegmentReorderIndex, computeSegmentTrimStart, computeSegmentTrimEnd } from "./segment-drag";
+
+const EDGE_ZONE = 8;
 
 type SegmentTrackProps = {
   pixelsPerFrame: number;
@@ -14,13 +18,27 @@ type ContextMenuState = {
   segmentId: string;
 } | null;
 
+type SegmentDragMode = "reorder" | "trim-start" | "trim-end" | null;
+
+type SegmentDragState = {
+  mode: SegmentDragMode;
+  segmentId: string;
+  startX: number;
+  didMove: boolean;
+};
+
 export const SegmentTrack = ({ pixelsPerFrame, totalFrames }: SegmentTrackProps) => {
   const segments = useEditorStore((s) => s.segments);
   const selectedSegmentId = useEditorStore((s) => s.selectedSegmentId);
   const selectSegment = useEditorStore((s) => s.selectSegment);
   const removeSegment = useEditorStore((s) => s.removeSegment);
+  const reorderSegments = useEditorStore((s) => s.reorderSegments);
+  const trimSegmentStart = useEditorStore((s) => s.trimSegmentStart);
+  const trimSegmentEnd = useEditorStore((s) => s.trimSegmentEnd);
 
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
+  const dragRef = useRef<SegmentDragState | null>(null);
+  const blockRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   const timeline = computeSequenceTimeline(segments);
 
@@ -45,6 +63,87 @@ export const SegmentTrack = ({ pixelsPerFrame, totalFrames }: SegmentTrackProps)
     setContextMenu(null);
   }, []);
 
+  const handleSegmentPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>, segmentId: string) => {
+      if (e.button !== 0) return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const offsetX = e.clientX - rect.left;
+      const edge = detectEdge(offsetX, rect.width, EDGE_ZONE);
+
+      const mode: SegmentDragMode =
+        edge === "left" ? "trim-start" : edge === "right" ? "trim-end" : "reorder";
+
+      dragRef.current = {
+        mode,
+        segmentId,
+        startX: e.clientX,
+        didMove: false,
+      };
+
+      e.currentTarget.setPointerCapture?.(e.pointerId);
+      e.currentTarget.style.cursor = mode === "reorder" ? "grabbing" : "col-resize";
+    },
+    [],
+  );
+
+  const handleSegmentPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag) {
+        // Hover cursor
+        const rect = e.currentTarget.getBoundingClientRect();
+        const offsetX = e.clientX - rect.left;
+        const edge = detectEdge(offsetX, rect.width, EDGE_ZONE);
+        e.currentTarget.style.cursor = edge === "left" || edge === "right" ? "col-resize" : "grab";
+        return;
+      }
+
+      drag.didMove = true;
+      const deltaX = e.clientX - drag.startX;
+      const deltaFrames = Math.round(deltaX / pixelsPerFrame);
+
+      if (drag.mode === "reorder") {
+        const currentTimeline = computeSequenceTimeline(segments);
+        const newIndex = computeSegmentReorderIndex(
+          segments,
+          drag.segmentId,
+          e.clientX - (e.currentTarget.closest("[data-testid='segment-track-row']") as HTMLElement | null)?.getBoundingClientRect().left!,
+          pixelsPerFrame,
+          currentTimeline,
+        );
+        reorderSegments(drag.segmentId, newIndex);
+      } else {
+        const segment = segments.find((s) => s.id === drag.segmentId);
+        if (!segment) return;
+
+        if (drag.mode === "trim-start") {
+          const { sourceStartFrame } = computeSegmentTrimStart(segment, deltaFrames);
+          trimSegmentStart(drag.segmentId, sourceStartFrame);
+        } else if (drag.mode === "trim-end") {
+          const { sourceEndFrame } = computeSegmentTrimEnd(segment, deltaFrames);
+          trimSegmentEnd(drag.segmentId, sourceEndFrame);
+        }
+        // Update startX so delta is incremental
+        drag.startX = e.clientX;
+      }
+    },
+    [pixelsPerFrame, segments, reorderSegments, trimSegmentStart, trimSegmentEnd],
+  );
+
+  const handleSegmentPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      e.currentTarget.releasePointerCapture?.(e.pointerId);
+      e.currentTarget.style.cursor = "grab";
+      dragRef.current = null;
+
+      if (!drag?.didMove) {
+        selectSegment(drag?.segmentId ?? null);
+      }
+    },
+    [selectSegment],
+  );
+
   if (segments.length === 0) return null;
 
   return (
@@ -59,6 +158,7 @@ export const SegmentTrack = ({ pixelsPerFrame, totalFrames }: SegmentTrackProps)
 
         {/* Track row */}
         <div
+          data-testid="segment-track-row"
           className="relative h-10 flex items-center flex-1"
           style={{ width: `${totalFrames * pixelsPerFrame}px` }}
         >
@@ -74,9 +174,15 @@ export const SegmentTrack = ({ pixelsPerFrame, totalFrames }: SegmentTrackProps)
               <div
                 key={pos.segmentId}
                 data-testid="segment-block"
+                ref={(el) => {
+                  if (el) blockRefs.current.set(pos.segmentId, el);
+                  else blockRefs.current.delete(pos.segmentId);
+                }}
                 className={`absolute h-8 rounded-sm border overflow-hidden whitespace-nowrap text-xs flex items-center gap-1 px-1 select-none bg-info/30 border-info${selected ? " ring-2 ring-base-content" : ""}`}
-                style={{ width: `${width}px`, left: `${left}px`, cursor: "pointer" }}
-                onClick={() => selectSegment(pos.segmentId)}
+                style={{ width: `${width}px`, left: `${left}px`, cursor: "grab" }}
+                onPointerDown={(e) => handleSegmentPointerDown(e, pos.segmentId)}
+                onPointerMove={handleSegmentPointerMove}
+                onPointerUp={handleSegmentPointerUp}
                 onContextMenu={(e) => handleContextMenu(e, pos.segmentId)}
               >
                 <Film className="w-3 h-3 shrink-0" />

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/SegmentTrack.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/SegmentTrack.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useState } from "react";
+import { Film, Trash2 } from "lucide-react";
+import { useEditorStore } from "~/stores/editorStore";
+import { computeSequenceTimeline } from "~/features/editor/utils/sequence-engine";
+
+type SegmentTrackProps = {
+  pixelsPerFrame: number;
+  totalFrames: number;
+};
+
+type ContextMenuState = {
+  x: number;
+  y: number;
+  segmentId: string;
+} | null;
+
+export const SegmentTrack = ({ pixelsPerFrame, totalFrames }: SegmentTrackProps) => {
+  const segments = useEditorStore((s) => s.segments);
+  const selectedSegmentId = useEditorStore((s) => s.selectedSegmentId);
+  const selectSegment = useEditorStore((s) => s.selectSegment);
+  const removeSegment = useEditorStore((s) => s.removeSegment);
+
+  const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
+
+  const timeline = computeSequenceTimeline(segments);
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent, segmentId: string) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setContextMenu({ x: e.clientX, y: e.clientY, segmentId });
+    },
+    [],
+  );
+
+  const handleDelete = useCallback(
+    (segmentId: string) => {
+      removeSegment(segmentId);
+      setContextMenu(null);
+    },
+    [removeSegment],
+  );
+
+  const closeContextMenu = useCallback(() => {
+    setContextMenu(null);
+  }, []);
+
+  if (segments.length === 0) return null;
+
+  return (
+    <>
+      {/* Track header + row wrapper */}
+      <div className="flex" onClick={closeContextMenu}>
+        {/* Header */}
+        <div className="w-32 h-10 flex items-center px-2 border-r border-base-300 shrink-0">
+          <Film className="w-3 h-3 mr-1 shrink-0" />
+          <span className="text-xs truncate">Video</span>
+        </div>
+
+        {/* Track row */}
+        <div
+          className="relative h-10 flex items-center flex-1"
+          style={{ width: `${totalFrames * pixelsPerFrame}px` }}
+        >
+          {timeline.positions.map((pos) => {
+            const segment = segments.find((s) => s.id === pos.segmentId);
+            if (!segment) return null;
+
+            const width = (pos.sequenceEndFrame - pos.sequenceStartFrame) * pixelsPerFrame;
+            const left = pos.sequenceStartFrame * pixelsPerFrame;
+            const selected = selectedSegmentId === pos.segmentId;
+
+            return (
+              <div
+                key={pos.segmentId}
+                data-testid="segment-block"
+                className={`absolute h-8 rounded-sm border overflow-hidden whitespace-nowrap text-xs flex items-center gap-1 px-1 select-none bg-info/30 border-info${selected ? " ring-2 ring-base-content" : ""}`}
+                style={{ width: `${width}px`, left: `${left}px`, cursor: "pointer" }}
+                onClick={() => selectSegment(pos.segmentId)}
+                onContextMenu={(e) => handleContextMenu(e, pos.segmentId)}
+              >
+                <Film className="w-3 h-3 shrink-0" />
+                <span className="truncate">{segment.sourceMediaId}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Context menu */}
+      {contextMenu && (
+        <div
+          data-testid="segment-context-menu"
+          className="fixed z-50 bg-base-100 border border-base-300 rounded shadow-lg py-1 min-w-32"
+          style={{ left: contextMenu.x, top: contextMenu.y }}
+        >
+          <button
+            data-testid="segment-delete-btn"
+            className="flex items-center gap-2 w-full px-3 py-1.5 text-sm text-error hover:bg-base-200 cursor-pointer"
+            onClick={() => handleDelete(contextMenu.segmentId)}
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+            Delete
+          </button>
+        </div>
+      )}
+    </>
+  );
+};

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/SegmentTrack.vitest.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/SegmentTrack.vitest.tsx
@@ -1,0 +1,139 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { useEditorStore } from "~/stores/editorStore";
+import { SegmentTrack } from "./SegmentTrack";
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  useEditorStore.getState().reset();
+});
+
+describe("SegmentTrack", () => {
+  test("renders segment blocks when segments exist", () => {
+    useEditorStore.getState().addSegment({
+      sourceMediaId: "media-1",
+      sourceStartFrame: 0,
+      sourceEndFrame: 90,
+    });
+    useEditorStore.getState().addSegment({
+      sourceMediaId: "media-2",
+      sourceStartFrame: 0,
+      sourceEndFrame: 60,
+    });
+
+    render(<SegmentTrack pixelsPerFrame={2} totalFrames={150} />);
+
+    const blocks = screen.getAllByTestId("segment-block");
+    expect(blocks).toHaveLength(2);
+  });
+
+  test("does not render when no segments", () => {
+    const { container } = render(<SegmentTrack pixelsPerFrame={2} totalFrames={900} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("clicking block calls selectSegment", () => {
+    useEditorStore.getState().addSegment({
+      sourceMediaId: "media-1",
+      sourceStartFrame: 0,
+      sourceEndFrame: 90,
+    });
+
+    const segmentId = useEditorStore.getState().segments[0].id;
+
+    render(<SegmentTrack pixelsPerFrame={2} totalFrames={900} />);
+
+    const block = screen.getByTestId("segment-block");
+    fireEvent.click(block);
+
+    expect(useEditorStore.getState().selectedSegmentId).toBe(segmentId);
+  });
+
+  test("blocks have correct relative widths (longer segment = wider block)", () => {
+    useEditorStore.getState().addSegment({
+      sourceMediaId: "media-1",
+      sourceStartFrame: 0,
+      sourceEndFrame: 90,
+    });
+    useEditorStore.getState().addSegment({
+      sourceMediaId: "media-2",
+      sourceStartFrame: 0,
+      sourceEndFrame: 30,
+    });
+
+    const pixelsPerFrame = 2;
+    render(<SegmentTrack pixelsPerFrame={pixelsPerFrame} totalFrames={120} />);
+
+    const blocks = screen.getAllByTestId("segment-block");
+
+    // First segment: 90 frames * 2px = 180px
+    expect(blocks[0].style.width).toBe("180px");
+    // Second segment: 30 frames * 2px = 60px
+    expect(blocks[1].style.width).toBe("60px");
+  });
+
+  test("selected block has highlight ring", () => {
+    useEditorStore.getState().addSegment({
+      sourceMediaId: "media-1",
+      sourceStartFrame: 0,
+      sourceEndFrame: 90,
+    });
+
+    const segmentId = useEditorStore.getState().segments[0].id;
+    useEditorStore.getState().selectSegment(segmentId);
+
+    render(<SegmentTrack pixelsPerFrame={2} totalFrames={900} />);
+
+    const block = screen.getByTestId("segment-block");
+    expect(block.className).toContain("ring");
+  });
+
+  test("shows truncated sourceMediaId as label", () => {
+    useEditorStore.getState().addSegment({
+      sourceMediaId: "my-source-media-id",
+      sourceStartFrame: 0,
+      sourceEndFrame: 90,
+    });
+
+    render(<SegmentTrack pixelsPerFrame={2} totalFrames={900} />);
+
+    const block = screen.getByTestId("segment-block");
+    expect(block.textContent).toContain("my-source-media-id");
+  });
+
+  test("right-click shows context menu with Delete option", () => {
+    useEditorStore.getState().addSegment({
+      sourceMediaId: "media-1",
+      sourceStartFrame: 0,
+      sourceEndFrame: 90,
+    });
+
+    render(<SegmentTrack pixelsPerFrame={2} totalFrames={900} />);
+
+    const block = screen.getByTestId("segment-block");
+    fireEvent.contextMenu(block);
+
+    const menu = screen.getByTestId("segment-context-menu");
+    expect(menu).toBeDefined();
+    expect(menu.textContent).toContain("Delete");
+  });
+
+  test("clicking Delete in context menu removes segment", () => {
+    useEditorStore.getState().addSegment({
+      sourceMediaId: "media-1",
+      sourceStartFrame: 0,
+      sourceEndFrame: 90,
+    });
+
+    render(<SegmentTrack pixelsPerFrame={2} totalFrames={900} />);
+
+    const block = screen.getByTestId("segment-block");
+    fireEvent.contextMenu(block);
+
+    const deleteBtn = screen.getByTestId("segment-delete-btn");
+    fireEvent.click(deleteBtn);
+
+    expect(useEditorStore.getState().segments).toHaveLength(0);
+  });
+});

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/SegmentTrack.vitest.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/SegmentTrack.vitest.tsx
@@ -45,7 +45,8 @@ describe("SegmentTrack", () => {
     render(<SegmentTrack pixelsPerFrame={2} totalFrames={900} />);
 
     const block = screen.getByTestId("segment-block");
-    fireEvent.click(block);
+    fireEvent.pointerDown(block, { button: 0, clientX: 50, clientY: 10 });
+    fireEvent.pointerUp(block, { clientX: 50, clientY: 10 });
 
     expect(useEditorStore.getState().selectedSegmentId).toBe(segmentId);
   });

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/Timeline.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/Timeline.tsx
@@ -7,6 +7,7 @@ import { Playhead } from "./Playhead";
 import { SourceMediaBar } from "./SourceMediaBar";
 import { TimeRuler } from "./TimeRuler";
 import { TrackHeader } from "./TrackHeader";
+import { SegmentTrack } from "./SegmentTrack";
 import { TrackRow } from "./TrackRow";
 import { TransportControls } from "./TransportControls";
 
@@ -207,6 +208,9 @@ export const Timeline = ({
             </div>
           </div>
         </div>
+
+        {/* Segment track (above operation tracks) */}
+        <SegmentTrack pixelsPerFrame={pixelsPerFrame} totalFrames={totalFrames} />
 
         {/* Tracks */}
         <div className="flex flex-1 overflow-hidden">

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/index.ts
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/index.ts
@@ -1,5 +1,6 @@
 export { Timeline } from "./Timeline";
 export { OperationBlock } from "./OperationBlock";
+export { SegmentTrack } from "./SegmentTrack";
 export { SourceMediaBar } from "./SourceMediaBar";
 export { TrackRow } from "./TrackRow";
 export { TrackHeader } from "./TrackHeader";

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/segment-drag.ts
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/segment-drag.ts
@@ -1,0 +1,51 @@
+import type { Segment, SequenceTimeline } from "~/features/editor/utils/sequence-engine";
+
+/**
+ * Given the mouse X position during drag, compute which index
+ * the dragged segment should land at.
+ * Compares mouseX to midpoints of other segment blocks to determine insertion point.
+ */
+export const computeSegmentReorderIndex = (
+  segments: Segment[],
+  draggedSegmentId: string,
+  mouseX: number,
+  pixelsPerFrame: number,
+  timeline: SequenceTimeline,
+): number => {
+  const draggedIndex = segments.findIndex((s) => s.id === draggedSegmentId);
+  if (draggedIndex === -1) return 0;
+
+  // Walk through positions (excluding the dragged segment) and find where mouseX falls
+  let insertIndex = 0;
+  for (let i = 0; i < timeline.positions.length; i++) {
+    if (timeline.positions[i]!.segmentId === draggedSegmentId) continue;
+    const pos = timeline.positions[i]!;
+    const midX = ((pos.sequenceStartFrame + pos.sequenceEndFrame) / 2) * pixelsPerFrame;
+    if (mouseX > midX) {
+      // We're past this segment's midpoint, so insert after it.
+      // Find the actual index of this segment in the segments array.
+      const segIndex = segments.findIndex((s) => s.id === pos.segmentId);
+      insertIndex = segIndex >= draggedIndex ? segIndex : segIndex + 1;
+    }
+  }
+
+  return insertIndex;
+};
+
+/** Adjust sourceStartFrame by delta, clamped to [0, sourceEndFrame - 1] */
+export const computeSegmentTrimStart = (
+  segment: Segment,
+  deltaFrames: number,
+): { sourceStartFrame: number } => {
+  const newStart = Math.max(0, Math.min(segment.sourceStartFrame + deltaFrames, segment.sourceEndFrame - 1));
+  return { sourceStartFrame: newStart };
+};
+
+/** Adjust sourceEndFrame by delta, clamped to [sourceStartFrame + 1, Infinity] */
+export const computeSegmentTrimEnd = (
+  segment: Segment,
+  deltaFrames: number,
+): { sourceEndFrame: number } => {
+  const newEnd = Math.max(segment.sourceStartFrame + 1, segment.sourceEndFrame + deltaFrames);
+  return { sourceEndFrame: newEnd };
+};

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/segment-drag.vitest.ts
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/segment-drag.vitest.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import { computeSegmentTrimStart, computeSegmentTrimEnd, computeSegmentReorderIndex } from "./segment-drag";
+import type { Segment } from "~/features/editor/utils/sequence-engine";
+import { computeSequenceTimeline } from "~/features/editor/utils/sequence-engine";
+
+const makeSegment = (id: string, start: number, end: number): Segment => ({
+  id,
+  sourceMediaId: `media-${id}`,
+  sourceStartFrame: start,
+  sourceEndFrame: end,
+});
+
+describe("segment-drag frame math", () => {
+  describe("computeSegmentTrimStart", () => {
+    test("clamps to not go below 0", () => {
+      const segment = makeSegment("a", 5, 100);
+      const result = computeSegmentTrimStart(segment, -20);
+      expect(result).toEqual({ sourceStartFrame: 0 });
+    });
+
+    test("clamps to not exceed endFrame - 1", () => {
+      const segment = makeSegment("a", 80, 100);
+      const result = computeSegmentTrimStart(segment, 30);
+      expect(result).toEqual({ sourceStartFrame: 99 });
+    });
+
+    test("adjusts by positive delta within range", () => {
+      const segment = makeSegment("a", 10, 100);
+      const result = computeSegmentTrimStart(segment, 5);
+      expect(result).toEqual({ sourceStartFrame: 15 });
+    });
+  });
+
+  describe("computeSegmentTrimEnd", () => {
+    test("clamps to not go below startFrame + 1", () => {
+      const segment = makeSegment("a", 50, 60);
+      const result = computeSegmentTrimEnd(segment, -20);
+      expect(result).toEqual({ sourceEndFrame: 51 });
+    });
+
+    test("adjusts by positive delta", () => {
+      const segment = makeSegment("a", 10, 100);
+      const result = computeSegmentTrimEnd(segment, 20);
+      expect(result).toEqual({ sourceEndFrame: 120 });
+    });
+
+    test("adjusts by negative delta within range", () => {
+      const segment = makeSegment("a", 10, 100);
+      const result = computeSegmentTrimEnd(segment, -5);
+      expect(result).toEqual({ sourceEndFrame: 95 });
+    });
+  });
+
+  describe("computeSegmentReorderIndex", () => {
+    // Three segments: A(0-30), B(30-60), C(60-90) at 1px/frame
+    const segments = [makeSegment("A", 0, 30), makeSegment("B", 0, 30), makeSegment("C", 0, 30)];
+    const pixelsPerFrame = 1;
+    const timeline = computeSequenceTimeline(segments);
+    // positions: A=[0,30], B=[30,60], C=[60,90]
+    // midpoints: A=15, B=45, C=75
+
+    test("returns correct index when dragging to the right", () => {
+      // Drag A past midpoint of B (45) and C (75) -> should land at index 2
+      const result = computeSegmentReorderIndex(segments, "A", 50, pixelsPerFrame, timeline);
+      expect(result).toBe(1);
+
+      // Drag A past all midpoints
+      const result2 = computeSegmentReorderIndex(segments, "A", 80, pixelsPerFrame, timeline);
+      expect(result2).toBe(2);
+    });
+
+    test("returns correct index when dragging to the left", () => {
+      // Drag C to before midpoint of A (15) -> should land at index 0
+      const result = computeSegmentReorderIndex(segments, "C", 10, pixelsPerFrame, timeline);
+      expect(result).toBe(0);
+
+      // Drag C between A and B midpoints -> should land at index 1
+      const result2 = computeSegmentReorderIndex(segments, "C", 20, pixelsPerFrame, timeline);
+      expect(result2).toBe(1);
+    });
+  });
+});

--- a/@fanslib/apps/web/src/features/editor/utils/sequence-engine.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/sequence-engine.ts
@@ -1,0 +1,80 @@
+export type Segment = {
+  id: string;
+  sourceMediaId: string;
+  sourceStartFrame: number;
+  sourceEndFrame: number;
+  transition?: {
+    type: "crossfade";
+    durationFrames: number;
+  };
+};
+
+export type SequencePosition = {
+  segmentId: string;
+  sequenceStartFrame: number;
+  sequenceEndFrame: number;
+};
+
+export type SequenceTimeline = {
+  positions: SequencePosition[];
+  totalDuration: number;
+};
+
+export type SourceFrameMapping = {
+  segmentId: string;
+  sourceMediaId: string;
+  sourceFrame: number;
+};
+
+export const mapSequenceFrameToSource = (
+  sequenceFrame: number,
+  timeline: SequenceTimeline,
+  segments: Segment[],
+): SourceFrameMapping[] =>
+  timeline.positions.reduce<SourceFrameMapping[]>((results, position, i) => {
+    const segment = segments[i]!;
+    if (sequenceFrame >= position.sequenceStartFrame && sequenceFrame < position.sequenceEndFrame) {
+      const offsetInSegment = sequenceFrame - position.sequenceStartFrame;
+      return [
+        ...results,
+        {
+          segmentId: segment.id,
+          sourceMediaId: segment.sourceMediaId,
+          sourceFrame: segment.sourceStartFrame + offsetInSegment,
+        },
+      ];
+    }
+    return results;
+  }, []);
+
+export const computeSequenceTimeline = (segments: Segment[]): SequenceTimeline => {
+  if (segments.length === 0) {
+    return { positions: [], totalDuration: 0 };
+  }
+
+  const positions = segments.reduce<{ positions: SequencePosition[]; cursor: number }>(
+    (acc, segment, i) => {
+      const segmentDuration = segment.sourceEndFrame - segment.sourceStartFrame;
+      const overlap = i > 0 && segment.transition ? segment.transition.durationFrames : 0;
+      const start = acc.cursor - overlap;
+
+      return {
+        positions: [
+          ...acc.positions,
+          {
+            segmentId: segment.id,
+            sequenceStartFrame: start,
+            sequenceEndFrame: start + segmentDuration,
+          },
+        ],
+        cursor: start + segmentDuration,
+      };
+    },
+    { positions: [], cursor: 0 },
+  );
+
+  return {
+    positions: positions.positions,
+    totalDuration: positions.cursor,
+  };
+};

--- a/@fanslib/apps/web/src/features/editor/utils/sequence-engine.vitest.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/sequence-engine.vitest.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "vitest";
+import { computeSequenceTimeline, mapSequenceFrameToSource } from "./sequence-engine";
+
+describe("sequence engine", () => {
+  describe("computeSequenceTimeline", () => {
+    test("single segment starts at frame 0", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+      ]);
+      expect(result.totalDuration).toBe(300);
+    });
+
+    test("crossfade transition causes segment overlap", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        {
+          id: "s2",
+          sourceMediaId: "m2",
+          sourceStartFrame: 0,
+          sourceEndFrame: 200,
+          transition: { type: "crossfade", durationFrames: 30 },
+        },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+        { segmentId: "s2", sequenceStartFrame: 270, sequenceEndFrame: 470 },
+      ]);
+      expect(result.totalDuration).toBe(470);
+    });
+
+    test("three segments with mixed transitions", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+        {
+          id: "s3",
+          sourceMediaId: "m3",
+          sourceStartFrame: 100,
+          sourceEndFrame: 250,
+          transition: { type: "crossfade", durationFrames: 20 },
+        },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+        { segmentId: "s2", sequenceStartFrame: 300, sequenceEndFrame: 500 },
+        { segmentId: "s3", sequenceStartFrame: 480, sequenceEndFrame: 630 },
+      ]);
+      expect(result.totalDuration).toBe(630);
+    });
+
+    test("total duration with crossfade is reduced by overlap amount", () => {
+      const withoutCrossfade = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ]);
+
+      const withCrossfade = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        {
+          id: "s2",
+          sourceMediaId: "m2",
+          sourceStartFrame: 0,
+          sourceEndFrame: 200,
+          transition: { type: "crossfade", durationFrames: 30 },
+        },
+      ]);
+
+      expect(withoutCrossfade.totalDuration - withCrossfade.totalDuration).toBe(30);
+    });
+
+    test("empty segments array returns totalDuration 0 and empty positions", () => {
+      const result = computeSequenceTimeline([]);
+
+      expect(result.positions).toEqual([]);
+      expect(result.totalDuration).toBe(0);
+    });
+
+    test("two segments with hard cuts are contiguous", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+        { segmentId: "s2", sequenceStartFrame: 300, sequenceEndFrame: 500 },
+      ]);
+      expect(result.totalDuration).toBe(500);
+    });
+  });
+
+  describe("mapSequenceFrameToSource", () => {
+    test("returns correct segment and source frame for frame in first segment", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 100, sourceEndFrame: 400 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ] as const;
+      const timeline = computeSequenceTimeline([...segments]);
+
+      const result = mapSequenceFrameToSource(50, timeline, [...segments]);
+
+      expect(result).toEqual([
+        { segmentId: "s1", sourceMediaId: "m1", sourceFrame: 150 },
+      ]);
+    });
+    test("during crossfade overlap returns both segments with correct source frames", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        {
+          id: "s2",
+          sourceMediaId: "m2",
+          sourceStartFrame: 0,
+          sourceEndFrame: 200,
+          transition: { type: "crossfade" as const, durationFrames: 30 },
+        },
+      ];
+      const timeline = computeSequenceTimeline(segments);
+
+      // s1: 0-300, s2: 270-470. Frame 280 is in the overlap region (270-300).
+      const result = mapSequenceFrameToSource(280, timeline, segments);
+
+      expect(result).toEqual([
+        { segmentId: "s1", sourceMediaId: "m1", sourceFrame: 280 },
+        { segmentId: "s2", sourceMediaId: "m2", sourceFrame: 10 },
+      ]);
+    });
+
+    test("frame exactly at hard-cut segment boundary belongs to second segment", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ];
+      const timeline = computeSequenceTimeline(segments);
+
+      // s1: [0, 300), s2: [300, 500). Frame 300 is the boundary.
+      const result = mapSequenceFrameToSource(300, timeline, segments);
+
+      expect(result).toEqual([
+        { segmentId: "s2", sourceMediaId: "m2", sourceFrame: 0 },
+      ]);
+    });
+
+    test("returns correct segment for frame in second segment after hard cut", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 50, sourceEndFrame: 250 },
+      ] as const;
+      const timeline = computeSequenceTimeline([...segments]);
+
+      const result = mapSequenceFrameToSource(350, timeline, [...segments]);
+
+      expect(result).toEqual([
+        { segmentId: "s2", sourceMediaId: "m2", sourceFrame: 100 },
+      ]);
+    });
+    test("single segment with 0-duration transition is ignored", () => {
+      const segments = [
+        {
+          id: "s1",
+          sourceMediaId: "m1",
+          sourceStartFrame: 0,
+          sourceEndFrame: 300,
+          transition: { type: "crossfade" as const, durationFrames: 0 },
+        },
+      ];
+      const timeline = computeSequenceTimeline(segments);
+
+      expect(timeline.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+      ]);
+      expect(timeline.totalDuration).toBe(300);
+    });
+  });
+});

--- a/@fanslib/apps/web/src/lib/queries/compositions.ts
+++ b/@fanslib/apps/web/src/lib/queries/compositions.ts
@@ -1,0 +1,23 @@
+import type { InferResponseType } from "hono";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/hono-client";
+import { QUERY_KEYS } from "./query-keys";
+
+type CompositionByIdResponse = InferResponseType<
+  (typeof api.api.compositions)["by-id"][":id"]["$get"],
+  200
+>;
+
+export type Composition = CompositionByIdResponse;
+
+export const useCompositionByIdQuery = (compositionId: string) =>
+  useQuery({
+    queryKey: QUERY_KEYS.compositions.byId(compositionId),
+    queryFn: async (): Promise<CompositionByIdResponse> => {
+      const result = await api.api.compositions["by-id"][":id"].$get({
+        param: { id: compositionId },
+      });
+      return result.json() as Promise<CompositionByIdResponse>;
+    },
+    enabled: !!compositionId,
+  });

--- a/@fanslib/apps/web/src/lib/queries/query-keys.ts
+++ b/@fanslib/apps/web/src/lib/queries/query-keys.ts
@@ -177,6 +177,11 @@ export const QUERY_KEYS = {
     health: () => ["companion", "health"] as const,
   },
 
+  compositions: {
+    byId: (id: string) => ["compositions", id] as const,
+    byShoot: (shootId: string) => ["shoots", "compositions", shootId] as const,
+  },
+
   organize: {
     unmanaged: () => ["organize", "unmanaged"] as const,
     knownRoles: () => ["organize", "known-roles"] as const,

--- a/@fanslib/apps/web/src/routeTree.gen.ts
+++ b/@fanslib/apps/web/src/routeTree.gen.ts
@@ -44,6 +44,7 @@ import { Route as ContentLibraryOrganizeRouteImport } from './routes/content/lib
 import { Route as ContentLibraryMediaRouteImport } from './routes/content/library/media'
 import { Route as LibraryMediaIdEditIndexRouteImport } from './routes/library/$mediaId/edit/index'
 import { Route as ContentLibraryMediaIndexRouteImport } from './routes/content/library/media/index'
+import { Route as ShootsShootIdCompositionsCompositionIdRouteImport } from './routes/shoots/$shootId/compositions/$compositionId'
 import { Route as LibraryMediaIdEditEditIdRouteImport } from './routes/library/$mediaId/edit/$editId'
 import { Route as ContentLibraryMediaMediaIdRouteImport } from './routes/content/library/media/$mediaId'
 
@@ -223,6 +224,12 @@ const ContentLibraryMediaIndexRoute =
     path: '/',
     getParentRoute: () => ContentLibraryMediaRoute,
   } as any)
+const ShootsShootIdCompositionsCompositionIdRoute =
+  ShootsShootIdCompositionsCompositionIdRouteImport.update({
+    id: '/compositions/$compositionId',
+    path: '/compositions/$compositionId',
+    getParentRoute: () => ShootsShootIdRoute,
+  } as any)
 const LibraryMediaIdEditEditIdRoute =
   LibraryMediaIdEditEditIdRouteImport.update({
     id: '/edit/$editId',
@@ -261,7 +268,7 @@ export interface FileRoutesByFullPath {
   '/settings/integrations': typeof SettingsIntegrationsRoute
   '/settings/repost': typeof SettingsRepostRoute
   '/settings/snippets': typeof SettingsSnippetsRoute
-  '/shoots/$shootId': typeof ShootsShootIdRoute
+  '/shoots/$shootId': typeof ShootsShootIdRouteWithChildren
   '/library/': typeof LibraryIndexRoute
   '/plan/': typeof PlanIndexRoute
   '/schedules/': typeof SchedulesIndexRoute
@@ -272,6 +279,7 @@ export interface FileRoutesByFullPath {
   '/library/$mediaId/': typeof LibraryMediaIdIndexRoute
   '/content/library/media/$mediaId': typeof ContentLibraryMediaMediaIdRoute
   '/library/$mediaId/edit/$editId': typeof LibraryMediaIdEditEditIdRoute
+  '/shoots/$shootId/compositions/$compositionId': typeof ShootsShootIdCompositionsCompositionIdRoute
   '/content/library/media/': typeof ContentLibraryMediaIndexRoute
   '/library/$mediaId/edit/': typeof LibraryMediaIdEditIndexRoute
 }
@@ -297,7 +305,7 @@ export interface FileRoutesByTo {
   '/settings/integrations': typeof SettingsIntegrationsRoute
   '/settings/repost': typeof SettingsRepostRoute
   '/settings/snippets': typeof SettingsSnippetsRoute
-  '/shoots/$shootId': typeof ShootsShootIdRoute
+  '/shoots/$shootId': typeof ShootsShootIdRouteWithChildren
   '/library': typeof LibraryIndexRoute
   '/plan': typeof PlanIndexRoute
   '/schedules': typeof SchedulesIndexRoute
@@ -307,6 +315,7 @@ export interface FileRoutesByTo {
   '/library/$mediaId': typeof LibraryMediaIdIndexRoute
   '/content/library/media/$mediaId': typeof ContentLibraryMediaMediaIdRoute
   '/library/$mediaId/edit/$editId': typeof LibraryMediaIdEditEditIdRoute
+  '/shoots/$shootId/compositions/$compositionId': typeof ShootsShootIdCompositionsCompositionIdRoute
   '/content/library/media': typeof ContentLibraryMediaIndexRoute
   '/library/$mediaId/edit': typeof LibraryMediaIdEditIndexRoute
 }
@@ -336,7 +345,7 @@ export interface FileRoutesById {
   '/settings/integrations': typeof SettingsIntegrationsRoute
   '/settings/repost': typeof SettingsRepostRoute
   '/settings/snippets': typeof SettingsSnippetsRoute
-  '/shoots/$shootId': typeof ShootsShootIdRoute
+  '/shoots/$shootId': typeof ShootsShootIdRouteWithChildren
   '/library/': typeof LibraryIndexRoute
   '/plan/': typeof PlanIndexRoute
   '/schedules/': typeof SchedulesIndexRoute
@@ -347,6 +356,7 @@ export interface FileRoutesById {
   '/library/$mediaId/': typeof LibraryMediaIdIndexRoute
   '/content/library/media/$mediaId': typeof ContentLibraryMediaMediaIdRoute
   '/library/$mediaId/edit/$editId': typeof LibraryMediaIdEditEditIdRoute
+  '/shoots/$shootId/compositions/$compositionId': typeof ShootsShootIdCompositionsCompositionIdRoute
   '/content/library/media/': typeof ContentLibraryMediaIndexRoute
   '/library/$mediaId/edit/': typeof LibraryMediaIdEditIndexRoute
 }
@@ -388,6 +398,7 @@ export interface FileRouteTypes {
     | '/library/$mediaId/'
     | '/content/library/media/$mediaId'
     | '/library/$mediaId/edit/$editId'
+    | '/shoots/$shootId/compositions/$compositionId'
     | '/content/library/media/'
     | '/library/$mediaId/edit/'
   fileRoutesByTo: FileRoutesByTo
@@ -423,6 +434,7 @@ export interface FileRouteTypes {
     | '/library/$mediaId'
     | '/content/library/media/$mediaId'
     | '/library/$mediaId/edit/$editId'
+    | '/shoots/$shootId/compositions/$compositionId'
     | '/content/library/media'
     | '/library/$mediaId/edit'
   id:
@@ -462,6 +474,7 @@ export interface FileRouteTypes {
     | '/library/$mediaId/'
     | '/content/library/media/$mediaId'
     | '/library/$mediaId/edit/$editId'
+    | '/shoots/$shootId/compositions/$compositionId'
     | '/content/library/media/'
     | '/library/$mediaId/edit/'
   fileRoutesById: FileRoutesById
@@ -480,7 +493,7 @@ export interface RootRouteChildren {
   FanslyFypRoute: typeof FanslyFypRoute
   LibraryMediaIdRoute: typeof LibraryMediaIdRouteWithChildren
   PostsPostIdRoute: typeof PostsPostIdRoute
-  ShootsShootIdRoute: typeof ShootsShootIdRoute
+  ShootsShootIdRoute: typeof ShootsShootIdRouteWithChildren
   LibraryIndexRoute: typeof LibraryIndexRoute
   PlanIndexRoute: typeof PlanIndexRoute
   ShootsIndexRoute: typeof ShootsIndexRoute
@@ -733,6 +746,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ContentLibraryMediaIndexRouteImport
       parentRoute: typeof ContentLibraryMediaRoute
     }
+    '/shoots/$shootId/compositions/$compositionId': {
+      id: '/shoots/$shootId/compositions/$compositionId'
+      path: '/compositions/$compositionId'
+      fullPath: '/shoots/$shootId/compositions/$compositionId'
+      preLoaderRoute: typeof ShootsShootIdCompositionsCompositionIdRouteImport
+      parentRoute: typeof ShootsShootIdRoute
+    }
     '/library/$mediaId/edit/$editId': {
       id: '/library/$mediaId/edit/$editId'
       path: '/edit/$editId'
@@ -848,6 +868,19 @@ const LibraryMediaIdRouteWithChildren = LibraryMediaIdRoute._addFileChildren(
   LibraryMediaIdRouteChildren,
 )
 
+interface ShootsShootIdRouteChildren {
+  ShootsShootIdCompositionsCompositionIdRoute: typeof ShootsShootIdCompositionsCompositionIdRoute
+}
+
+const ShootsShootIdRouteChildren: ShootsShootIdRouteChildren = {
+  ShootsShootIdCompositionsCompositionIdRoute:
+    ShootsShootIdCompositionsCompositionIdRoute,
+}
+
+const ShootsShootIdRouteWithChildren = ShootsShootIdRoute._addFileChildren(
+  ShootsShootIdRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CaptioningRoute: CaptioningRoute,
@@ -862,7 +895,7 @@ const rootRouteChildren: RootRouteChildren = {
   FanslyFypRoute: FanslyFypRoute,
   LibraryMediaIdRoute: LibraryMediaIdRouteWithChildren,
   PostsPostIdRoute: PostsPostIdRoute,
-  ShootsShootIdRoute: ShootsShootIdRoute,
+  ShootsShootIdRoute: ShootsShootIdRouteWithChildren,
   LibraryIndexRoute: LibraryIndexRoute,
   PlanIndexRoute: PlanIndexRoute,
   ShootsIndexRoute: ShootsIndexRoute,
@@ -870,12 +903,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}

--- a/@fanslib/apps/web/src/routes/shoots/$shootId/compositions/$compositionId.tsx
+++ b/@fanslib/apps/web/src/routes/shoots/$shootId/compositions/$compositionId.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { CompositionEditor } from "~/features/editor/components/CompositionEditor";
+
+const CompositionEditorRoute = () => {
+  const { shootId, compositionId } = Route.useParams();
+  return <CompositionEditor shootId={shootId} compositionId={compositionId} />;
+};
+
+export const Route = createFileRoute("/shoots/$shootId/compositions/$compositionId")({
+  component: CompositionEditorRoute,
+});

--- a/@fanslib/apps/web/src/stores/editorStore.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { type CropOperation, normalizeCropOperation } from "~/features/editor/utils/crop-operation";
+import type { Segment } from "~/features/editor/utils/sequence-engine";
 
 type Track = {
   id: string;
@@ -9,6 +10,8 @@ type Track = {
 
 type EditorState = {
   tracks: Track[];
+  segments: Segment[];
+  selectedSegmentId: string | null;
   operations: unknown[];
   selectedOperationIndex: number | null;
   selectedOperationId: string | null;
@@ -71,6 +74,14 @@ type EditorState = {
   // Watermark convenience
   addWatermark: (assetId: string) => void;
 
+  // Segment mutations
+  addSegment: (segment: Omit<Segment, "id">) => void;
+  removeSegment: (segmentId: string) => void;
+  reorderSegments: (segmentId: string, newIndex: number) => void;
+  trimSegmentStart: (segmentId: string, newSourceStartFrame: number) => void;
+  trimSegmentEnd: (segmentId: string, newSourceEndFrame: number) => void;
+  selectSegment: (segmentId: string | null) => void;
+
   // Track management
   addTrack: () => void;
   removeTrack: (trackId: string) => void;
@@ -86,15 +97,15 @@ type EditorState = {
   markClean: () => void;
 
   // Hydrate from existing MediaEdit
-  hydrate: (data: unknown[] | { tracks: Track[] }) => void;
-  // Restore tracks from unified history snapshot (does not touch per-store undo stacks)
-  restoreTracks: (tracks: unknown[]) => void;
+  hydrate: (data: unknown[] | { tracks: Track[]; segments?: Segment[] }) => void;
+  // Restore tracks (and optionally segments) from unified history snapshot (does not touch per-store undo stacks)
+  restoreTracks: (tracks: unknown[], segments?: Segment[]) => void;
 
   // Reset
   reset: () => void;
 };
 
-type HistoryEntry = Track[];
+type HistoryEntry = { tracks: Track[]; segments: Segment[] };
 
 const makeDefaultTrack = (): Track => ({
   id: crypto.randomUUID(),
@@ -158,8 +169,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
     return tracks.length - 1;
   };
 
+  const cloneSegments = (segments: Segment[]): Segment[] =>
+    segments.map((s) => ({ ...s, transition: s.transition ? { ...s.transition } : undefined }));
+
   const pushHistory = () => {
-    undoStack.push(cloneTracks(get().tracks));
+    const state = get();
+    undoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
     redoStack = []; // Clear redo on new mutation
   };
 
@@ -173,6 +188,8 @@ export const useEditorStore = create<EditorState>((set, get) => {
 
   return {
     tracks: [initialTrack],
+    segments: [],
+    selectedSegmentId: null,
     operations: [],
     selectedOperationIndex: null,
     selectedOperationId: null,
@@ -373,10 +390,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
     undo: () => {
       const previous = undoStack.pop();
       if (previous === undefined) return;
-      redoStack.push(cloneTracks(get().tracks));
+      const state = get();
+      redoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
       set({
-        tracks: previous,
-        operations: flattenTracks(previous),
+        tracks: previous.tracks,
+        segments: previous.segments,
+        operations: flattenTracks(previous.tracks),
         canUndo: undoStack.length > 0,
         canRedo: true,
         cropEditingOperationIndex: null,
@@ -387,10 +406,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
     redo: () => {
       const next = redoStack.pop();
       if (next === undefined) return;
-      undoStack.push(cloneTracks(get().tracks));
+      const state = get();
+      undoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
       set({
-        tracks: next,
-        operations: flattenTracks(next),
+        tracks: next.tracks,
+        segments: next.segments,
+        operations: flattenTracks(next.tracks),
         canUndo: true,
         canRedo: redoStack.length > 0,
         cropEditingOperationIndex: null,
@@ -697,6 +718,60 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set({ selectedOperationId: id });
     },
 
+    addSegment: (segment) => {
+      pushHistory();
+      set((state) => ({
+        segments: [...state.segments, { ...segment, id: crypto.randomUUID() }],
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    removeSegment: (segmentId) => {
+      pushHistory();
+      set((state) => ({
+        segments: state.segments.filter((s) => s.id !== segmentId),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    reorderSegments: (segmentId, newIndex) => {
+      pushHistory();
+      set((state) => {
+        const segments = [...state.segments];
+        const fromIndex = segments.findIndex((s) => s.id === segmentId);
+        if (fromIndex === -1) return { ...updateUndoRedoFlags() };
+        const [moved] = segments.splice(fromIndex, 1);
+        // Drop transition if moved to index 0
+        const placed = newIndex === 0 ? { ...moved, transition: undefined } : moved;
+        segments.splice(newIndex, 0, placed);
+        return { segments, ...updateUndoRedoFlags() };
+      });
+    },
+
+    trimSegmentStart: (segmentId, newSourceStartFrame) => {
+      pushHistory();
+      set((state) => ({
+        segments: state.segments.map((s) =>
+          s.id === segmentId ? { ...s, sourceStartFrame: newSourceStartFrame } : s,
+        ),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    trimSegmentEnd: (segmentId, newSourceEndFrame) => {
+      pushHistory();
+      set((state) => ({
+        segments: state.segments.map((s) =>
+          s.id === segmentId ? { ...s, sourceEndFrame: newSourceEndFrame } : s,
+        ),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    selectSegment: (segmentId) => {
+      set({ selectedSegmentId: segmentId });
+    },
+
     addTrack: () => {
       pushHistory();
       set((state) => {
@@ -763,7 +838,8 @@ export const useEditorStore = create<EditorState>((set, get) => {
       redoStack = [];
 
       // Detect format: array = legacy flat operations, object with tracks = new format
-      const tracks: Track[] = Array.isArray(data)
+      const isLegacy = Array.isArray(data);
+      const tracks: Track[] = isLegacy
         ? [
             {
               id: crypto.randomUUID(),
@@ -779,11 +855,17 @@ export const useEditorStore = create<EditorState>((set, get) => {
           ]
         : (data as { tracks: Track[] }).tracks;
 
+      const segments: Segment[] = isLegacy
+        ? []
+        : (data as { segments?: Segment[] }).segments ?? [];
+
       set({
         tracks,
+        segments,
         operations: flattenTracks(tracks),
         selectedOperationIndex: null,
         selectedOperationId: null,
+        selectedSegmentId: null,
         cropEditingOperationIndex: null,
         cropEditingOperationId: null,
         canUndo: false,
@@ -792,11 +874,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
       });
     },
 
-    restoreTracks: (rawTracks) => {
+    restoreTracks: (rawTracks, segments) => {
       const tracks = rawTracks as Track[];
       set({
         tracks,
         operations: flattenTracks(tracks),
+        ...(segments !== undefined ? { segments } : {}),
       });
     },
 
@@ -805,6 +888,8 @@ export const useEditorStore = create<EditorState>((set, get) => {
       redoStack = [];
       set({
         tracks: [makeDefaultTrack()],
+        segments: [],
+        selectedSegmentId: null,
         operations: [],
         selectedOperationIndex: null,
         selectedOperationId: null,

--- a/@fanslib/apps/web/src/stores/editorStore.vitest.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.vitest.ts
@@ -631,6 +631,132 @@ describe("editorStore", () => {
     });
   });
 
+  describe("segments", () => {
+    test("addSegment appends a segment with generated id", () => {
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "media-1",
+        sourceStartFrame: 0,
+        sourceEndFrame: 90,
+      });
+      const segments = useEditorStore.getState().segments;
+      expect(segments).toHaveLength(1);
+      expect(segments[0].sourceMediaId).toBe("media-1");
+      expect(segments[0].sourceStartFrame).toBe(0);
+      expect(segments[0].sourceEndFrame).toBe(90);
+      expect(typeof segments[0].id).toBe("string");
+      expect(segments[0].id.length).toBeGreaterThan(0);
+    });
+
+    test("removeSegment removes by id", () => {
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "media-1",
+        sourceStartFrame: 0,
+        sourceEndFrame: 90,
+      });
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "media-2",
+        sourceStartFrame: 0,
+        sourceEndFrame: 60,
+      });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().removeSegment(id);
+      const segments = useEditorStore.getState().segments;
+      expect(segments).toHaveLength(1);
+      expect(segments[0].sourceMediaId).toBe("media-2");
+    });
+
+    test("reorderSegments moves to new index", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "a", sourceStartFrame: 0, sourceEndFrame: 30 });
+      useEditorStore.getState().addSegment({ sourceMediaId: "b", sourceStartFrame: 0, sourceEndFrame: 30 });
+      useEditorStore.getState().addSegment({ sourceMediaId: "c", sourceStartFrame: 0, sourceEndFrame: 30 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().reorderSegments(id, 2);
+      const segments = useEditorStore.getState().segments;
+      expect(segments[0].sourceMediaId).toBe("b");
+      expect(segments[1].sourceMediaId).toBe("c");
+      expect(segments[2].sourceMediaId).toBe("a");
+    });
+
+    test("reorderSegments drops transition when segment moves to index 0", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "a", sourceStartFrame: 0, sourceEndFrame: 30 });
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "b",
+        sourceStartFrame: 0,
+        sourceEndFrame: 30,
+        transition: { type: "crossfade", durationFrames: 10 },
+      });
+      const id = useEditorStore.getState().segments[1].id;
+      useEditorStore.getState().reorderSegments(id, 0);
+      const segments = useEditorStore.getState().segments;
+      expect(segments[0].sourceMediaId).toBe("b");
+      expect(segments[0].transition).toBeUndefined();
+    });
+
+    test("trimSegmentStart adjusts sourceStartFrame", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().trimSegmentStart(id, 15);
+      expect(useEditorStore.getState().segments[0].sourceStartFrame).toBe(15);
+    });
+
+    test("trimSegmentEnd adjusts sourceEndFrame", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().trimSegmentEnd(id, 60);
+      expect(useEditorStore.getState().segments[0].sourceEndFrame).toBe(60);
+    });
+
+    test("selectSegment sets selectedSegmentId", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().selectSegment(id);
+      expect(useEditorStore.getState().selectedSegmentId).toBe(id);
+      useEditorStore.getState().selectSegment(null);
+      expect(useEditorStore.getState().selectedSegmentId).toBeNull();
+    });
+
+    test("undo/redo works for segment mutations", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      expect(useEditorStore.getState().segments).toHaveLength(1);
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().segments).toHaveLength(0);
+      useEditorStore.getState().redo();
+      expect(useEditorStore.getState().segments).toHaveLength(1);
+      expect(useEditorStore.getState().segments[0].sourceMediaId).toBe("media-1");
+    });
+
+    test("undo/redo still works for operation mutations (regression)", () => {
+      useEditorStore.getState().addOperation({ type: "blur" });
+      expect(useEditorStore.getState().operations).toHaveLength(1);
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().operations).toHaveLength(0);
+      useEditorStore.getState().redo();
+      expect(useEditorStore.getState().operations).toHaveLength(1);
+    });
+
+    test("hydrate accepts and restores segments", () => {
+      const data = {
+        tracks: [{ id: "t1", name: "Track 1", operations: [] }],
+        segments: [
+          { id: "s1", sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 },
+          { id: "s2", sourceMediaId: "media-2", sourceStartFrame: 10, sourceEndFrame: 50 },
+        ],
+      };
+      useEditorStore.getState().hydrate(data);
+      expect(useEditorStore.getState().segments).toHaveLength(2);
+      expect(useEditorStore.getState().segments[0].id).toBe("s1");
+      expect(useEditorStore.getState().segments[1].sourceMediaId).toBe("media-2");
+    });
+
+    test("reset clears segments and selectedSegmentId", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      useEditorStore.getState().selectSegment(useEditorStore.getState().segments[0].id);
+      useEditorStore.getState().reset();
+      expect(useEditorStore.getState().segments).toEqual([]);
+      expect(useEditorStore.getState().selectedSegmentId).toBeNull();
+    });
+  });
+
   describe("zoom operations", () => {
     test("addZoom adds a zoom operation with default values", () => {
       useEditorStore.getState().addZoom();


### PR DESCRIPTION
## Summary

- Pure functions: `computeSegmentTrimStart`, `computeSegmentTrimEnd`, `computeSegmentReorderIndex`
- Trim clamps to valid frame ranges (min 1 frame duration)
- Reorder uses midpoint comparison for target index
- SegmentTrack gains pointer handlers: edge → trim, center → reorder, no-move → select
- Cursor changes on hover (col-resize near edges, grab in center)

Stacked on #376 (Segment track visualization)

Closes #346

## Test plan

- [x] Trim start clamps to not go below 0
- [x] Trim start clamps to not exceed endFrame - 1
- [x] Trim end clamps to not go below startFrame + 1
- [x] Trim end adjusts by positive delta
- [x] Reorder index correct when dragging right
- [x] Reorder index correct when dragging left
- [x] 8 pure function tests pass, existing 8 SegmentTrack tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)