### PR TITLE
feat(video): extend SequenceComposition for multi-segment hard cuts

### DIFF
--- a/@fanslib/apps/server/src/features/compositions/entity.ts
+++ b/@fanslib/apps/server/src/features/compositions/entity.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import type { Relation } from "typeorm";
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import { Shoot } from "../shoots/entity";
+
+@Entity("composition")
+export class Composition {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ type: "varchar", name: "shootId" })
+  shootId!: string;
+
+  @ManyToOne(() => Shoot, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "shootId" })
+  shoot!: Relation<Shoot>;
+
+  @Column({ type: "varchar", name: "name" })
+  name!: string;
+
+  @Column({ type: "simple-json", name: "segments", default: "[]" })
+  segments: unknown[] = [];
+
+  @Column({ type: "simple-json", name: "tracks", default: "[]" })
+  tracks: unknown[] = [];
+
+  @Column({ type: "simple-json", name: "exportRegions", default: "[]" })
+  exportRegions: unknown[] = [];
+
+  @CreateDateColumn({ type: "datetime", name: "createdAt" })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: "datetime", name: "updatedAt" })
+  updatedAt!: Date;
+}
+
+const SegmentTransitionSchema = z.object({
+  type: z.literal("crossfade"),
+  durationFrames: z.number(),
+  easing: z.string().optional(),
+});
+
+export const SegmentSchema = z.object({
+  id: z.string(),
+  sourceMediaId: z.string(),
+  sourceStartFrame: z.number(),
+  sourceEndFrame: z.number(),
+  transition: SegmentTransitionSchema.optional(),
+});
+
+export const TrackSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  operations: z.array(z.unknown()),
+});
+
+export const ExportRegionSchema = z.object({
+  id: z.string(),
+  startFrame: z.number(),
+  endFrame: z.number(),
+  package: z.string().nullable().optional(),
+  role: z.string().nullable().optional(),
+  contentRating: z.string().nullable().optional(),
+  quality: z.string().nullable().optional(),
+});
+
+export const CompositionSchema = z.object({
+  id: z.string(),
+  shootId: z.string(),
+  name: z.string(),
+  segments: z.array(SegmentSchema),
+  tracks: z.array(TrackSchema),
+  exportRegions: z.array(ExportRegionSchema),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/create.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/create.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const CreateCompositionRequestBodySchema = z.object({
+  shootId: z.string(),
+  name: z.string(),
+});
+
+export const createComposition = async (
+  payload: z.infer<typeof CreateCompositionRequestBodySchema>,
+): Promise<Composition> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+
+  const composition = repo.create({
+    shootId: payload.shootId,
+    name: payload.name,
+    segments: [],
+    tracks: [],
+    exportRegions: [],
+  });
+
+  await repo.save(composition);
+  const created = await repo.findOne({ where: { id: composition.id } });
+  if (!created) throw new Error(`Failed to fetch created composition ${composition.id}`);
+  return created;
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/delete.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/delete.ts
@@ -1,0 +1,11 @@
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const deleteComposition = async (id: string): Promise<boolean> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+  const composition = await repo.findOne({ where: { id } });
+  if (!composition) return false;
+  await repo.delete(id);
+  return true;
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-id.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-id.ts
@@ -1,0 +1,8 @@
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const fetchCompositionById = async (id: string): Promise<Composition | null> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+  return repo.findOne({ where: { id } });
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-shoot.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/fetch-by-shoot.ts
@@ -1,0 +1,11 @@
+import { db } from "../../../../lib/db";
+import { Composition } from "../../entity";
+
+export const fetchCompositionsByShoot = async (shootId: string): Promise<Composition[]> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+  return repo.find({
+    where: { shootId },
+    order: { createdAt: "DESC" },
+  });
+};

--- a/@fanslib/apps/server/src/features/compositions/operations/composition/update.ts
+++ b/@fanslib/apps/server/src/features/compositions/operations/composition/update.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { db } from "../../../../lib/db";
+import { Composition, SegmentSchema, TrackSchema, ExportRegionSchema } from "../../entity";
+
+export const UpdateCompositionRequestBodySchema = z.object({
+  name: z.string().optional(),
+  segments: z.array(SegmentSchema).optional(),
+  tracks: z.array(TrackSchema).optional(),
+  exportRegions: z.array(ExportRegionSchema).optional(),
+});
+
+export const updateComposition = async (
+  id: string,
+  payload: z.infer<typeof UpdateCompositionRequestBodySchema>,
+): Promise<Composition | null> => {
+  const database = await db();
+  const repo = database.getRepository(Composition);
+
+  const composition = await repo.findOne({ where: { id } });
+  if (!composition) return null;
+
+  if (payload.name !== undefined) composition.name = payload.name;
+  if (payload.segments !== undefined) composition.segments = payload.segments;
+  if (payload.tracks !== undefined) composition.tracks = payload.tracks;
+  if (payload.exportRegions !== undefined) composition.exportRegions = payload.exportRegions;
+
+  await repo.save(composition);
+  return composition;
+};

--- a/@fanslib/apps/server/src/features/compositions/routes.test.ts
+++ b/@fanslib/apps/server/src/features/compositions/routes.test.ts
@@ -1,0 +1,257 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import "reflect-metadata";
+import { getTestDataSource, setupTestDatabase, teardownTestDatabase } from "../../lib/test-db";
+import { resetAllFixtures } from "../../lib/test-fixtures";
+import { devalueMiddleware } from "../../lib/devalue-middleware";
+import { parseResponse } from "../../test-utils/setup";
+import { Shoot } from "../shoots/entity";
+import { compositionsRoutes } from "./routes";
+
+describe("Compositions Routes", () => {
+  // eslint-disable-next-line functional/no-let
+  let app: Hono;
+  // eslint-disable-next-line functional/no-let
+  let testShoot: Shoot;
+
+  beforeAll(async () => {
+    await setupTestDatabase();
+    await resetAllFixtures();
+    app = new Hono().use("*", devalueMiddleware()).route("/", compositionsRoutes);
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetAllFixtures();
+    // Create a shoot for compositions to reference
+    const dataSource = getTestDataSource();
+    const shootRepo = dataSource.getRepository(Shoot);
+    testShoot = shootRepo.create({
+      name: "Test Shoot",
+      shootDate: new Date("2026-04-08"),
+    });
+    testShoot = await shootRepo.save(testShoot);
+  });
+
+  describe("POST /api/compositions", () => {
+    test("creates a composition and returns it with all fields", async () => {
+      const response = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          shootId: testShoot.id,
+          name: "Trailer v1",
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{
+        id: string;
+        shootId: string;
+        name: string;
+        segments: unknown[];
+        tracks: unknown[];
+        exportRegions: unknown[];
+        createdAt: string;
+        updatedAt: string;
+      }>(response);
+
+      expect(data?.id).toBeDefined();
+      expect(data?.shootId).toBe(testShoot.id);
+      expect(data?.name).toBe("Trailer v1");
+      expect(data?.segments).toEqual([]);
+      expect(data?.tracks).toEqual([]);
+      expect(data?.exportRegions).toEqual([]);
+    });
+  });
+
+  describe("PATCH /api/compositions/by-id/:id", () => {
+    test("updates composition name, segments, tracks, and exportRegions", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Original" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const segments = [
+        { id: "seg-1", sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 900 },
+      ];
+      const tracks = [
+        { id: "track-1", name: "Overlays", operations: [] },
+      ];
+      const exportRegions = [
+        { id: "er-1", startFrame: 0, endFrame: 450 },
+      ];
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "Updated",
+          segments,
+          tracks,
+          exportRegions,
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{
+        name: string;
+        segments: unknown[];
+        tracks: unknown[];
+        exportRegions: unknown[];
+      }>(response);
+      expect(data?.name).toBe("Updated");
+      expect(data?.segments).toHaveLength(1);
+      expect(data?.tracks).toHaveLength(1);
+      expect(data?.exportRegions).toHaveLength(1);
+    });
+
+    test("returns 404 for non-existent composition", async () => {
+      const response = await app.request("/api/compositions/by-id/nonexistent", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Nope" }),
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("GET /api/compositions/by-shoot/:shootId", () => {
+    test("lists all compositions for a shoot", async () => {
+      await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Comp A" }),
+      });
+      await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Comp B" }),
+      });
+
+      const response = await app.request(`/api/compositions/by-shoot/${testShoot.id}`);
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ id: string; name: string }[]>(response);
+      expect(data).toHaveLength(2);
+      const names = data?.map((c) => c.name).sort();
+      expect(names).toEqual(["Comp A", "Comp B"]);
+    });
+
+    test("returns empty array for shoot with no compositions", async () => {
+      const response = await app.request(`/api/compositions/by-shoot/${testShoot.id}`);
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<unknown[]>(response);
+      expect(data).toHaveLength(0);
+    });
+  });
+
+  describe("DELETE /api/compositions/by-id/:id", () => {
+    test("deletes a composition", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "To Delete" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`, {
+        method: "DELETE",
+      });
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ success: boolean }>(response);
+      expect(data?.success).toBe(true);
+
+      // Verify it's gone
+      const getResponse = await app.request(`/api/compositions/by-id/${created?.id}`);
+      expect(getResponse.status).toBe(404);
+    });
+
+    test("returns 404 for non-existent composition", async () => {
+      const response = await app.request("/api/compositions/by-id/nonexistent", {
+        method: "DELETE",
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("GET /api/compositions/by-id/:id", () => {
+    test("fetches a composition by ID", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Fetch Test" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`);
+      expect(response.status).toBe(200);
+
+      const data = await parseResponse<{ id: string; name: string }>(response);
+      expect(data?.id).toBe(created?.id);
+      expect(data?.name).toBe("Fetch Test");
+    });
+
+    test("returns 404 for non-existent composition", async () => {
+      const response = await app.request("/api/compositions/by-id/nonexistent");
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Schema validation", () => {
+    test("rejects update with invalid segment shape", async () => {
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Validate Me" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      const response = await app.request(`/api/compositions/by-id/${created?.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          segments: [{ invalid: "shape" }],
+        }),
+      });
+      expect(response.status).toBe(422);
+    });
+
+    test("rejects create without required fields", async () => {
+      const response = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(response.status).toBe(422);
+    });
+  });
+
+  describe("Shoot cascade", () => {
+    test("deleting a shoot cascades to its compositions", async () => {
+      // Create a composition on the test shoot
+      const createResponse = await app.request("/api/compositions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shootId: testShoot.id, name: "Will Be Cascaded" }),
+      });
+      const created = await parseResponse<{ id: string }>(createResponse);
+
+      // Delete the shoot directly
+      const dataSource = getTestDataSource();
+      const shootRepo = dataSource.getRepository(Shoot);
+      await shootRepo.delete(testShoot.id);
+
+      // The composition should be gone
+      const getResponse = await app.request(`/api/compositions/by-id/${created?.id}`);
+      expect(getResponse.status).toBe(404);
+    });
+  });
+});

