### PR TITLE
feat: pause/resume button for tus uploads (#392)

### DIFF
--- a/@fanslib/apps/web/src/features/library/components/UploadDialog/UploadDialog.tsx
+++ b/@fanslib/apps/web/src/features/library/components/UploadDialog/UploadDialog.tsx
@@ -64,6 +64,9 @@ export const UploadDialog = ({ open, onOpenChange }: UploadDialogProps) => {
     retryAllFailed,
     startUpload,
     cancelUpload,
+    pauseAll,
+    resumeAll,
+    isPaused,
     isUploading,
     completedCount,
     failedCount,
@@ -276,9 +279,17 @@ export const UploadDialog = ({ open, onOpenChange }: UploadDialogProps) => {
                   )}
 
                   {phase === "uploading" && !allDone && (
-                    <Button variant="outline" onPress={requestClose}>
-                      Close
-                    </Button>
+                    <>
+                      <Button
+                        variant="outline"
+                        onPress={() => (isPaused ? resumeAll() : pauseAll())}
+                      >
+                        {isPaused ? "Resume" : "Pause"}
+                      </Button>
+                      <Button variant="outline" onPress={requestClose}>
+                        Close
+                      </Button>
+                    </>
                   )}
 
                   {phase === "uploading" && allDone && failedCount > 0 && (

--- a/@fanslib/apps/web/src/hooks/useUploadQueue.ts
+++ b/@fanslib/apps/web/src/hooks/useUploadQueue.ts
@@ -27,6 +27,9 @@ type UseUploadQueueResult = {
   retryAllFailed: () => void;
   startUpload: (shootId: string) => void;
   cancelUpload: () => void;
+  pauseAll: () => void;
+  resumeAll: () => void;
+  isPaused: boolean;
   isUploading: boolean;
   completedCount: number;
   failedCount: number;
@@ -57,12 +60,15 @@ const parseMediaFromResponse = (body: string): Media | undefined => {
 
 export const useUploadQueue = (): UseUploadQueueResult => {
   const [files, setFiles] = useState<UploadFileState[]>([]);
+  const [isPaused, setIsPaused] = useState(false);
   const uploadMapRef = useRef<Map<string, tus.Upload>>(new Map());
   const shootIdRef = useRef<string>("");
   const filesRef = useRef<UploadFileState[]>([]);
   const drainQueueRef = useRef<((shootId: string) => void) | null>(null);
+  const isPausedRef = useRef(false);
 
   filesRef.current = files;
+  isPausedRef.current = isPaused;
 
   const updateFile = useCallback((id: string, patch: Partial<UploadFileState>) => {
     setFiles((prev) => prev.map((f) => (f.id === id ? { ...f, ...patch } : f)));
@@ -109,6 +115,7 @@ export const useUploadQueue = (): UseUploadQueueResult => {
 
   const drainQueue = useCallback(
     (shootId: string) => {
+      if (isPausedRef.current) return;
       const current = filesRef.current;
       const activeCount = uploadMapRef.current.size;
       const slotsAvailable = CONCURRENT_UPLOADS - activeCount;
@@ -174,6 +181,23 @@ export const useUploadQueue = (): UseUploadQueueResult => {
       upload.abort(true).catch(() => undefined);
     });
     uploadMapRef.current.clear();
+    setIsPaused(false);
+  }, []);
+
+  const pauseAll = useCallback(() => {
+    setIsPaused(true);
+    uploadMapRef.current.forEach((upload) => {
+      upload.abort(false).catch(() => undefined);
+    });
+  }, []);
+
+  const resumeAll = useCallback(() => {
+    setIsPaused(false);
+    uploadMapRef.current.forEach((upload) => {
+      upload.start();
+    });
+    const shootId = shootIdRef.current;
+    if (shootId) setTimeout(() => drainQueueRef.current?.(shootId), 0);
   }, []);
 
   const isUploading = files.some((f) => f.status === "uploading" || f.status === "processing");
@@ -190,6 +214,9 @@ export const useUploadQueue = (): UseUploadQueueResult => {
     retryAllFailed,
     startUpload,
     cancelUpload,
+    pauseAll,
+    resumeAll,
+    isPaused,
     isUploading,
     completedCount,
     failedCount,


### PR DESCRIPTION
## Summary

- Single Pause/Resume toggle in the UploadDialog uploading phase footer.
- Pause calls tus-js-client \`abort(false)\` on every active upload (keeps server bytes) and stops the drain loop; Resume calls \`start()\` on each and re-drains.

Stacked on #395 (#391). Fixes #392.

## Test plan

- [x] Typecheck clean.
- [x] Web vitest suite unaffected (434/434).
- [ ] Manual verification: during a multi-file upload, press Pause, confirm all progress stops; press Resume, confirm all active files continue from where they paused and queued files begin uploading again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)