### PR TITLE
feat: daily cron cleans abandoned tus staging (#394)

### DIFF
--- a/@fanslib/apps/server/src/features/library/operations/cleanup-tus-staging/index.test.ts
+++ b/@fanslib/apps/server/src/features/library/operations/cleanup-tus-staging/index.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { cleanAbandonedTusStaging } from "./index";
+
+const TEST_ROOT = path.join(tmpdir(), `cleanup-tus-staging-test-${process.pid}`);
+const STAGING_DIR = path.join(TEST_ROOT, ".tus-incoming");
+
+const seedFile = (name: string, ageInDays: number) => {
+  const filePath = path.join(STAGING_DIR, name);
+  writeFileSync(filePath, "x");
+  const mtime = new Date(Date.now() - ageInDays * 24 * 60 * 60 * 1000);
+  utimesSync(filePath, mtime, mtime);
+  return filePath;
+};
+
+describe("cleanAbandonedTusStaging", () => {
+  beforeEach(() => {
+    process.env.APPDATA_PATH = TEST_ROOT;
+    process.env.MEDIA_PATH = TEST_ROOT;
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+    mkdirSync(STAGING_DIR, { recursive: true });
+  });
+
+  afterAll(() => {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+  });
+
+  test("deletes files older than 7 days and keeps newer files", async () => {
+    const old = seedFile("old-chunk", 8);
+    const olderSidecar = seedFile("old-chunk.json", 8);
+    const fresh = seedFile("fresh-chunk", 1);
+    const freshSidecar = seedFile("fresh-chunk.json", 1);
+
+    await cleanAbandonedTusStaging();
+
+    expect(existsSync(old)).toBe(false);
+    expect(existsSync(olderSidecar)).toBe(false);
+    expect(existsSync(fresh)).toBe(true);
+    expect(existsSync(freshSidecar)).toBe(true);
+  });
+
+  test("is a no-op if the staging directory does not exist", async () => {
+    rmSync(STAGING_DIR, { recursive: true, force: true });
+    await expect(cleanAbandonedTusStaging()).resolves.toBeUndefined();
+  });
+});

--- a/@fanslib/apps/server/src/features/library/operations/cleanup-tus-staging/index.ts
+++ b/@fanslib/apps/server/src/features/library/operations/cleanup-tus-staging/index.ts
@@ -1,0 +1,31 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { env } from "../../../../lib/env";
+import { TUS_STAGING_SUBDIR } from "../../tus-server";
+
+const STAGING_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+const unlinkIfStale = async (filePath: string, cutoffMs: number) => {
+  const stats = await fs.stat(filePath);
+  if (!stats.isFile()) return;
+  if (stats.mtimeMs >= cutoffMs) return;
+  await fs.unlink(filePath);
+};
+
+export const cleanAbandonedTusStaging = async (): Promise<void> => {
+  const stagingDir = path.join(env().mediaPath, TUS_STAGING_SUBDIR);
+  const cutoffMs = Date.now() - STAGING_MAX_AGE_MS;
+
+  const entries = await fs.readdir(stagingDir).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return [] as string[];
+    throw error;
+  });
+
+  await Promise.all(
+    entries.map((entry) =>
+      unlinkIfStale(path.join(stagingDir, entry), cutoffMs).catch((error) => {
+        console.error(`Failed to clean abandoned tus file ${entry}:`, error);
+      }),
+    ),
+  );
+};

--- a/@fanslib/apps/server/src/index.ts
+++ b/@fanslib/apps/server/src/index.ts
@@ -22,6 +22,7 @@ import { postsRoutes } from "./features/posts/routes";
 import { Cron } from "croner";
 import { runScheduledPostsCronTick } from "./features/posts/scheduled-posts-cron";
 import { runAnalyticsCronTick } from "./features/analytics/analytics-cron";
+import { cleanAbandonedTusStaging } from "./features/library/operations/cleanup-tus-staging";
 import { performPeriodicCleanup } from "./features/tags/drift-prevention";
 import { redditAutomationRoutes } from "./features/reddit-automation/routes";
 import { settingsRoutes } from "./features/settings/routes";
@@ -144,6 +145,12 @@ if (isScheduledPostsCronEnabled) {
   new Cron("0 * * * *", { name: "analytics-fetch", protect: true }, () => {
     runAnalyticsCronTick().catch((error) => {
       console.error("Analytics fetch cron tick failed:", error);
+    });
+  });
+
+  new Cron("0 3 * * *", { name: "tus-staging-cleanup", protect: true }, () => {
+    cleanAbandonedTusStaging().catch((error) => {
+      console.error("Tus staging cleanup cron tick failed:", error);
     });
   });
 }


### PR DESCRIPTION
## Summary

- New croner job \`0 3 * * *\` ("tus-staging-cleanup") in \`apps/server/src/index.ts\`, gated behind the same \`DISABLE_CRON\` / \`NODE_ENV !== "test"\` flags as scheduled-posts, tag-drift, and analytics.
- Logic extracted into \`cleanAbandonedTusStaging\` deep module — scans \`{mediaPath}/.tus-incoming/\`, unlinks files (chunk + sidecar) with \`mtime\` older than 7 days.
- Job failures log via \`console.error\` without crashing the server.

Stacked on #395 (#391). Fixes #394.

## Test plan

- [x] Unit test: stale files (8 days) deleted; fresh files (1 day) kept.
- [x] Unit test: no-op when staging directory does not exist.
- [x] Full server suite passes.
- [x] Typecheck + lint clean.
- [ ] Manual: seed a file in .tus-incoming/ with mtime 8 days ago, trigger the job, confirm the file is gone; seed another with mtime 1 day ago, confirm it remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)