--- a/@fanslib/apps/server/src/features/compositions/routes.ts
+++ b/@fanslib/apps/server/src/features/compositions/routes.ts
@@ -1,0 +1,54 @@
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { validationError, notFound } from "../../lib/hono-utils";
+import {
+  CreateCompositionRequestBodySchema,
+  createComposition,
+} from "./operations/composition/create";
+import { deleteComposition } from "./operations/composition/delete";
+import { fetchCompositionById } from "./operations/composition/fetch-by-id";
+import { fetchCompositionsByShoot } from "./operations/composition/fetch-by-shoot";
+import {
+  UpdateCompositionRequestBodySchema,
+  updateComposition,
+} from "./operations/composition/update";
+
+export const compositionsRoutes = new Hono()
+  .basePath("/api/compositions")
+  .post(
+    "/",
+    zValidator("json", CreateCompositionRequestBodySchema, validationError),
+    async (c) => {
+      const body = c.req.valid("json");
+      const result = await createComposition(body);
+      return c.json(result);
+    },
+  )
+  .patch(
+    "/by-id/:id",
+    zValidator("json", UpdateCompositionRequestBodySchema, validationError),
+    async (c) => {
+      const id = c.req.param("id");
+      const body = c.req.valid("json");
+      const composition = await updateComposition(id, body);
+      if (!composition) return notFound(c, "Composition not found");
+      return c.json(composition);
+    },
+  )
+  .get("/by-id/:id", async (c) => {
+    const id = c.req.param("id");
+    const composition = await fetchCompositionById(id);
+    if (!composition) return notFound(c, "Composition not found");
+    return c.json(composition);
+  })
+  .get("/by-shoot/:shootId", async (c) => {
+    const shootId = c.req.param("shootId");
+    const compositions = await fetchCompositionsByShoot(shootId);
+    return c.json(compositions);
+  })
+  .delete("/by-id/:id", async (c) => {
+    const id = c.req.param("id");
+    const success = await deleteComposition(id);
+    if (!success) return notFound(c, "Composition not found");
+    return c.json({ success: true });
+  });

--- a/@fanslib/apps/server/src/index.ts
+++ b/@fanslib/apps/server/src/index.ts
@@ -9,6 +9,7 @@ import { analyticsRoutes } from "./features/analytics/routes";
 import { assetsRoutes } from "./features/assets/routes";
 import { candidatesRoutes } from "./features/analytics/candidates/routes";
 import { channelsRoutes } from "./features/channels/routes";
+import { compositionsRoutes } from "./features/compositions/routes";
 import { contentSchedulesRoutes } from "./features/content-schedules/routes";
 import { filterPresetsRoutes } from "./features/filter-presets/routes";
 import { hashtagsRoutes } from "./features/hashtags/routes";
@@ -89,6 +90,7 @@ const app = new Hono()
   .route("/", subredditsRoutes)
   .route("/", tagsRoutes)
   .route("/", channelsRoutes)
+  .route("/", compositionsRoutes)
   .route("/", contentSchedulesRoutes)
   .route("/", libraryRoutes)
   .route("/", organizeRoutes)

--- a/@fanslib/apps/server/src/lib/db.ts
+++ b/@fanslib/apps/server/src/lib/db.ts
@@ -7,6 +7,7 @@ import "reflect-metadata";
 import initSqlJs from "sql.js";
 import { DataSource } from "typeorm";
 import { Asset } from "../features/assets/entity";
+import { Composition } from "../features/compositions/entity";
 import { FanslyMediaCandidate } from "../features/analytics/candidate-entity";
 import { FanslyAnalyticsAggregate, FanslyAnalyticsDatapoint } from "../features/analytics/entity";
 import { Channel, ChannelType } from "../features/channels/entity";
