### PR TITLE
feat: verify cancel terminates server-side staging (#393)

### DIFF
--- a/@fanslib/apps/server/src/features/library/routes.test.ts
+++ b/@fanslib/apps/server/src/features/library/routes.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { Hono } from "hono";
-import { existsSync, mkdirSync, rmSync } from "fs";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "fs";
 import { join } from "path";
 import "reflect-metadata";
 import { getTestDataSource, setupTestDatabase, teardownTestDatabase } from "../../lib/test-db";
@@ -446,6 +446,43 @@ describe("Library Routes", () => {
       });
 
       expect(response.status).toBe(400);
+    });
+
+    test("DELETE on the upload URL removes the staged chunk and sidecar", async () => {
+      const dataSource = getTestDataSource();
+      const shootRepo = dataSource.getRepository(Shoot);
+      const shoot = await shootRepo.save(
+        shootRepo.create({ name: "Cancel Shoot", shootDate: new Date("2026-04-20") }),
+      );
+
+      const creation = await app.request("/api/media/upload", {
+        method: "POST",
+        headers: {
+          "Tus-Resumable": "1.0.0",
+          "Upload-Length": "1024",
+          "Upload-Metadata": tusMetadata({
+            filename: "photo.jpg",
+            shootId: shoot.id,
+          }),
+        },
+      });
+      expect(creation.status).toBe(201);
+      const location = creation.headers.get("Location");
+      expect(location).toBeTruthy();
+      const uploadId = location!.split("/").pop()!;
+
+      const stagingDir = join(TEST_MEDIA_DIR, ".tus-incoming");
+      const entriesBefore = readdirSync(stagingDir);
+      expect(entriesBefore.some((e) => e.startsWith(uploadId))).toBe(true);
+
+      const deletion = await app.request(`/api/media/upload/${uploadId}`, {
+        method: "DELETE",
+        headers: { "Tus-Resumable": "1.0.0" },
+      });
+      expect(deletion.status).toBe(204);
+
+      const entriesAfter = readdirSync(stagingDir);
+      expect(entriesAfter.some((e) => e.startsWith(uploadId))).toBe(false);
     });
 
     test("creation POST rejects unknown shootId with 404 before any bytes flow", async () => {

--- a/@fanslib/apps/web/src/hooks/useUploadQueue.ts
+++ b/@fanslib/apps/web/src/hooks/useUploadQueue.ts
@@ -169,6 +169,8 @@ export const useUploadQueue = (): UseUploadQueueResult => {
     [drainQueue],
   );
 
+  // abort(true) issues DELETE so the server drops staging bytes. Tab-close
+  // is deliberately not wired here — those bytes stay until the cleanup cron.
   const cancelUpload = useCallback(() => {
     uploadMapRef.current.forEach((upload) => {
       upload.abort(true).catch(() => undefined);


### PR DESCRIPTION
## Summary

- Adds a route smoke test asserting that \`DELETE /api/media/upload/:id\` removes the staged chunk + sidecar from \`.tus-incoming/\`.
- Adds an explanatory comment to \`cancelUpload\` clarifying the \`abort(true)\` semantic and why tab-close is deliberately not wired (left for cleanup cron).

\`cancelUpload\` itself was already implemented in #391 — this slice locks in that behavior with a regression test. Stacked on #395 (#391).

Fixes #393.

## Test plan

- [x] New DELETE smoke test passes.
- [x] Full server test suite unaffected.
- [x] Typecheck clean.
- [ ] Manual: start a large upload, open the close-confirmation, press 'Cancel upload', confirm the staging directory is empty for that upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)