### PR TITLE
chore(web): clean up all lint errors and warnings

### DIFF
--- a/@fanslib/apps/web/src/features/editor/components/CompositionEditor.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/CompositionEditor.tsx
@@ -45,8 +45,10 @@ export const CompositionEditor = ({ shootId, compositionId }: CompositionEditorP
   const { data: shoot } = useShootQuery({ id: shootId });
   const hydrate = useEditorStore((s) => s.hydrate);
   const reset = useEditorStore((s) => s.reset);
-  const operations = useEditorStore((s) => s.operations) ?? [];
-  const segments = useEditorStore((s) => s.segments) ?? [];
+  const storeOperations = useEditorStore((s) => s.operations);
+  const operations = useMemo(() => storeOperations ?? [], [storeOperations]);
+  const storeSegments = useEditorStore((s) => s.segments);
+  const segments = useMemo(() => storeSegments ?? [], [storeSegments]);
   const selectedSourceId = useEditorStore((s) => s.selectedSourceId) ?? null;
   const setSelectedOperationId = useEditorStore((s) => s.setSelectedOperationId);
   const undo = useEditorStore((s) => s.undo);

--- a/@fanslib/apps/web/src/features/editor/components/CompositionEditor.vitest.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/CompositionEditor.vitest.tsx
@@ -2,12 +2,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
+import type * as TanstackRouter from "@tanstack/react-router";
 import { describe, expect, test, vi, beforeEach } from "vitest";
 
 vi.mock("@tanstack/react-router", async () => {
-  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
-    "@tanstack/react-router",
-  );
+  const actual = await vi.importActual<typeof TanstackRouter>("@tanstack/react-router");
   return {
     ...actual,
     useNavigate: () => vi.fn(),

--- a/@fanslib/apps/web/src/features/editor/components/EditorCanvas.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/EditorCanvas.tsx
@@ -96,6 +96,7 @@ const CropRectPreviewFrame = ({ crop, children }: { crop: CropOperation; childre
 const wrapWithCropChain = (crops: CropOperation[], inner: ReactNode): ReactNode =>
   crops.reduce(
     (acc, crop, i) => (
+      // oxlint-disable-next-line react/no-array-index-key -- crops are ordered render-time inputs without ids
       <CropRectPreviewFrame key={`crop-${i}`} crop={crop}>
         {acc}
       </CropRectPreviewFrame>
@@ -140,6 +141,7 @@ const PreviewOverlays = ({
       {blurRegions.map((blur, i) =>
         isOutsideFrameRange(frame, blur.startFrame, blur.endFrame) ? null : (
           <div
+            // oxlint-disable-next-line react/no-array-index-key -- preview region order is the identity
             key={i}
             style={{
               position: "absolute",
@@ -159,6 +161,7 @@ const PreviewOverlays = ({
         const half = ps / 2;
         const filterId = `px-preview-${i}`;
         return (
+          // oxlint-disable-next-line react/no-array-index-key -- preview region order is the identity
           <React.Fragment key={`px-${i}`}>
             <svg style={{ position: "absolute", width: 0, height: 0 }}>
               <defs>
@@ -208,6 +211,7 @@ const PreviewOverlays = ({
       {emojis.map((em, i) =>
         isOutsideFrameRange(frame, em.startFrame, em.endFrame) ? null : (
           <div
+            // oxlint-disable-next-line react/no-array-index-key -- preview emoji order is the identity
             key={`em-${i}`}
             style={{
               position: "absolute",
@@ -225,6 +229,7 @@ const PreviewOverlays = ({
         ),
       )}
       {captions.map((cap, i) => (
+        // oxlint-disable-next-line react/no-array-index-key -- preview caption order is the identity
         <CaptionOverlay key={`cap-${i}`} caption={cap} compositionWidth={COMPOSITION_WIDTH} />
       ))}
     </>

--- a/@fanslib/apps/web/src/features/editor/components/EditorCanvas/preview-composition.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/EditorCanvas/preview-composition.tsx
@@ -75,6 +75,7 @@ export const CropRectPreviewFrame = ({ crop, children }: { crop: CropOperation; 
 export const wrapWithCropChain = (crops: CropOperation[], inner: ReactNode): ReactNode =>
   crops.reduce(
     (acc, crop, i) => (
+      // oxlint-disable-next-line react/no-array-index-key -- crops are ordered render-time inputs without ids
       <CropRectPreviewFrame key={`crop-${i}`} crop={crop}>
         {acc}
       </CropRectPreviewFrame>
@@ -97,6 +98,7 @@ const PreviewOverlays = ({
       {blurRegions.map((blur, i) =>
         isOutsideFrameRange(frame, blur.startFrame, blur.endFrame) ? null : (
           <div
+            // oxlint-disable-next-line react/no-array-index-key -- preview region order is the identity
             key={i}
             style={{
               position: "absolute",
@@ -116,6 +118,7 @@ const PreviewOverlays = ({
         const half = ps / 2;
         const filterId = `px-preview-${i}`;
         return (
+          // oxlint-disable-next-line react/no-array-index-key -- preview region order is the identity
           <React.Fragment key={`px-${i}`}>
             <svg style={{ position: "absolute", width: 0, height: 0 }}>
               <defs>
@@ -165,6 +168,7 @@ const PreviewOverlays = ({
       {emojis.map((em, i) =>
         isOutsideFrameRange(frame, em.startFrame, em.endFrame) ? null : (
           <div
+            // oxlint-disable-next-line react/no-array-index-key -- preview emoji order is the identity
             key={`em-${i}`}
             style={{
               position: "absolute",
@@ -182,6 +186,7 @@ const PreviewOverlays = ({
         ),
       )}
       {captions.map((cap, i) => (
+        // oxlint-disable-next-line react/no-array-index-key -- preview caption order is the identity
         <CaptionOverlay key={`cap-${i}`} caption={cap} compositionWidth={compositionWidth} />
       ))}
     </>

--- a/@fanslib/apps/web/src/features/editor/components/ExportDialog.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/ExportDialog.tsx
@@ -54,27 +54,27 @@ export const ExportDialog = ({ open, onOpenChange }: ExportDialogProps) => {
     return () => dialog.removeEventListener("close", handleClose);
   }, [onOpenChange]);
 
-  const createAndQueueEdit = async (
-    type: "transform" | "clip",
-    ops: unknown[],
-    editTracks?: Track[],
-  ): Promise<void> => {
-    const res = await api.api["media-edits"].$post({
-      json: {
-        sourceMediaId: sourceMediaId!,
-        type,
-        operations: ops,
-        ...(editTracks && editTracks.length > 0 ? { tracks: editTracks } : {}),
-      },
-    });
-    if (!res.ok) throw new Error("Failed to create edit");
-    const data = (await res.json()) as { id: string };
+  const createAndQueueEdit = useCallback(
+    async (type: "transform" | "clip", ops: unknown[], editTracks?: Track[]): Promise<void> => {
+      if (!sourceMediaId) throw new Error("No source media selected");
+      const res = await api.api["media-edits"].$post({
+        json: {
+          sourceMediaId,
+          type,
+          operations: ops,
+          ...(editTracks && editTracks.length > 0 ? { tracks: editTracks } : {}),
+        },
+      });
+      if (!res.ok) throw new Error("Failed to create edit");
+      const data = (await res.json()) as { id: string };
 
-    const queueRes = await api.api["media-edits"][":id"].queue.$post({
-      param: { id: data.id },
-    });
-    if (!queueRes.ok) throw new Error("Failed to queue render");
-  };
+      const queueRes = await api.api["media-edits"][":id"].queue.$post({
+        param: { id: data.id },
+      });
+      if (!queueRes.ok) throw new Error("Failed to queue render");
+    },
+    [sourceMediaId],
+  );
 
   const handleExport = useCallback(async () => {
     setExporting(true);
@@ -106,9 +106,10 @@ export const ExportDialog = ({ open, onOpenChange }: ExportDialogProps) => {
             markClean();
             return editId;
           }
+          if (!sourceMediaId) throw new Error("No source media selected");
           const res = await api.api["media-edits"].$post({
             json: {
-              sourceMediaId: sourceMediaId!,
+              sourceMediaId,
               type: "transform",
               operations,
             },
@@ -150,6 +151,7 @@ export const ExportDialog = ({ open, onOpenChange }: ExportDialogProps) => {
     markClean,
     onOpenChange,
     queryClient,
+    createAndQueueEdit,
   ]);
 
   return (

--- a/@fanslib/apps/web/src/features/editor/components/RegionOverlay.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/RegionOverlay.tsx
@@ -102,26 +102,25 @@ export const RegionOverlay = ({
       }
 
       const corner = dragState.corner ?? "se";
-      let newX = dragState.startX;
-      let newY = dragState.startY;
-      let newWidth = dragState.startWidth;
-      let newHeight = dragState.startHeight;
+      const { newX, newWidth } = corner.endsWith("e")
+        ? {
+            newX: dragState.startX,
+            newWidth: clamp01(dragState.startWidth + relDx, 1 - dragState.startX),
+          }
+        : {
+            newX: clamp01(dragState.startX + relDx),
+            newWidth: clamp01(dragState.startWidth - relDx),
+          };
 
-      if (corner.endsWith("e")) {
-        newWidth = clamp01(dragState.startWidth + relDx, 1 - dragState.startX);
-      } else {
-        // West corners: move x and shrink width
-        newX = clamp01(dragState.startX + relDx);
-        newWidth = clamp01(dragState.startWidth - relDx);
-      }
-
-      if (corner.startsWith("s")) {
-        newHeight = clamp01(dragState.startHeight + relDy, 1 - dragState.startY);
-      } else {
-        // North corners: move y and shrink height
-        newY = clamp01(dragState.startY + relDy);
-        newHeight = clamp01(dragState.startHeight - relDy);
-      }
+      const { newY, newHeight } = corner.startsWith("s")
+        ? {
+            newY: dragState.startY,
+            newHeight: clamp01(dragState.startHeight + relDy, 1 - dragState.startY),
+          }
+        : {
+            newY: clamp01(dragState.startY + relDy),
+            newHeight: clamp01(dragState.startHeight - relDy),
+          };
 
       updateOperationById(selectedId, {
         ...op,
@@ -186,6 +185,7 @@ export const RegionOverlay = ({
 
           return (
             <div
+              // oxlint-disable-next-line react/no-array-index-key -- overlay index matches the rendered order of operations
               key={index}
               data-overlay
               className={`absolute ${
@@ -236,6 +236,7 @@ export const RegionOverlay = ({
 
         return (
           <div
+            // oxlint-disable-next-line react/no-array-index-key -- overlay index matches the rendered order of operations
             key={index}
             data-overlay
             className={`absolute ${

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/OperationBlock.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/OperationBlock.tsx
@@ -196,6 +196,7 @@ export const OperationBlock = ({
       {selected &&
         keyframes?.map((kf, i) => (
           <div
+            // oxlint-disable-next-line react/no-array-index-key -- keyframes are positioned by array index
             key={i}
             data-testid={`keyframe-diamond-${i}`}
             className="absolute w-2 h-2 rotate-45 bg-base-content cursor-pointer"

--- a/@fanslib/apps/web/src/features/editor/components/Timeline/SourceMediaBar.tsx
+++ b/@fanslib/apps/web/src/features/editor/components/Timeline/SourceMediaBar.tsx
@@ -44,6 +44,7 @@ export const SourceMediaBar = ({ filename, totalFrames, pixelsPerFrame }: Source
 
         return (
           <div
+            // oxlint-disable-next-line react/no-array-index-key -- source ranges are ordered by index
             key={i}
             data-testid={`source-range-${i}`}
             className={`absolute top-0 bottom-0 border rounded cursor-pointer ${colorClass} ${

--- a/@fanslib/apps/web/src/features/library/components/CreatePostDialog/index.tsx
+++ b/@fanslib/apps/web/src/features/library/components/CreatePostDialog/index.tsx
@@ -159,7 +159,7 @@ export const CreatePostDialog = ({
     if (!isRedditChannel) {
       setSelectedSubreddits([]);
     }
-  }, [isRedditChannel]);
+  }, [isRedditChannel, setSelectedSubreddits]);
 
   const handleMediaSelect = (mediaItem: Media) => {
     setSelectedMedia((prev) => {
@@ -249,6 +249,8 @@ export const CreatePostDialog = ({
       virtualPost,
       onNavigateToSlot,
       allPosts,
+      setSelectedMedia,
+      setCaption,
     ],
   );
 
@@ -271,7 +273,7 @@ export const CreatePostDialog = ({
       // Show message if no unfilled slots remain
       toast();
     }
-  }, [virtualPost, onNavigateToSlot, allPosts]);
+  }, [virtualPost, onNavigateToSlot, allPosts, setSelectedMedia, setCaption]);
 
   useEffect(() => {
     if (!open) return;

--- a/@fanslib/apps/web/src/features/library/components/MediaFilters/FilterGroupEditor.tsx
+++ b/@fanslib/apps/web/src/features/library/components/MediaFilters/FilterGroupEditor.tsx
@@ -26,8 +26,8 @@ export const FilterGroupEditor = ({ className = "" }: FilterGroupEditorProps) =>
   return (
     <div className={`${className} space-y-2`}>
       {filters.map((group, groupIndex) => (
-        // oxlint-disable-next-line react/no-array-index-key
         <div
+          // oxlint-disable-next-line react/no-array-index-key -- filter groups are positional
           key={`group-${groupIndex}-${group.include ? "include" : "exclude"}`}
           className="border rounded-lg"
         >
@@ -54,6 +54,7 @@ export const FilterGroupEditor = ({ className = "" }: FilterGroupEditorProps) =>
                   </Tooltip>
 
                   {group.items.map((item, itemIndex) => (
+                    // oxlint-disable-next-line react/no-array-index-key -- getFilterItemKey falls back to positional index for filters without stable id
                     <div key={getFilterItemKey(item, itemIndex)} className="flex-shrink-0">
                       <FilterItemRenderer
                         type={item.type}

--- a/@fanslib/apps/web/src/features/library/components/MediaTagEditor/DimensionTagSelector/HierarchicalTagSelector.tsx
+++ b/@fanslib/apps/web/src/features/library/components/MediaTagEditor/DimensionTagSelector/HierarchicalTagSelector.tsx
@@ -28,9 +28,11 @@ const buildTagTree = (tags: TagDefinition[]): TagNode[] => {
     const node = tagMap.get(tag.id)!;
     const parentId = tag.parentTagId;
 
-    parentId === null || !tagMap.has(parentId)
-      ? roots.push(node)
-      : tagMap.get(parentId)?.children.push(node);
+    if (parentId === null || !tagMap.has(parentId)) {
+      roots.push(node);
+    } else {
+      tagMap.get(parentId)?.children.push(node);
+    }
   });
 
   return roots;

--- a/@fanslib/apps/web/src/features/library/components/OrganizePage/OrganizePage.tsx
+++ b/@fanslib/apps/web/src/features/library/components/OrganizePage/OrganizePage.tsx
@@ -100,7 +100,7 @@ const buildPreviewPath = (
 export const OrganizePage = () => {
   const { data: groups, isLoading } = useUnmanagedMediaQuery();
   const { data: shootsData } = useShootsQuery({ limit: 200 });
-  const shoots = shootsData?.items ?? [];
+  const shoots = useMemo(() => shootsData?.items ?? [], [shootsData]);
   const organizeMutation = useOrganizeMutation();
   const createShootMutation = useCreateShootMutation();
 

--- a/@fanslib/apps/web/src/features/posts/components/PostCalendar/PostCalendarPostMedia.tsx
+++ b/@fanslib/apps/web/src/features/posts/components/PostCalendar/PostCalendarPostMedia.tsx
@@ -42,6 +42,7 @@ export const PostCalendarPostMedia = ({ postMedia, isVirtual }: PostCalendarPost
         return (
           <div
             className="relative aspect-square rounded-md overflow-hidden"
+            // oxlint-disable-next-line react/no-array-index-key -- empty slots fall back to index, filled slots use media id
             key={`media-slot-${postMedia[i]?.media.id ?? i}`}
             style={media ? { viewTransitionName: `media-${media.id}` } : undefined}
           >

--- a/@fanslib/apps/web/src/routes/dev/media-tile-aspect.tsx
+++ b/@fanslib/apps/web/src/routes/dev/media-tile-aspect.tsx
@@ -24,7 +24,7 @@ const galleryTileProps = {
 
 const MediaTileAspectPrototypePage = () => {
   const { data, isLoading } = useMediaListQuery({ page: 1, limit: 6 });
-  const items = (data?.items ?? []) as unknown as Media[];
+  const items = useMemo(() => (data?.items ?? []) as unknown as Media[], [data]);
 
   useMediaSelectionSetup(items);
 

--- a/@fanslib/apps/web/src/stores/mediaSelectionStore.ts
+++ b/@fanslib/apps/web/src/stores/mediaSelectionStore.ts
@@ -38,7 +38,11 @@ export const useMediaSelectionStore = create<MediaSelectionStore>((set) => ({
   toggleItem: (id, globalIndex) =>
     set((s) => {
       const next = new Set(s.selectedIds);
-      next.has(id) ? next.delete(id) : next.add(id);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
       return { selectedIds: next, lastClickedIndex: globalIndex };
     }),
 


### PR DESCRIPTION
## Summary

Takes @fanslib/web from \`26 warnings and 3 errors\` (CI red) to \`0/0\` (CI green).

### Errors
- \`ExportDialog.tsx\`: guard \`sourceMediaId\` with an early throw instead of \`!\` assertion (x2).
- \`CompositionEditor.vitest.tsx\`: replace \`import()\` type annotation with top-level \`import type * as\` alias.
- \`RegionOverlay.tsx\`: refactor four \`let\` corner-handle vars into \`const\` destructuring off ternaries.
- \`mediaSelectionStore.ts\`, \`HierarchicalTagSelector.tsx\`: rewrite expression-statement ternaries as if/else.

### Warnings
- \`exhaustive-deps\`: wrap zustand-derived arrays (\`segments\`, \`operations\`, \`shoots\`, \`items\`) in \`useMemo\` at source; promote \`createAndQueueEdit\` to \`useCallback\` and add to \`handleExport\` deps; add missing setter deps in CreatePostDialog.
- \`no-array-index-key\`: add targeted \`oxlint-disable-next-line\` comments (with reasons) in render-pipeline components where array order is the intrinsic identity.

## Test plan

- [x] \`bun run lint\` — 0 warnings, 0 errors.
- [x] \`bun run typecheck\` — clean.
- [x] Web vitest — 434/434 pass.
- [x] Behavior preserved — no logic rewritten except the \`let\` → \`const\` destructure in RegionOverlay (semantically identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)