@@ -80,6 +81,7 @@ const createAppDataSource = (driver?: Awaited<ReturnType<typeof initSqlJs>>) => 
     ...(driver ? { driver } : {}),
     entities: [
       Asset,
+      Composition,
       Media,
       MediaEdit,
       Post,

--- a/@fanslib/apps/server/src/lib/test-db.ts
+++ b/@fanslib/apps/server/src/lib/test-db.ts
@@ -2,6 +2,7 @@
 import initSqlJs from "sql.js";
 import { DataSource } from "typeorm";
 import { Asset } from "../features/assets/entity";
+import { Composition } from "../features/compositions/entity";
 import { FanslyMediaCandidate } from "../features/analytics/candidate-entity";
 import { FanslyAnalyticsAggregate, FanslyAnalyticsDatapoint } from "../features/analytics/entity";
 import { Channel, ChannelType } from "../features/channels/entity";
@@ -39,6 +40,7 @@ export const createTestDataSource = (driver?: Awaited<ReturnType<typeof initSqlJ
     ...(driver ? { driver } : {}),
     entities: [
       Asset,
+      Composition,
       Media,
       MediaEdit,
       Post,
@@ -118,6 +120,7 @@ export const clearAllTables = async () => {
     "CaptionSnippet",
     "Subreddit",
     "Channel",
+    "Composition",
     "Shoot",
     "TagDefinition",
     "TagDimension",

--- a/@fanslib/apps/web/src/features/editor/components/CompositionEditor.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/CompositionEditor.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from "react";
+import { useCompositionByIdQuery } from "~/lib/queries/compositions";
+import { useEditorStore } from "~/stores/editorStore";
+
+type CompositionEditorProps = {
+  shootId: string;
+  compositionId: string;
+};
+
+export const CompositionEditor = ({ shootId, compositionId }: CompositionEditorProps) => {
+  const { data: composition, isLoading, error } = useCompositionByIdQuery(compositionId);
+  const hydrate = useEditorStore((s) => s.hydrate);
+  const reset = useEditorStore((s) => s.reset);
+
+  useEffect(() => {
+    if (!composition) return;
+    // The API returns JSONValue[] for tracks/segments; runtime shapes match the store types.
+    hydrate({
+      tracks: composition.tracks,
+      segments: composition.segments,
+    } as Parameters<typeof hydrate>[0]);
+  }, [composition, hydrate]);
+
+  useEffect(() => {
+    return () => {
+      reset();
+    };
+  }, [reset]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center" data-testid="composition-loading">
+        <p className="text-muted-foreground">Loading composition...</p>
+      </div>
+    );
+  }
+
+  if (error || !composition) {
+    return (
+      <div className="flex h-full items-center justify-center" data-testid="composition-error">
+        <p className="text-destructive">
+          {error?.message ?? "Composition not found"}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col" data-testid="composition-editor">
+      <div className="border-b p-4">
+        <h1 className="text-lg font-semibold">{composition.name}</h1>
+        <p className="text-muted-foreground text-sm">
+          Shoot: {shootId} &middot; {composition.segments.length} segment{composition.segments.length !== 1 ? "s" : ""}
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/@fanslib/apps/web/src/features/editor/components/CompositionEditor.vitest.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/CompositionEditor.vitest.tsx
@@ -1,0 +1,139 @@
+/// <reference types="@testing-library/jest-dom" />
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+
+// Mock the composition query hook
+vi.mock("~/lib/queries/compositions", () => ({
+  useCompositionByIdQuery: vi.fn(),
+}));
+
+// Mock the editor store
+const mockHydrate = vi.fn();
+const mockReset = vi.fn();
+vi.mock("~/stores/editorStore", () => ({
+  useEditorStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ hydrate: mockHydrate, reset: mockReset }),
+  ),
+}));
+
+import { useCompositionByIdQuery } from "~/lib/queries/compositions";
+
+// Import after mocks
+import { CompositionEditor } from "./CompositionEditor";
+
+const mockUseCompositionByIdQuery = vi.mocked(useCompositionByIdQuery);
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const makeComposition = (overrides?: Record<string, unknown>) => ({
+  id: "comp-1",
+  shootId: "shoot-1",
+  name: "My Composition",
+  segments: [
+    { id: "seg-1", sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 150 },
+    { id: "seg-2", sourceMediaId: "media-2", sourceStartFrame: 30, sourceEndFrame: 120 },
+  ],
+  tracks: [{ id: "track-1", name: "Track 1", operations: [] }],
+  exportRegions: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("CompositionEditor", () => {
+  test("shows loading state initially", () => {
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useCompositionByIdQuery>);
+
+    render(<CompositionEditor shootId="shoot-1" compositionId="comp-1" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByTestId("composition-loading")).toBeInTheDocument();
+    expect(screen.getByText("Loading composition...")).toBeInTheDocument();
+  });
+
+  test("shows error when composition not found", () => {
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("Composition not found"),
+    } as ReturnType<typeof useCompositionByIdQuery>);
+
+    render(<CompositionEditor shootId="shoot-1" compositionId="comp-1" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByTestId("composition-error")).toBeInTheDocument();
+    expect(screen.getByText("Composition not found")).toBeInTheDocument();
+  });
+
+  test("renders composition name when data loads", () => {
+    const composition = makeComposition();
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: composition,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCompositionByIdQuery>);
+
+    render(<CompositionEditor shootId="shoot-1" compositionId="comp-1" />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByTestId("composition-editor")).toBeInTheDocument();
+    expect(screen.getByText("My Composition")).toBeInTheDocument();
+    expect(screen.getByText(/2 segments/)).toBeInTheDocument();
+  });
+
+  test("hydrates the editor store when composition loads", async () => {
+    const composition = makeComposition();
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: composition,
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCompositionByIdQuery>);
+
+    render(<CompositionEditor shootId="shoot-1" compositionId="comp-1" />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(mockHydrate).toHaveBeenCalledWith({
+        tracks: composition.tracks,
+        segments: composition.segments,
+      });
+    });
+  });
+
+  test("resets the store on unmount", () => {
+    mockUseCompositionByIdQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useCompositionByIdQuery>);
+
+    const { unmount } = render(
+      <CompositionEditor shootId="shoot-1" compositionId="comp-1" />,
+      { wrapper: createWrapper() },
+    );
+
+    unmount();
+    expect(mockReset).toHaveBeenCalled();
+  });
+});

--- a/@fanslib/apps/web/src/features/editor/utils/sequence-engine.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/sequence-engine.ts
@@ -1,0 +1,80 @@
+export type Segment = {
+  id: string;
+  sourceMediaId: string;
+  sourceStartFrame: number;
+  sourceEndFrame: number;
+  transition?: {
+    type: "crossfade";
+    durationFrames: number;
+  };
+};
+
+export type SequencePosition = {
+  segmentId: string;
+  sequenceStartFrame: number;
+  sequenceEndFrame: number;
+};
+
+export type SequenceTimeline = {
+  positions: SequencePosition[];
+  totalDuration: number;
+};
+
+export type SourceFrameMapping = {
+  segmentId: string;
+  sourceMediaId: string;
+  sourceFrame: number;
+};
+
+export const mapSequenceFrameToSource = (
+  sequenceFrame: number,
+  timeline: SequenceTimeline,
+  segments: Segment[],
+): SourceFrameMapping[] =>
+  timeline.positions.reduce<SourceFrameMapping[]>((results, position, i) => {
+    const segment = segments[i]!;
+    if (sequenceFrame >= position.sequenceStartFrame && sequenceFrame < position.sequenceEndFrame) {
+      const offsetInSegment = sequenceFrame - position.sequenceStartFrame;
+      return [
+        ...results,
+        {
+          segmentId: segment.id,
+          sourceMediaId: segment.sourceMediaId,
+          sourceFrame: segment.sourceStartFrame + offsetInSegment,
+        },
+      ];
+    }
+    return results;
+  }, []);
+
+export const computeSequenceTimeline = (segments: Segment[]): SequenceTimeline => {
+  if (segments.length === 0) {
+    return { positions: [], totalDuration: 0 };
+  }
+
+  const positions = segments.reduce<{ positions: SequencePosition[]; cursor: number }>(
+    (acc, segment, i) => {
+      const segmentDuration = segment.sourceEndFrame - segment.sourceStartFrame;
+      const overlap = i > 0 && segment.transition ? segment.transition.durationFrames : 0;
+      const start = acc.cursor - overlap;
+
+      return {
+        positions: [
+          ...acc.positions,
+          {
+            segmentId: segment.id,
+            sequenceStartFrame: start,
+            sequenceEndFrame: start + segmentDuration,
+          },
+        ],
+        cursor: start + segmentDuration,
+      };
+    },
+    { positions: [], cursor: 0 },
+  );
+
+  return {
+    positions: positions.positions,
+    totalDuration: positions.cursor,
+  };
+};

--- a/@fanslib/apps/web/src/features/editor/utils/sequence-engine.vitest.ts
+++ b/@fanslib/apps/web/src/features/editor/utils/sequence-engine.vitest.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "vitest";
+import { computeSequenceTimeline, mapSequenceFrameToSource } from "./sequence-engine";
+
+describe("sequence engine", () => {
+  describe("computeSequenceTimeline", () => {
+    test("single segment starts at frame 0", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+      ]);
+      expect(result.totalDuration).toBe(300);
+    });
+
+    test("crossfade transition causes segment overlap", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        {
+          id: "s2",
+          sourceMediaId: "m2",
+          sourceStartFrame: 0,
+          sourceEndFrame: 200,
+          transition: { type: "crossfade", durationFrames: 30 },
+        },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+        { segmentId: "s2", sequenceStartFrame: 270, sequenceEndFrame: 470 },
+      ]);
+      expect(result.totalDuration).toBe(470);
+    });
+
+    test("three segments with mixed transitions", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+        {
+          id: "s3",
+          sourceMediaId: "m3",
+          sourceStartFrame: 100,
+          sourceEndFrame: 250,
+          transition: { type: "crossfade", durationFrames: 20 },
+        },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+        { segmentId: "s2", sequenceStartFrame: 300, sequenceEndFrame: 500 },
+        { segmentId: "s3", sequenceStartFrame: 480, sequenceEndFrame: 630 },
+      ]);
+      expect(result.totalDuration).toBe(630);
+    });
+
+    test("total duration with crossfade is reduced by overlap amount", () => {
+      const withoutCrossfade = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ]);
+
+      const withCrossfade = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        {
+          id: "s2",
+          sourceMediaId: "m2",
+          sourceStartFrame: 0,
+          sourceEndFrame: 200,
+          transition: { type: "crossfade", durationFrames: 30 },
+        },
+      ]);
+
+      expect(withoutCrossfade.totalDuration - withCrossfade.totalDuration).toBe(30);
+    });
+
+    test("empty segments array returns totalDuration 0 and empty positions", () => {
+      const result = computeSequenceTimeline([]);
+
+      expect(result.positions).toEqual([]);
+      expect(result.totalDuration).toBe(0);
+    });
+
+    test("two segments with hard cuts are contiguous", () => {
+      const result = computeSequenceTimeline([
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ]);
+
+      expect(result.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+        { segmentId: "s2", sequenceStartFrame: 300, sequenceEndFrame: 500 },
+      ]);
+      expect(result.totalDuration).toBe(500);
+    });
+  });
+
+  describe("mapSequenceFrameToSource", () => {
+    test("returns correct segment and source frame for frame in first segment", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 100, sourceEndFrame: 400 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ] as const;
+      const timeline = computeSequenceTimeline([...segments]);
+
+      const result = mapSequenceFrameToSource(50, timeline, [...segments]);
+
+      expect(result).toEqual([
+        { segmentId: "s1", sourceMediaId: "m1", sourceFrame: 150 },
+      ]);
+    });
+    test("during crossfade overlap returns both segments with correct source frames", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        {
+          id: "s2",
+          sourceMediaId: "m2",
+          sourceStartFrame: 0,
+          sourceEndFrame: 200,
+          transition: { type: "crossfade" as const, durationFrames: 30 },
+        },
+      ];
+      const timeline = computeSequenceTimeline(segments);
+
+      // s1: 0-300, s2: 270-470. Frame 280 is in the overlap region (270-300).
+      const result = mapSequenceFrameToSource(280, timeline, segments);
+
+      expect(result).toEqual([
+        { segmentId: "s1", sourceMediaId: "m1", sourceFrame: 280 },
+        { segmentId: "s2", sourceMediaId: "m2", sourceFrame: 10 },
+      ]);
+    });
+
+    test("frame exactly at hard-cut segment boundary belongs to second segment", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 0, sourceEndFrame: 200 },
+      ];
+      const timeline = computeSequenceTimeline(segments);
+
+      // s1: [0, 300), s2: [300, 500). Frame 300 is the boundary.
+      const result = mapSequenceFrameToSource(300, timeline, segments);
+
+      expect(result).toEqual([
+        { segmentId: "s2", sourceMediaId: "m2", sourceFrame: 0 },
+      ]);
+    });
+
+    test("returns correct segment for frame in second segment after hard cut", () => {
+      const segments = [
+        { id: "s1", sourceMediaId: "m1", sourceStartFrame: 0, sourceEndFrame: 300 },
+        { id: "s2", sourceMediaId: "m2", sourceStartFrame: 50, sourceEndFrame: 250 },
+      ] as const;
+      const timeline = computeSequenceTimeline([...segments]);
+
+      const result = mapSequenceFrameToSource(350, timeline, [...segments]);
+
+      expect(result).toEqual([
+        { segmentId: "s2", sourceMediaId: "m2", sourceFrame: 100 },
+      ]);
+    });
+    test("single segment with 0-duration transition is ignored", () => {
+      const segments = [
+        {
+          id: "s1",
+          sourceMediaId: "m1",
+          sourceStartFrame: 0,
+          sourceEndFrame: 300,
+          transition: { type: "crossfade" as const, durationFrames: 0 },
+        },
+      ];
+      const timeline = computeSequenceTimeline(segments);
+
+      expect(timeline.positions).toEqual([
+        { segmentId: "s1", sequenceStartFrame: 0, sequenceEndFrame: 300 },
+      ]);
+      expect(timeline.totalDuration).toBe(300);
+    });
+  });
+});

--- a/@fanslib/apps/web/src/lib/queries/compositions.ts
+++ b/@fanslib/apps/web/src/lib/queries/compositions.ts
@@ -1,0 +1,23 @@
+import type { InferResponseType } from "hono";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/hono-client";
+import { QUERY_KEYS } from "./query-keys";
+
+type CompositionByIdResponse = InferResponseType<
+  (typeof api.api.compositions)["by-id"][":id"]["$get"],
+  200
+>;
+
+export type Composition = CompositionByIdResponse;
+
+export const useCompositionByIdQuery = (compositionId: string) =>
+  useQuery({
+    queryKey: QUERY_KEYS.compositions.byId(compositionId),
+    queryFn: async (): Promise<CompositionByIdResponse> => {
+      const result = await api.api.compositions["by-id"][":id"].$get({
+        param: { id: compositionId },
+      });
+      return result.json() as Promise<CompositionByIdResponse>;
+    },
+    enabled: !!compositionId,
+  });

--- a/@fanslib/apps/web/src/lib/queries/query-keys.ts
+++ b/@fanslib/apps/web/src/lib/queries/query-keys.ts
@@ -177,6 +177,11 @@ export const QUERY_KEYS = {
     health: () => ["companion", "health"] as const,
   },
 
+  compositions: {
+    byId: (id: string) => ["compositions", id] as const,
+    byShoot: (shootId: string) => ["shoots", "compositions", shootId] as const,
+  },
+
   organize: {
     unmanaged: () => ["organize", "unmanaged"] as const,
     knownRoles: () => ["organize", "known-roles"] as const,

--- a/@fanslib/apps/web/src/routeTree.gen.ts
+++ b/@fanslib/apps/web/src/routeTree.gen.ts
@@ -44,6 +44,7 @@ import { Route as ContentLibraryOrganizeRouteImport } from './routes/content/lib
 import { Route as ContentLibraryMediaRouteImport } from './routes/content/library/media'
 import { Route as LibraryMediaIdEditIndexRouteImport } from './routes/library/$mediaId/edit/index'
 import { Route as ContentLibraryMediaIndexRouteImport } from './routes/content/library/media/index'
+import { Route as ShootsShootIdCompositionsCompositionIdRouteImport } from './routes/shoots/$shootId/compositions/$compositionId'
 import { Route as LibraryMediaIdEditEditIdRouteImport } from './routes/library/$mediaId/edit/$editId'
 import { Route as ContentLibraryMediaMediaIdRouteImport } from './routes/content/library/media/$mediaId'
 
@@ -223,6 +224,12 @@ const ContentLibraryMediaIndexRoute =
     path: '/',
     getParentRoute: () => ContentLibraryMediaRoute,
   } as any)
+const ShootsShootIdCompositionsCompositionIdRoute =
+  ShootsShootIdCompositionsCompositionIdRouteImport.update({
+    id: '/compositions/$compositionId',
+    path: '/compositions/$compositionId',
+    getParentRoute: () => ShootsShootIdRoute,
+  } as any)
 const LibraryMediaIdEditEditIdRoute =
   LibraryMediaIdEditEditIdRouteImport.update({
     id: '/edit/$editId',
@@ -261,7 +268,7 @@ export interface FileRoutesByFullPath {
   '/settings/integrations': typeof SettingsIntegrationsRoute
   '/settings/repost': typeof SettingsRepostRoute
   '/settings/snippets': typeof SettingsSnippetsRoute
-  '/shoots/$shootId': typeof ShootsShootIdRoute
+  '/shoots/$shootId': typeof ShootsShootIdRouteWithChildren
   '/library/': typeof LibraryIndexRoute
   '/plan/': typeof PlanIndexRoute
   '/schedules/': typeof SchedulesIndexRoute
@@ -272,6 +279,7 @@ export interface FileRoutesByFullPath {
   '/library/$mediaId/': typeof LibraryMediaIdIndexRoute
   '/content/library/media/$mediaId': typeof ContentLibraryMediaMediaIdRoute
   '/library/$mediaId/edit/$editId': typeof LibraryMediaIdEditEditIdRoute
+  '/shoots/$shootId/compositions/$compositionId': typeof ShootsShootIdCompositionsCompositionIdRoute
   '/content/library/media/': typeof ContentLibraryMediaIndexRoute
   '/library/$mediaId/edit/': typeof LibraryMediaIdEditIndexRoute
 }
@@ -297,7 +305,7 @@ export interface FileRoutesByTo {
   '/settings/integrations': typeof SettingsIntegrationsRoute
   '/settings/repost': typeof SettingsRepostRoute
   '/settings/snippets': typeof SettingsSnippetsRoute
-  '/shoots/$shootId': typeof ShootsShootIdRoute
+  '/shoots/$shootId': typeof ShootsShootIdRouteWithChildren
   '/library': typeof LibraryIndexRoute
   '/plan': typeof PlanIndexRoute
   '/schedules': typeof SchedulesIndexRoute
@@ -307,6 +315,7 @@ export interface FileRoutesByTo {
   '/library/$mediaId': typeof LibraryMediaIdIndexRoute
   '/content/library/media/$mediaId': typeof ContentLibraryMediaMediaIdRoute
   '/library/$mediaId/edit/$editId': typeof LibraryMediaIdEditEditIdRoute
+  '/shoots/$shootId/compositions/$compositionId': typeof ShootsShootIdCompositionsCompositionIdRoute
   '/content/library/media': typeof ContentLibraryMediaIndexRoute
   '/library/$mediaId/edit': typeof LibraryMediaIdEditIndexRoute
 }
@@ -336,7 +345,7 @@ export interface FileRoutesById {
   '/settings/integrations': typeof SettingsIntegrationsRoute
   '/settings/repost': typeof SettingsRepostRoute
   '/settings/snippets': typeof SettingsSnippetsRoute
-  '/shoots/$shootId': typeof ShootsShootIdRoute
+  '/shoots/$shootId': typeof ShootsShootIdRouteWithChildren
   '/library/': typeof LibraryIndexRoute
   '/plan/': typeof PlanIndexRoute
   '/schedules/': typeof SchedulesIndexRoute
@@ -347,6 +356,7 @@ export interface FileRoutesById {
   '/library/$mediaId/': typeof LibraryMediaIdIndexRoute
   '/content/library/media/$mediaId': typeof ContentLibraryMediaMediaIdRoute
   '/library/$mediaId/edit/$editId': typeof LibraryMediaIdEditEditIdRoute
+  '/shoots/$shootId/compositions/$compositionId': typeof ShootsShootIdCompositionsCompositionIdRoute
   '/content/library/media/': typeof ContentLibraryMediaIndexRoute
   '/library/$mediaId/edit/': typeof LibraryMediaIdEditIndexRoute
 }
@@ -388,6 +398,7 @@ export interface FileRouteTypes {
     | '/library/$mediaId/'
     | '/content/library/media/$mediaId'
     | '/library/$mediaId/edit/$editId'
+    | '/shoots/$shootId/compositions/$compositionId'
     | '/content/library/media/'
     | '/library/$mediaId/edit/'
   fileRoutesByTo: FileRoutesByTo
@@ -423,6 +434,7 @@ export interface FileRouteTypes {
     | '/library/$mediaId'
     | '/content/library/media/$mediaId'
     | '/library/$mediaId/edit/$editId'
+    | '/shoots/$shootId/compositions/$compositionId'
     | '/content/library/media'
     | '/library/$mediaId/edit'
   id:
@@ -462,6 +474,7 @@ export interface FileRouteTypes {
     | '/library/$mediaId/'
     | '/content/library/media/$mediaId'
     | '/library/$mediaId/edit/$editId'
+    | '/shoots/$shootId/compositions/$compositionId'
     | '/content/library/media/'
     | '/library/$mediaId/edit/'
   fileRoutesById: FileRoutesById
@@ -480,7 +493,7 @@ export interface RootRouteChildren {
   FanslyFypRoute: typeof FanslyFypRoute
   LibraryMediaIdRoute: typeof LibraryMediaIdRouteWithChildren
   PostsPostIdRoute: typeof PostsPostIdRoute
-  ShootsShootIdRoute: typeof ShootsShootIdRoute
+  ShootsShootIdRoute: typeof ShootsShootIdRouteWithChildren
   LibraryIndexRoute: typeof LibraryIndexRoute
   PlanIndexRoute: typeof PlanIndexRoute
   ShootsIndexRoute: typeof ShootsIndexRoute
@@ -733,6 +746,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ContentLibraryMediaIndexRouteImport
       parentRoute: typeof ContentLibraryMediaRoute
     }
+    '/shoots/$shootId/compositions/$compositionId': {
+      id: '/shoots/$shootId/compositions/$compositionId'
+      path: '/compositions/$compositionId'
+      fullPath: '/shoots/$shootId/compositions/$compositionId'
+      preLoaderRoute: typeof ShootsShootIdCompositionsCompositionIdRouteImport
+      parentRoute: typeof ShootsShootIdRoute
+    }
     '/library/$mediaId/edit/$editId': {
       id: '/library/$mediaId/edit/$editId'
       path: '/edit/$editId'
@@ -848,6 +868,19 @@ const LibraryMediaIdRouteWithChildren = LibraryMediaIdRoute._addFileChildren(
   LibraryMediaIdRouteChildren,
 )
 
+interface ShootsShootIdRouteChildren {
+  ShootsShootIdCompositionsCompositionIdRoute: typeof ShootsShootIdCompositionsCompositionIdRoute
+}
+
+const ShootsShootIdRouteChildren: ShootsShootIdRouteChildren = {
+  ShootsShootIdCompositionsCompositionIdRoute:
+    ShootsShootIdCompositionsCompositionIdRoute,
+}
+
+const ShootsShootIdRouteWithChildren = ShootsShootIdRoute._addFileChildren(
+  ShootsShootIdRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CaptioningRoute: CaptioningRoute,
@@ -862,7 +895,7 @@ const rootRouteChildren: RootRouteChildren = {
   FanslyFypRoute: FanslyFypRoute,
   LibraryMediaIdRoute: LibraryMediaIdRouteWithChildren,
   PostsPostIdRoute: PostsPostIdRoute,
-  ShootsShootIdRoute: ShootsShootIdRoute,
+  ShootsShootIdRoute: ShootsShootIdRouteWithChildren,
   LibraryIndexRoute: LibraryIndexRoute,
   PlanIndexRoute: PlanIndexRoute,
   ShootsIndexRoute: ShootsIndexRoute,
@@ -870,12 +903,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}

--- a/@fanslib/apps/web/src/routes/shoots/$shootId/compositions/$compositionId.tsx
+++ b/@fanslib/apps/web/src/routes/shoots/$shootId/compositions/$compositionId.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { CompositionEditor } from "~/features/editor/components/CompositionEditor";
+
+const CompositionEditorRoute = () => {
+  const { shootId, compositionId } = Route.useParams();
+  return <CompositionEditor shootId={shootId} compositionId={compositionId} />;
+};
+
+export const Route = createFileRoute("/shoots/$shootId/compositions/$compositionId")({
+  component: CompositionEditorRoute,
+});

--- a/@fanslib/apps/web/src/stores/editorStore.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { type CropOperation, normalizeCropOperation } from "~/features/editor/utils/crop-operation";
+import type { Segment } from "~/features/editor/utils/sequence-engine";
 
 type Track = {
   id: string;
@@ -9,6 +10,8 @@ type Track = {
 
 type EditorState = {
   tracks: Track[];
+  segments: Segment[];
+  selectedSegmentId: string | null;
   operations: unknown[];
   selectedOperationIndex: number | null;
   selectedOperationId: string | null;
@@ -71,6 +74,14 @@ type EditorState = {
   // Watermark convenience
   addWatermark: (assetId: string) => void;
 
+  // Segment mutations
+  addSegment: (segment: Omit<Segment, "id">) => void;
+  removeSegment: (segmentId: string) => void;
+  reorderSegments: (segmentId: string, newIndex: number) => void;
+  trimSegmentStart: (segmentId: string, newSourceStartFrame: number) => void;
+  trimSegmentEnd: (segmentId: string, newSourceEndFrame: number) => void;
+  selectSegment: (segmentId: string | null) => void;
+
   // Track management
   addTrack: () => void;
   removeTrack: (trackId: string) => void;
@@ -86,15 +97,15 @@ type EditorState = {
   markClean: () => void;
 
   // Hydrate from existing MediaEdit
-  hydrate: (data: unknown[] | { tracks: Track[] }) => void;
-  // Restore tracks from unified history snapshot (does not touch per-store undo stacks)
-  restoreTracks: (tracks: unknown[]) => void;
+  hydrate: (data: unknown[] | { tracks: Track[]; segments?: Segment[] }) => void;
+  // Restore tracks (and optionally segments) from unified history snapshot (does not touch per-store undo stacks)
+  restoreTracks: (tracks: unknown[], segments?: Segment[]) => void;
 
   // Reset
   reset: () => void;
 };
 
-type HistoryEntry = Track[];
+type HistoryEntry = { tracks: Track[]; segments: Segment[] };
 
 const makeDefaultTrack = (): Track => ({
   id: crypto.randomUUID(),
@@ -158,8 +169,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
     return tracks.length - 1;
   };
 
+  const cloneSegments = (segments: Segment[]): Segment[] =>
+    segments.map((s) => ({ ...s, transition: s.transition ? { ...s.transition } : undefined }));
+
   const pushHistory = () => {
-    undoStack.push(cloneTracks(get().tracks));
+    const state = get();
+    undoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
     redoStack = []; // Clear redo on new mutation
   };
 
@@ -173,6 +188,8 @@ export const useEditorStore = create<EditorState>((set, get) => {
 
   return {
     tracks: [initialTrack],
+    segments: [],
+    selectedSegmentId: null,
     operations: [],
     selectedOperationIndex: null,
     selectedOperationId: null,
@@ -373,10 +390,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
     undo: () => {
       const previous = undoStack.pop();
       if (previous === undefined) return;
-      redoStack.push(cloneTracks(get().tracks));
+      const state = get();
+      redoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
       set({
-        tracks: previous,
-        operations: flattenTracks(previous),
+        tracks: previous.tracks,
+        segments: previous.segments,
+        operations: flattenTracks(previous.tracks),
         canUndo: undoStack.length > 0,
         canRedo: true,
         cropEditingOperationIndex: null,
@@ -387,10 +406,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
     redo: () => {
       const next = redoStack.pop();
       if (next === undefined) return;
-      undoStack.push(cloneTracks(get().tracks));
+      const state = get();
+      undoStack.push({ tracks: cloneTracks(state.tracks), segments: cloneSegments(state.segments) });
       set({
-        tracks: next,
-        operations: flattenTracks(next),
+        tracks: next.tracks,
+        segments: next.segments,
+        operations: flattenTracks(next.tracks),
         canUndo: true,
         canRedo: redoStack.length > 0,
         cropEditingOperationIndex: null,
@@ -697,6 +718,60 @@ export const useEditorStore = create<EditorState>((set, get) => {
       set({ selectedOperationId: id });
     },
 
+    addSegment: (segment) => {
+      pushHistory();
+      set((state) => ({
+        segments: [...state.segments, { ...segment, id: crypto.randomUUID() }],
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    removeSegment: (segmentId) => {
+      pushHistory();
+      set((state) => ({
+        segments: state.segments.filter((s) => s.id !== segmentId),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    reorderSegments: (segmentId, newIndex) => {
+      pushHistory();
+      set((state) => {
+        const segments = [...state.segments];
+        const fromIndex = segments.findIndex((s) => s.id === segmentId);
+        if (fromIndex === -1) return { ...updateUndoRedoFlags() };
+        const [moved] = segments.splice(fromIndex, 1);
+        // Drop transition if moved to index 0
+        const placed = newIndex === 0 ? { ...moved, transition: undefined } : moved;
+        segments.splice(newIndex, 0, placed);
+        return { segments, ...updateUndoRedoFlags() };
+      });
+    },
+
+    trimSegmentStart: (segmentId, newSourceStartFrame) => {
+      pushHistory();
+      set((state) => ({
+        segments: state.segments.map((s) =>
+          s.id === segmentId ? { ...s, sourceStartFrame: newSourceStartFrame } : s,
+        ),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    trimSegmentEnd: (segmentId, newSourceEndFrame) => {
+      pushHistory();
+      set((state) => ({
+        segments: state.segments.map((s) =>
+          s.id === segmentId ? { ...s, sourceEndFrame: newSourceEndFrame } : s,
+        ),
+        ...updateUndoRedoFlags(),
+      }));
+    },
+
+    selectSegment: (segmentId) => {
+      set({ selectedSegmentId: segmentId });
+    },
+
     addTrack: () => {
       pushHistory();
       set((state) => {
@@ -763,7 +838,8 @@ export const useEditorStore = create<EditorState>((set, get) => {
       redoStack = [];
 
       // Detect format: array = legacy flat operations, object with tracks = new format
-      const tracks: Track[] = Array.isArray(data)
+      const isLegacy = Array.isArray(data);
+      const tracks: Track[] = isLegacy
         ? [
             {
               id: crypto.randomUUID(),
@@ -779,11 +855,17 @@ export const useEditorStore = create<EditorState>((set, get) => {
           ]
         : (data as { tracks: Track[] }).tracks;
 
+      const segments: Segment[] = isLegacy
+        ? []
+        : (data as { segments?: Segment[] }).segments ?? [];
+
       set({
         tracks,
+        segments,
         operations: flattenTracks(tracks),
         selectedOperationIndex: null,
         selectedOperationId: null,
+        selectedSegmentId: null,
         cropEditingOperationIndex: null,
         cropEditingOperationId: null,
         canUndo: false,
@@ -792,11 +874,12 @@ export const useEditorStore = create<EditorState>((set, get) => {
       });
     },
 
-    restoreTracks: (rawTracks) => {
+    restoreTracks: (rawTracks, segments) => {
       const tracks = rawTracks as Track[];
       set({
         tracks,
         operations: flattenTracks(tracks),
+        ...(segments !== undefined ? { segments } : {}),
       });
     },
 
@@ -805,6 +888,8 @@ export const useEditorStore = create<EditorState>((set, get) => {
       redoStack = [];
       set({
         tracks: [makeDefaultTrack()],
+        segments: [],
+        selectedSegmentId: null,
         operations: [],
         selectedOperationIndex: null,
         selectedOperationId: null,

--- a/@fanslib/apps/web/src/stores/editorStore.vitest.ts
+++ b/@fanslib/apps/web/src/stores/editorStore.vitest.ts
@@ -631,6 +631,132 @@ describe("editorStore", () => {
     });
   });
 
+  describe("segments", () => {
+    test("addSegment appends a segment with generated id", () => {
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "media-1",
+        sourceStartFrame: 0,
+        sourceEndFrame: 90,
+      });
+      const segments = useEditorStore.getState().segments;
+      expect(segments).toHaveLength(1);
+      expect(segments[0].sourceMediaId).toBe("media-1");
+      expect(segments[0].sourceStartFrame).toBe(0);
+      expect(segments[0].sourceEndFrame).toBe(90);
+      expect(typeof segments[0].id).toBe("string");
+      expect(segments[0].id.length).toBeGreaterThan(0);
+    });
+
+    test("removeSegment removes by id", () => {
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "media-1",
+        sourceStartFrame: 0,
+        sourceEndFrame: 90,
+      });
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "media-2",
+        sourceStartFrame: 0,
+        sourceEndFrame: 60,
+      });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().removeSegment(id);
+      const segments = useEditorStore.getState().segments;
+      expect(segments).toHaveLength(1);
+      expect(segments[0].sourceMediaId).toBe("media-2");
+    });
+
+    test("reorderSegments moves to new index", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "a", sourceStartFrame: 0, sourceEndFrame: 30 });
+      useEditorStore.getState().addSegment({ sourceMediaId: "b", sourceStartFrame: 0, sourceEndFrame: 30 });
+      useEditorStore.getState().addSegment({ sourceMediaId: "c", sourceStartFrame: 0, sourceEndFrame: 30 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().reorderSegments(id, 2);
+      const segments = useEditorStore.getState().segments;
+      expect(segments[0].sourceMediaId).toBe("b");
+      expect(segments[1].sourceMediaId).toBe("c");
+      expect(segments[2].sourceMediaId).toBe("a");
+    });
+
+    test("reorderSegments drops transition when segment moves to index 0", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "a", sourceStartFrame: 0, sourceEndFrame: 30 });
+      useEditorStore.getState().addSegment({
+        sourceMediaId: "b",
+        sourceStartFrame: 0,
+        sourceEndFrame: 30,
+        transition: { type: "crossfade", durationFrames: 10 },
+      });
+      const id = useEditorStore.getState().segments[1].id;
+      useEditorStore.getState().reorderSegments(id, 0);
+      const segments = useEditorStore.getState().segments;
+      expect(segments[0].sourceMediaId).toBe("b");
+      expect(segments[0].transition).toBeUndefined();
+    });
+
+    test("trimSegmentStart adjusts sourceStartFrame", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().trimSegmentStart(id, 15);
+      expect(useEditorStore.getState().segments[0].sourceStartFrame).toBe(15);
+    });
+
+    test("trimSegmentEnd adjusts sourceEndFrame", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().trimSegmentEnd(id, 60);
+      expect(useEditorStore.getState().segments[0].sourceEndFrame).toBe(60);
+    });
+
+    test("selectSegment sets selectedSegmentId", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      const id = useEditorStore.getState().segments[0].id;
+      useEditorStore.getState().selectSegment(id);
+      expect(useEditorStore.getState().selectedSegmentId).toBe(id);
+      useEditorStore.getState().selectSegment(null);
+      expect(useEditorStore.getState().selectedSegmentId).toBeNull();
+    });
+
+    test("undo/redo works for segment mutations", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      expect(useEditorStore.getState().segments).toHaveLength(1);
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().segments).toHaveLength(0);
+      useEditorStore.getState().redo();
+      expect(useEditorStore.getState().segments).toHaveLength(1);
+      expect(useEditorStore.getState().segments[0].sourceMediaId).toBe("media-1");
+    });
+
+    test("undo/redo still works for operation mutations (regression)", () => {
+      useEditorStore.getState().addOperation({ type: "blur" });
+      expect(useEditorStore.getState().operations).toHaveLength(1);
+      useEditorStore.getState().undo();
+      expect(useEditorStore.getState().operations).toHaveLength(0);
+      useEditorStore.getState().redo();
+      expect(useEditorStore.getState().operations).toHaveLength(1);
+    });
+
+    test("hydrate accepts and restores segments", () => {
+      const data = {
+        tracks: [{ id: "t1", name: "Track 1", operations: [] }],
+        segments: [
+          { id: "s1", sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 },
+          { id: "s2", sourceMediaId: "media-2", sourceStartFrame: 10, sourceEndFrame: 50 },
+        ],
+      };
+      useEditorStore.getState().hydrate(data);
+      expect(useEditorStore.getState().segments).toHaveLength(2);
+      expect(useEditorStore.getState().segments[0].id).toBe("s1");
+      expect(useEditorStore.getState().segments[1].sourceMediaId).toBe("media-2");
+    });
+
+    test("reset clears segments and selectedSegmentId", () => {
+      useEditorStore.getState().addSegment({ sourceMediaId: "media-1", sourceStartFrame: 0, sourceEndFrame: 90 });
+      useEditorStore.getState().selectSegment(useEditorStore.getState().segments[0].id);
+      useEditorStore.getState().reset();
+      expect(useEditorStore.getState().segments).toEqual([]);
+      expect(useEditorStore.getState().selectedSegmentId).toBeNull();
+    });
+  });
+
   describe("zoom operations", () => {
     test("addZoom adds a zoom operation with default values", () => {
       useEditorStore.getState().addZoom();

--- a/@fanslib/libraries/video/src/Root.tsx
+++ b/@fanslib/libraries/video/src/Root.tsx
@@ -1,6 +1,7 @@
 import { Composition } from "remotion";
 import { WatermarkComposition } from "./compositions/WatermarkComposition";
 import { VideoComposition } from "./compositions/VideoComposition";
+import { SequenceComposition } from "./compositions/SequenceComposition";
 
 export const RemotionRoot: React.FC = () => (
   <>
@@ -35,6 +36,19 @@ export const RemotionRoot: React.FC = () => (
       defaultProps={{
         sourceUrl: "",
         startFrom: 0,
+        operations: [],
+        assetUrls: {},
+      }}
+    />
+    <Composition
+      id="SequenceComposition"
+      component={SequenceComposition}
+      durationInFrames={1}
+      fps={30}
+      width={1920}
+      height={1080}
+      defaultProps={{
+        segments: [],
         operations: [],
         assetUrls: {},
       }}

--- a/@fanslib/libraries/video/src/compositions/SequenceComposition.test.tsx
+++ b/@fanslib/libraries/video/src/compositions/SequenceComposition.test.tsx
@@ -46,3 +46,89 @@ describe("SequenceComposition", () => {
     expect(props.assetUrls).toBeDefined();
   });
 });
+
+describe("computeActiveSegment", () => {
+  const seg1: SegmentInput = {
+    id: "seg-1",
+    sourceMediaId: "media-1",
+    sourceUrl: "https://example.com/a.mp4",
+    sourceStartFrame: 0,
+    sourceEndFrame: 90,
+  };
+
+  const seg2: SegmentInput = {
+    id: "seg-2",
+    sourceMediaId: "media-2",
+    sourceUrl: "https://example.com/b.mp4",
+    sourceStartFrame: 30,
+    sourceEndFrame: 120,
+  };
+
+  const seg3: SegmentInput = {
+    id: "seg-3",
+    sourceMediaId: "media-3",
+    sourceUrl: "https://example.com/c.mp4",
+    sourceStartFrame: 0,
+    sourceEndFrame: 60,
+  };
+
+  test("first segment is active at frame 0", async () => {
+    const { computeActiveSegment } = await import("./SequenceComposition");
+    const result = computeActiveSegment(0, [seg1, seg2]);
+    expect(result).not.toBeNull();
+    expect(result!.segment.id).toBe("seg-1");
+    expect(result!.sourceFrame).toBe(0);
+  });
+
+  test("first segment is active at its last frame", async () => {
+    const { computeActiveSegment } = await import("./SequenceComposition");
+    // seg1 duration = 90 frames (0..89)
+    const result = computeActiveSegment(89, [seg1, seg2]);
+    expect(result).not.toBeNull();
+    expect(result!.segment.id).toBe("seg-1");
+    expect(result!.sourceFrame).toBe(89);
+  });
+
+  test("second segment is active after first segment's duration", async () => {
+    const { computeActiveSegment } = await import("./SequenceComposition");
+    // seg1 duration = 90, so frame 90 is the first frame of seg2
+    const result = computeActiveSegment(90, [seg1, seg2]);
+    expect(result).not.toBeNull();
+    expect(result!.segment.id).toBe("seg-2");
+    // seg2.sourceStartFrame is 30, so source frame = 30 + (90 - 90) = 30
+    expect(result!.sourceFrame).toBe(30);
+  });
+
+  test("correct source frame computation with non-zero sourceStartFrame", async () => {
+    const { computeActiveSegment } = await import("./SequenceComposition");
+    // Frame 100 is 10 frames into seg2 (seg1 duration = 90)
+    // seg2.sourceStartFrame = 30, so source frame = 30 + 10 = 40
+    const result = computeActiveSegment(100, [seg1, seg2]);
+    expect(result).not.toBeNull();
+    expect(result!.segment.id).toBe("seg-2");
+    expect(result!.sourceFrame).toBe(40);
+  });
+
+  test("returns null past all segments", async () => {
+    const { computeActiveSegment } = await import("./SequenceComposition");
+    // Total duration = 90 + 90 = 180
+    const result = computeActiveSegment(180, [seg1, seg2]);
+    expect(result).toBeNull();
+  });
+
+  test("returns null for empty segments array", async () => {
+    const { computeActiveSegment } = await import("./SequenceComposition");
+    const result = computeActiveSegment(0, []);
+    expect(result).toBeNull();
+  });
+
+  test("handles three segments correctly", async () => {
+    const { computeActiveSegment } = await import("./SequenceComposition");
+    // seg1: 90 frames, seg2: 90 frames, seg3: 60 frames
+    // Frame 180 should be first frame of seg3
+    const result = computeActiveSegment(180, [seg1, seg2, seg3]);
+    expect(result).not.toBeNull();
+    expect(result!.segment.id).toBe("seg-3");
+    expect(result!.sourceFrame).toBe(0);
+  });
+});

--- a/@fanslib/libraries/video/src/compositions/SequenceComposition.test.tsx
+++ b/@fanslib/libraries/video/src/compositions/SequenceComposition.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import type { SequenceCompositionProps, SegmentInput } from "./SequenceComposition";
+
+describe("SequenceComposition", () => {
+  test("exports the component", async () => {
+    const mod = await import("./SequenceComposition");
+    expect(mod.SequenceComposition).toBeDefined();
+    expect(typeof mod.SequenceComposition).toBe("function");
+  });
+
+  test("SegmentInput type accepts valid segment", () => {
+    const segment: SegmentInput = {
+      id: "seg-1",
+      sourceMediaId: "media-1",
+      sourceUrl: "https://example.com/video.mp4",
+      sourceStartFrame: 0,
+      sourceEndFrame: 150,
+    };
+    expect(segment.id).toBe("seg-1");
+    expect(segment.sourceEndFrame - segment.sourceStartFrame).toBe(150);
+  });
+
+  test("SequenceCompositionProps accepts single-segment input", () => {
+    const props: SequenceCompositionProps = {
+      segments: [
+        {
+          id: "seg-1",
+          sourceMediaId: "media-1",
+          sourceUrl: "https://example.com/video.mp4",
+          sourceStartFrame: 30,
+          sourceEndFrame: 180,
+        },
+      ],
+    };
+    expect(props.segments).toHaveLength(1);
+    expect(props.segments[0]!.sourceStartFrame).toBe(30);
+  });
+
+  test("SequenceCompositionProps accepts optional operations and assetUrls", () => {
+    const props: SequenceCompositionProps = {
+      segments: [],
+      operations: [],
+      assetUrls: { "asset-1": "https://example.com/asset.png" },
+    };
+    expect(props.operations).toEqual([]);
+    expect(props.assetUrls).toBeDefined();
+  });
+});

--- a/@fanslib/libraries/video/src/compositions/SequenceComposition.tsx
+++ b/@fanslib/libraries/video/src/compositions/SequenceComposition.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { OffthreadVideo, useCurrentFrame } from "remotion";
+import type { Operation } from "../types";
+
+export type SegmentInput = {
+  id: string;
+  sourceMediaId: string;
+  sourceUrl: string;
+  sourceStartFrame: number;
+  sourceEndFrame: number;
+};
+
+export type SequenceCompositionProps = {
+  segments: SegmentInput[];
+  /** Overlay operations positioned on the sequence timeline (not yet rendered — see #353) */
+  operations?: Operation[];
+  /** Asset URLs keyed by assetId */
+  assetUrls?: Record<string, string>;
+};
+
+export const SequenceComposition: React.FC<SequenceCompositionProps> = ({
+  segments,
+  // operations and assetUrls intentionally unused — overlay rendering comes in #353
+}) => {
+  const frame = useCurrentFrame();
+
+  if (segments.length === 0) {
+    return <div style={{ width: "100%", height: "100%", background: "#000" }} />;
+  }
+
+  // Single-segment case: render the source video starting from the segment's source range
+  const segment = segments[0]!;
+
+  return (
+    <div style={{ position: "relative", width: "100%", height: "100%" }}>
+      <OffthreadVideo
+        src={segment.sourceUrl}
+        startFrom={segment.sourceStartFrame}
+        style={{ width: "100%", height: "100%", objectFit: "contain" }}
+      />
+    </div>
+  );
+};

--- a/@fanslib/libraries/video/src/compositions/SequenceComposition.tsx
+++ b/@fanslib/libraries/video/src/compositions/SequenceComposition.tsx
@@ -18,24 +18,45 @@ export type SequenceCompositionProps = {
   assetUrls?: Record<string, string>;
 };
 
+/**
+ * Given segments (ordered), compute which one is active at the current frame.
+ * For hard cuts (no transitions): segments play back-to-back sequentially.
+ */
+export const computeActiveSegment = (
+  frame: number,
+  segments: SegmentInput[],
+): { segment: SegmentInput; sourceFrame: number } | null => {
+  let cursor = 0;
+  for (const segment of segments) {
+    const duration = segment.sourceEndFrame - segment.sourceStartFrame;
+    if (frame < cursor + duration) {
+      return {
+        segment,
+        sourceFrame: segment.sourceStartFrame + (frame - cursor),
+      };
+    }
+    cursor += duration;
+  }
+  return null;
+};
+
 export const SequenceComposition: React.FC<SequenceCompositionProps> = ({
   segments,
   // operations and assetUrls intentionally unused — overlay rendering comes in #353
 }) => {
   const frame = useCurrentFrame();
 
-  if (segments.length === 0) {
+  const active = computeActiveSegment(frame, segments);
+
+  if (!active) {
     return <div style={{ width: "100%", height: "100%", background: "#000" }} />;
   }
-
-  // Single-segment case: render the source video starting from the segment's source range
-  const segment = segments[0]!;
 
   return (
     <div style={{ position: "relative", width: "100%", height: "100%" }}>
       <OffthreadVideo
-        src={segment.sourceUrl}
-        startFrom={segment.sourceStartFrame}
+        src={active.segment.sourceUrl}
+        startFrom={active.sourceFrame}
         style={{ width: "100%", height: "100%", objectFit: "contain" }}
       />
     </div>

--- a/@fanslib/libraries/video/src/compositions/index.ts
+++ b/@fanslib/libraries/video/src/compositions/index.ts
@@ -6,7 +6,7 @@ export { PixelateRegion } from "./PixelateRegion";
 export { VideoComposition } from "./VideoComposition";
 export { WatermarkComposition } from "./WatermarkComposition";
 export { ZoomEffect } from "./ZoomEffect";
-export { SequenceComposition } from "./SequenceComposition";
+export { SequenceComposition, computeActiveSegment } from "./SequenceComposition";
 export type { VideoCompositionProps } from "./VideoComposition";
 export type { WatermarkCompositionProps } from "./WatermarkComposition";
 export type { SequenceCompositionProps, SegmentInput } from "./SequenceComposition";

--- a/@fanslib/libraries/video/src/compositions/index.ts
+++ b/@fanslib/libraries/video/src/compositions/index.ts
@@ -6,5 +6,7 @@ export { PixelateRegion } from "./PixelateRegion";
 export { VideoComposition } from "./VideoComposition";
 export { WatermarkComposition } from "./WatermarkComposition";
 export { ZoomEffect } from "./ZoomEffect";
+export { SequenceComposition } from "./SequenceComposition";
 export type { VideoCompositionProps } from "./VideoComposition";
 export type { WatermarkCompositionProps } from "./WatermarkComposition";
+export type { SequenceCompositionProps, SegmentInput } from "./SequenceComposition";


### PR DESCRIPTION
## Summary

- `computeActiveSegment(frame, segments)` pure function for segment selection at any frame
- SequenceComposition renders correct segment with frame-accurate hard cuts
- Handles multi-source (different sourceUrls per segment)
- Returns black frame past all segments

Stacked on #384 (Single-segment preview)

Closes #348

## Test plan

- [x] First segment active at frame 0
- [x] Boundary frame at end of first segment
- [x] Second segment active after first
- [x] Correct source frame with non-zero sourceStartFrame
- [x] Returns null past all segments
- [x] Empty segments array
- [x] Three-segment sequential playback
- [x] 11 tests pass (4 existing + 7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)